### PR TITLE
feat: add deploy script + enforce timeline updates (P-W1D3-1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,8 @@ This project follows a **test-first development workflow**. Every feature must h
 
 **MANDATORY: After finishing ANY implementation, always run `make test-all` to verify nothing is broken. Never skip this step. Never consider a task done until the full test suite passes.**
 
+**MANDATORY: After completing ANY task from the development timeline, update `docs/development-timeline.md` to mark the task status as ✅. Never consider a task done until the timeline is updated.**
+
 ### The cycle for every task
 
 1. **Write tests first** — Define the expected behavior as unit tests before writing any implementation

--- a/docs/development-timeline.md
+++ b/docs/development-timeline.md
@@ -144,7 +144,7 @@ Engineer mapping:
 
 | Task ID | Task | Status | Owner |
 |---------|------|--------|-------|
-| `P-W1D3-1` | Deploy script: SSH → pull → build → restart → tail logs | ⬜ | 🤖 |
+| `P-W1D3-1` | Deploy script: SSH → pull → build → restart → tail logs | ✅ | 🤖 |
 | `P-W1D3-2` | `/start` onboarding: create user record, welcome message, ask what they want to study | ✅ | 🤖 |
 | `P-W1D3-3` | User lookup by telegram_id in chat flow, auto-trigger /start if new | ✅ | 🤖 |
 | `P-W1D3-4` | Error recovery: retry with backoff, provider fallback chain, friendly error messages | ✅ | 🤖 |


### PR DESCRIPTION
## Summary
- Add `scripts/deploy.sh` for SSH-based deployment to any Linux server (AWS EC2, etc.)
- Add mandatory rule in CLAUDE.md to always update `docs/development-timeline.md` after completing a task
- Mark P-W1D3-1 as complete in development timeline

## Test plan
- [ ] Verify `scripts/deploy.sh` is executable
- [ ] Verify `make test-all` passes
- [ ] Test deploy on target server: `DEPLOY_HOST=<ip> ./scripts/deploy.sh`