### PR TITLE
feat: add deploy script (P-W1D3-1)

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVER="${DEPLOY_HOST:-}"
+USER="${DEPLOY_USER:-ubuntu}"
+APP_DIR="${DEPLOY_DIR:-/opt/pai-bot}"
+
+if [[ -z "$SERVER" ]]; then
+    echo "Error: DEPLOY_HOST is not set"
+    echo "Usage: DEPLOY_HOST=your-server ./scripts/deploy.sh"
+    exit 1
+fi
+
+echo "=== Deploying P&AI Bot to $USER@$SERVER:$APP_DIR ==="
+
+ssh "$USER@$SERVER" << REMOTE
+set -euo pipefail
+cd $APP_DIR
+echo "--- Pulling latest code ---"
+git pull origin main
+echo "--- Building app ---"
+docker compose build app
+echo "--- Restarting app ---"
+docker compose up -d app
+echo "=== Deploy complete ==="
+docker compose logs --tail=20 app
+REMOTE


### PR DESCRIPTION
## Summary
- Add `scripts/deploy.sh` for SSH-based deployment to any Linux server (AWS EC2, DigitalOcean, etc.)
- Automates: SSH → git pull → docker compose build → restart → tail logs
- Configurable via `DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_DIR` env vars

## Task
`P-W1D3-1` — Deploy script: SSH → pull → build → restart → tail logs

## Test plan
- [ ] Verify script is executable (`ls -la scripts/deploy.sh`)
- [ ] Verify `make test-all` passes
- [ ] Test on target EC2 instance: `DEPLOY_HOST=<ip> ./scripts/deploy.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)