### PR TITLE
docs: mark developer-b task status updates

### DIFF
--- a/docs/development-timeline.md
+++ b/docs/development-timeline.md
@@ -136,8 +136,8 @@ Engineer mapping:
 | `P-W1D2-1` | Message persistence: save every exchange to `messages` table with conversation_id, model, tokens | ✅ | 🤖 |
 | `P-W1D2-2` | Event logging: `events` table, log session_started, message_sent, ai_response (non-blocking goroutine) | ✅ | 🤖 |
 | `P-W1D2-3` | Anthropic provider: Claude Messages API implementation, update router for task-based routing | ✅ | 🤖 |
-| `P-W1D2-4` | Topic detection: keyword scan → load matching topic's teaching notes into system prompt | ⬜ | 🤖 |
-| `P-W1D2-5` | Structured problem-solving prompt pattern (dual-loop): system prompt v2 instructs AI to follow Understand → Plan → Solve → Verify → Connect steps for every math question. Include curriculum citation in every explanation (e.g., "KSSM Form 1 > Algebra > Linear Equations"). Inspired by [DeepTutor](https://github.com/HKUDS/DeepTutor)'s dual-loop solver | ⬜ | 🤖 |
+| `P-W1D2-4` | Topic detection: keyword scan → load matching topic's teaching notes into system prompt | ✅ | 🤖 |
+| `P-W1D2-5` | Structured problem-solving prompt pattern (dual-loop): system prompt v2 instructs AI to follow Understand → Plan → Solve → Verify → Connect steps for every math question. Include curriculum citation in every explanation (e.g., "KSSM Form 1 > Algebra > Linear Equations"). Inspired by [DeepTutor](https://github.com/HKUDS/DeepTutor)'s dual-loop solver | ✅ | 🤖 |
 | `P-W1D2-6` | 🧑 Test 30 conversation scenarios, log every bad response, validate dual-loop solving pattern quality | ⬜ | 🧑 Human |
 
 ### Day 3 (Wed) — Deploy + First Students

--- a/docs/implementation-guide.md
+++ b/docs/implementation-guide.md
@@ -2879,7 +2879,7 @@ go build ./cmd/server
 
 - [ ] `internal/chat/gateway.go` + tests — unified message routing
 - [ ] `internal/chat/telegram.go` + tests — Telegram long-polling adapter
-- [ ] `internal/agent/engine.go` + tests — ProcessMessage pipeline with /start handler
+- [x] `internal/agent/engine.go` + tests — ProcessMessage pipeline with /start handler
 - [ ] `internal/curriculum/loader.go` + tests — loads YAML topics + teaching notes
 - [ ] `cmd/server/main.go` wires everything together
 - [ ] Team members can chat with the bot on Telegram. AI responds using curriculum context.
@@ -3291,9 +3291,9 @@ make test-all
 
 - [ ] `internal/agent/store.go` + tests — ConversationStore with MemoryStore implementation
 - [ ] `internal/agent/events.go` + tests — EventLogger with MemoryEventLogger
-- [ ] `internal/agent/topics.go` + tests — keyword-based topic detection
-- [ ] AI router updated with task-based routing preferences
-- [ ] System prompt includes curriculum context when topic is detected
+- [x] `internal/agent/topics.go` + tests — keyword-based topic detection
+- [x] AI router updated with task-based routing preferences
+- [x] System prompt includes curriculum context when topic is detected
 - [ ] 🧑 Human tested 30 conversation scenarios, system prompt v2 applied
 - [ ] `make test-all` passes with zero failures
 
@@ -3470,9 +3470,9 @@ Update `internal/ai/router.go` to add retry logic with exponential backoff and c
 #### Day 3 Exit Criteria
 
 - [ ] `scripts/deploy.sh` — automated deployment script
-- [ ] `/start` creates user record, sends welcome message with form selection
-- [ ] Auto-lookup user by telegram_id on every message, auto-trigger /start for new users
-- [ ] AI router retries with backoff, falls back through provider chain
+- [x] `/start` creates user record, sends welcome message with form selection
+- [x] Auto-lookup user by telegram_id on every message, auto-trigger /start for new users
+- [x] AI router retries with backoff, falls back through provider chain
 - [ ] 🧑 Deployed to AWS, 3 pilot students onboarded and chatting
 - [ ] `make test-all` passes
 


### PR DESCRIPTION
## Summary
This PR updates implementation status tracking to reflect Developer B work that has already shipped in code. It aligns checklist/state artifacts with the current repository state so planning and reporting are accurate.

## Problem
The status fields in `docs/development-timeline.md` and Day exit criteria in `docs/implementation-guide.md` were stale for several Developer B tasks. This created a mismatch between actual delivery and documented status.

## Root Cause
Recent Day 2/Day 3 changes were merged through feature branches, but the corresponding progress markers in planning docs were not updated in the same flow.

## What Changed
1. Updated `docs/development-timeline.md`:
   - Marked `P-W1D2-4` (topic detection + teaching-note injection) as complete.
   - Marked `P-W1D2-5` (structured problem-solving prompt + citation behavior) as complete.

2. Updated `docs/implementation-guide.md`:
   - Marked Day 1 Developer B engine checklist item as complete.
   - Marked Day 2 Developer B checklist items as complete:
     - topic detection implementation,
     - router task-based routing,
     - curriculum-context prompt injection.
   - Marked Day 3 Developer B checklist items as complete:
     - `/start` onboarding with form-selection behavior,
     - telegram user lookup with auto-start for new users,
     - retry/backoff fallback behavior in the AI router.

## Scope and Intent
This PR is documentation-only and intentionally conservative:
- It marks only Developer B implementation outcomes.
- It does not mark manual/human tasks as complete.
- It does not introduce product or code behavior changes.

## Validation
I ran the full project validation to ensure the branch is healthy even though this change is docs-only:
- `make test-all`
  - `golangci-lint run ./...` passed
  - `go test ./...` passed

