### PR TITLE
feat: groups/classes with bot commands + admin API (P-W3D12-1)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/p-n-ai/pai-bot/internal/auth"
 	"github.com/p-n-ai/pai-bot/internal/chat"
 	"github.com/p-n-ai/pai-bot/internal/curriculum"
+	"github.com/p-n-ai/pai-bot/internal/group"
 	"github.com/p-n-ai/pai-bot/internal/platform/cache"
 	"github.com/p-n-ai/pai-bot/internal/platform/config"
 	"github.com/p-n-ai/pai-bot/internal/platform/database"
@@ -75,6 +76,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	groupStore := group.NewPostgresStore(db.Pool)
+
 	// Load curriculum (warn if unavailable, don't fail).
 	loader, err := curriculum.NewLoader(cfg.CurriculumPath)
 	if err != nil {
@@ -103,6 +106,7 @@ func main() {
 		XP:                   xpTracker,
 		Goals:                goalStore,
 		Challenges:           challengeStore,
+		Groups:               groupStore,
 		DevMode:              cfg.Features.DevMode,
 	})
 
@@ -192,10 +196,10 @@ func main() {
 	mux := newHandlerWithServicesAndAdminProvider(
 		tenantAdminDataSourceProvider{
 			newForTenant: func(tenantID string) adminDataSource {
-				return adminapi.New(db.Pool, tenantID)
+				return adminapi.New(db.Pool, tenantID, groupStore)
 			},
 			newForPlatform: func() adminDataSource {
-				return adminapi.NewPlatform(db.Pool)
+				return adminapi.NewPlatform(db.Pool, groupStore)
 			},
 		},
 		gatewaySender{gw},
@@ -240,6 +244,10 @@ type adminDataSource interface {
 	GetParentSummary(parentID string) (adminapi.ParentSummary, error)
 	GetAIUsage() (adminapi.AIUsageSummary, error)
 	GetMetrics() (adminapi.MetricsSummary, error)
+	ListClasses(ctx context.Context) ([]adminapi.ClassListItem, error)
+	CreateClass(ctx context.Context, name, syllabusID, createdByUserID string) (*adminapi.ClassListItem, error)
+	GetClassDetail(ctx context.Context, classID string) (*adminapi.ClassDetail, error)
+	UpdateClass(ctx context.Context, classID string, name *string, status *string) error
 }
 
 type adminDataSourceProvider interface {
@@ -401,6 +409,10 @@ func newHandlerWithServicesAndAdminProvider(adminProvider adminDataSourceProvide
 	mux.Handle("POST /api/auth/refresh", handleAuthRefresh(authSvc))
 	mux.Handle("POST /api/auth/logout", handleAuthLogout(authSvc))
 	mux.Handle("POST /api/admin/invites", adminOrAbove(handleAdminInvite(authSvc)))
+	mux.Handle("GET /api/admin/classes", teacherOrAbove(handleAdminListClasses(adminProvider)))
+	mux.Handle("POST /api/admin/classes", teacherOrAbove(handleAdminCreateClass(adminProvider)))
+	mux.Handle("GET /api/admin/classes/{id}", teacherOrAbove(handleAdminGetClassDetail(adminProvider)))
+	mux.Handle("PATCH /api/admin/classes/{id}", teacherOrAbove(handleAdminUpdateClass(adminProvider)))
 	mux.Handle("GET /api/admin/classes/{id}/progress", teacherOrAbove(handleAdminClassProgress(adminProvider)))
 	mux.Handle("GET /api/admin/students/{id}", teacherOrAbove(handleAdminStudentDetail(adminProvider)))
 	mux.Handle("GET /api/admin/students/{id}/conversations", teacherOrAbove(handleAdminStudentConversations(adminProvider)))
@@ -579,6 +591,116 @@ func handleAdminStudentNudge(adminProvider adminDataSourceProvider, sender messa
 			"student": detail.Student.ID,
 			"channel": msg.Channel,
 		})
+	}
+}
+
+func handleAdminListClasses(adminProvider adminDataSourceProvider) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		admin, ok := resolveAdminDataSource(w, r, adminProvider)
+		if !ok {
+			return
+		}
+
+		payload, err := admin.ListClasses(r.Context())
+		if err != nil {
+			writeAdminError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, payload)
+	}
+}
+
+func handleAdminCreateClass(adminProvider adminDataSourceProvider) http.HandlerFunc {
+	type request struct {
+		Name            string `json:"name"`
+		SyllabusID      string `json:"syllabus_id"`
+		CreatedByUserID string `json:"created_by_user_id"`
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		admin, ok := resolveAdminDataSource(w, r, adminProvider)
+		if !ok {
+			return
+		}
+
+		var body request
+		if err := decodeJSONBody(r, &body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if strings.TrimSpace(body.Name) == "" {
+			http.Error(w, "name is required", http.StatusBadRequest)
+			return
+		}
+
+		// Default created_by_user_id to the authenticated user if not provided.
+		if strings.TrimSpace(body.CreatedByUserID) == "" {
+			if claims, ok := auth.ClaimsFromContext(r.Context()); ok {
+				body.CreatedByUserID = claims.Subject
+			}
+		}
+
+		payload, err := admin.CreateClass(r.Context(), body.Name, body.SyllabusID, body.CreatedByUserID)
+		if err != nil {
+			writeAdminError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusCreated, payload)
+	}
+}
+
+func handleAdminGetClassDetail(adminProvider adminDataSourceProvider) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		admin, ok := resolveAdminDataSource(w, r, adminProvider)
+		if !ok {
+			return
+		}
+
+		payload, err := admin.GetClassDetail(r.Context(), r.PathValue("id"))
+		if err != nil {
+			writeAdminError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, payload)
+	}
+}
+
+func handleAdminUpdateClass(adminProvider adminDataSourceProvider) http.HandlerFunc {
+	type request struct {
+		Name   *string `json:"name"`
+		Status *string `json:"status"`
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		admin, ok := resolveAdminDataSource(w, r, adminProvider)
+		if !ok {
+			return
+		}
+
+		var body request
+		if err := decodeJSONBody(r, &body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if body.Name == nil && body.Status == nil {
+			http.Error(w, "at least one of name or status is required", http.StatusBadRequest)
+			return
+		}
+		if body.Status != nil && *body.Status != "archived" {
+			http.Error(w, "status must be 'archived'", http.StatusBadRequest)
+			return
+		}
+		if body.Name != nil && strings.TrimSpace(*body.Name) == "" {
+			http.Error(w, "name must not be empty", http.StatusBadRequest)
+			return
+		}
+
+		if err := admin.UpdateClass(r.Context(), r.PathValue("id"), body.Name, body.Status); err != nil {
+			writeAdminError(w, err)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
 	}
 }
 
@@ -793,7 +915,7 @@ func withCORS(next http.Handler) http.Handler {
 		if slices.Contains(allowedOrigins, origin) {
 			w.Header().Set("Access-Control-Allow-Origin", origin)
 			w.Header().Set("Vary", "Origin")
-			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PATCH, OPTIONS")
 			w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
 		}
 

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -87,6 +87,141 @@ func TestAdminClassProgressEndpoint(t *testing.T) {
 	}
 }
 
+func TestAdminListClassesEndpoint(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/classes", nil)
+	req.Header.Set("Authorization", "Bearer "+mustIssueAdminToken(t))
+	rec := httptest.NewRecorder()
+
+	newHandler(stubAdminAPI{}, &chatGatewayStub{}).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var payload []struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if len(payload) != 1 {
+		t.Fatalf("classes count = %d, want 1", len(payload))
+	}
+	if payload[0].ID != "cls_1" {
+		t.Fatalf("classes[0].id = %q, want cls_1", payload[0].ID)
+	}
+}
+
+func TestAdminCreateClassEndpoint(t *testing.T) {
+	body := `{"name":"Form 2 Geometry","syllabus_id":"kssm-form-2"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/admin/classes", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+mustIssueAdminToken(t))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	newHandler(stubAdminAPI{}, &chatGatewayStub{}).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusCreated)
+	}
+
+	var payload struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if payload.Name != "Form 2 Geometry" {
+		t.Fatalf("name = %q, want Form 2 Geometry", payload.Name)
+	}
+}
+
+func TestAdminCreateClassEndpointRequiresName(t *testing.T) {
+	body := `{"syllabus_id":"kssm-form-2"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/admin/classes", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+mustIssueAdminToken(t))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	newHandler(stubAdminAPI{}, &chatGatewayStub{}).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAdminGetClassDetailEndpoint(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/classes/cls_1", nil)
+	req.Header.Set("Authorization", "Bearer "+mustIssueAdminToken(t))
+	rec := httptest.NewRecorder()
+
+	newHandler(stubAdminAPI{}, &chatGatewayStub{}).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var payload struct {
+		ID      string `json:"id"`
+		Members []struct {
+			UserID string `json:"user_id"`
+		} `json:"members"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if payload.ID != "cls_1" {
+		t.Fatalf("id = %q, want cls_1", payload.ID)
+	}
+	if len(payload.Members) != 1 {
+		t.Fatalf("members count = %d, want 1", len(payload.Members))
+	}
+}
+
+func TestAdminGetClassDetailNotFound(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/classes/missing", nil)
+	req.Header.Set("Authorization", "Bearer "+mustIssueAdminToken(t))
+	rec := httptest.NewRecorder()
+
+	newHandler(stubAdminAPI{}, &chatGatewayStub{}).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestAdminUpdateClassEndpoint(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		wantStatus int
+	}{
+		{name: "rename", body: `{"name":"New Name"}`, wantStatus: http.StatusNoContent},
+		{name: "archive", body: `{"status":"archived"}`, wantStatus: http.StatusNoContent},
+		{name: "rename and archive", body: `{"name":"New Name","status":"archived"}`, wantStatus: http.StatusNoContent},
+		{name: "empty body", body: `{}`, wantStatus: http.StatusBadRequest},
+		{name: "invalid status", body: `{"status":"active"}`, wantStatus: http.StatusBadRequest},
+		{name: "empty name", body: `{"name":""}`, wantStatus: http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPatch, "/api/admin/classes/cls_1", strings.NewReader(tt.body))
+			req.Header.Set("Authorization", "Bearer "+mustIssueAdminToken(t))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+
+			newHandler(stubAdminAPI{}, &chatGatewayStub{}).ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d (body: %s)", rec.Code, tt.wantStatus, rec.Body.String())
+			}
+		})
+	}
+}
+
 func TestAdminStudentDetailEndpoint(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/admin/students/stu_1", nil)
 	req.Header.Set("Authorization", "Bearer "+mustIssueAdminToken(t))
@@ -796,6 +931,48 @@ func (stubAdminAPI) GetMetrics() (adminapi.MetricsSummary, error) {
 			},
 		},
 	}, nil
+}
+
+func (stubAdminAPI) ListClasses(_ context.Context) ([]adminapi.ClassListItem, error) {
+	return []adminapi.ClassListItem{
+		{ID: "cls_1", Name: "Form 1 Algebra", JoinCode: "ABC123", Status: "active", MemberCount: 3},
+	}, nil
+}
+
+func (stubAdminAPI) CreateClass(_ context.Context, name, syllabusID, createdByUserID string) (*adminapi.ClassListItem, error) {
+	return &adminapi.ClassListItem{
+		ID:         "cls_new",
+		Name:       name,
+		SyllabusID: syllabusID,
+		JoinCode:   "XYZ789",
+		Status:     "active",
+		MemberCount: 1,
+	}, nil
+}
+
+func (stubAdminAPI) GetClassDetail(_ context.Context, classID string) (*adminapi.ClassDetail, error) {
+	if classID == "missing" {
+		return nil, adminapi.ErrNotFound
+	}
+	return &adminapi.ClassDetail{
+		ClassListItem: adminapi.ClassListItem{
+			ID:          classID,
+			Name:        "Form 1 Algebra",
+			JoinCode:    "ABC123",
+			Status:      "active",
+			MemberCount: 1,
+		},
+		Members: []adminapi.ClassMember{
+			{UserID: "usr_1", MembershipRole: "owner", JoinedAt: time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)},
+		},
+	}, nil
+}
+
+func (stubAdminAPI) UpdateClass(_ context.Context, classID string, _ *string, _ *string) error {
+	if classID == "missing" {
+		return adminapi.ErrNotFound
+	}
+	return nil
 }
 
 var _ adminDataSource = stubAdminAPI{}

--- a/docs/development-timeline.md
+++ b/docs/development-timeline.md
@@ -297,7 +297,7 @@ When adding a new item here, use an `A-WxDy-...` ID and do not backfill it into 
 
 | Task ID | Task | Owner | Status | Remark |
 |---------|------|-------|--------|--------|
-| `P-W3D12-1` | Class groups: `groups` + `group_members` tables, `/join [code]`, `/create_group [name]` | 🤖 | ⬜ | |
+| `P-W3D12-1` | Class groups: `groups` + `group_members` tables, `/join [code]`, `/group create [name]` | 🤖 | ✅ | `internal/group` package, `/group create|join|leave|list` + `/join` alias, admin API at `/api/admin/classes`, tenant-scoped join codes, membership_role (owner/admin/member) |
 | `P-W3D12-2` | Weekly leaderboard: `/leaderboard` shows top 10 by weekly mastery gain within group | 🤖 | ⬜ | |
 | `P-W3D12-3` | Monday recap: scheduler sends weekly leaderboard summary to all group members | 🤖 | ⬜ | |
 | `P-W3D12-4` | 🧑 Set up 2 test groups: pilot school group + Pandai beta group | 🧑 Human | ✅ | Setup telegram group from existing users|

--- a/docs/superpowers/plans/2026-03-31-groups.md
+++ b/docs/superpowers/plans/2026-03-31-groups.md
@@ -1,0 +1,454 @@
+# Groups (Classes) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Teachers create groups (displayed as "classes" in admin), students join via code. Enables leaderboards and Monday recaps.
+
+**Architecture:** New `internal/group` package with `Store` interface shared by bot engine and admin API. `groups` + `group_members` tables with tenant isolation and syllabus validation. Bot commands `/group create|join|leave|list` with `/join` alias. Admin API at `/api/admin/classes`.
+
+**Tech Stack:** Go stdlib, `pgxpool`, `crypto/rand` for join codes, existing `ConversationStore` + `adminapi.Service` patterns.
+
+---
+
+## Task 1: Migration
+
+**Files:**
+- Create: `migrations/20260331100000_groups.sql`
+
+- [ ] **Step 1: Create migration**
+
+```sql
+-- +goose Up
+CREATE TABLE groups (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id   UUID NOT NULL REFERENCES tenants(id),
+    name        TEXT NOT NULL,
+    syllabus_id TEXT,
+    join_code   TEXT NOT NULL UNIQUE,
+    status      TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'archived')),
+    created_by  UUID REFERENCES users(id) ON DELETE SET NULL,
+    created_at  TIMESTAMPTZ DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_groups_tenant_status ON groups(tenant_id, status);
+CREATE INDEX idx_groups_join_code ON groups(join_code);
+
+CREATE TABLE group_members (
+    group_id        UUID NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+    user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    membership_role TEXT NOT NULL DEFAULT 'member'
+                    CHECK (membership_role IN ('owner', 'admin', 'member')),
+    joined_at       TIMESTAMPTZ DEFAULT NOW(),
+    PRIMARY KEY (group_id, user_id)
+);
+
+CREATE INDEX idx_group_members_user ON group_members(user_id);
+
+-- +goose Down
+DROP TABLE IF EXISTS group_members;
+DROP TABLE IF EXISTS groups;
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add migrations/20260331100000_groups.sql
+git commit -m "feat: add groups and group_members migration"
+```
+
+---
+
+## Task 2: Group Package — Types, Interface, Join Code
+
+**Files:**
+- Create: `internal/group/store.go`
+- Create: `internal/group/joincode.go`
+- Create: `internal/group/joincode_test.go`
+
+- [ ] **Step 1: Create `internal/group/store.go` with types and interface**
+
+```go
+package group
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var (
+	ErrGroupNotFound     = errors.New("group not found")
+	ErrAlreadyMember     = errors.New("already a member")
+	ErrNotMember         = errors.New("not a member")
+	ErrOwnerCannotLeave  = errors.New("owner cannot leave group")
+	ErrGroupArchived     = errors.New("group is archived")
+)
+
+type Group struct {
+	ID         string
+	TenantID   string
+	Name       string
+	SyllabusID string
+	JoinCode   string
+	Status     string
+	CreatedBy  string
+	CreatedAt  time.Time
+}
+
+type Member struct {
+	UserID         string
+	MembershipRole string
+	JoinedAt       time.Time
+}
+
+type Store interface {
+	Create(ctx context.Context, g Group) (*Group, error)
+	GetByID(ctx context.Context, tenantID, groupID string) (*Group, error)
+	GetByJoinCode(ctx context.Context, tenantID, code string) (*Group, error)
+	ListByTenant(ctx context.Context, tenantID string) ([]Group, error)
+	ListByUser(ctx context.Context, userID string) ([]Group, error)
+	Archive(ctx context.Context, tenantID, groupID string) error
+	AddMember(ctx context.Context, groupID, userID, membershipRole string) error
+	RemoveMember(ctx context.Context, groupID, userID string) error
+	GetMembers(ctx context.Context, groupID string) ([]Member, error)
+	MemberCount(ctx context.Context, groupID string) (int, error)
+	IsMember(ctx context.Context, groupID, userID string) (bool, error)
+}
+```
+
+- [ ] **Step 2: Write join code tests**
+
+Create `internal/group/joincode_test.go`:
+
+```go
+package group
+
+import (
+	"strings"
+	"testing"
+)
+
+const validCharset = "ABCDEFGHJKMNPQRSTUVWXYZ23456789"
+
+func TestGenerateJoinCode_Length(t *testing.T) {
+	code, err := GenerateJoinCode()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(code) != 6 {
+		t.Errorf("len = %d, want 6", len(code))
+	}
+}
+
+func TestGenerateJoinCode_Charset(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		code, err := GenerateJoinCode()
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, c := range code {
+			if !strings.ContainsRune(validCharset, c) {
+				t.Errorf("invalid char %c in code %s", c, code)
+			}
+		}
+	}
+}
+
+func TestGenerateJoinCode_Unique(t *testing.T) {
+	seen := make(map[string]bool)
+	for i := 0; i < 1000; i++ {
+		code, _ := GenerateJoinCode()
+		if seen[code] {
+			t.Fatalf("duplicate code: %s", code)
+		}
+		seen[code] = true
+	}
+}
+
+func TestNormalizeJoinCode(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"abc123", "ABC123"},
+		{"  XYZ  ", "XYZ"},
+		{"abc-123", "ABC-123"},
+	}
+	for _, tt := range tests {
+		got := NormalizeJoinCode(tt.in)
+		if got != tt.want {
+			t.Errorf("NormalizeJoinCode(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+```
+
+- [ ] **Step 3: Implement join code generator**
+
+Create `internal/group/joincode.go`:
+
+```go
+package group
+
+import (
+	"crypto/rand"
+	"math/big"
+	"strings"
+)
+
+const joinCodeCharset = "ABCDEFGHJKMNPQRSTUVWXYZ23456789"
+const joinCodeLength = 6
+
+func GenerateJoinCode() (string, error) {
+	b := make([]byte, joinCodeLength)
+	max := big.NewInt(int64(len(joinCodeCharset)))
+	for i := range b {
+		n, err := rand.Int(rand.Reader, max)
+		if err != nil {
+			return "", err
+		}
+		b[i] = joinCodeCharset[n.Int64()]
+	}
+	return string(b), nil
+}
+
+func NormalizeJoinCode(code string) string {
+	return strings.ToUpper(strings.TrimSpace(code))
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/group/ -v`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/group/
+git commit -m "feat: add group package with types, store interface, and join code generator"
+```
+
+---
+
+## Task 3: Memory Store
+
+**Files:**
+- Create: `internal/group/store_memory.go`
+- Create: `internal/group/store_test.go`
+
+- [ ] **Step 1: Write tests**
+
+Create `internal/group/store_test.go` with table-driven tests covering:
+- Create group → returns populated Group with ID and join code
+- GetByID → found / not found / wrong tenant returns ErrGroupNotFound
+- GetByJoinCode → found / wrong tenant returns ErrGroupNotFound (tenant isolation)
+- ListByTenant → returns only groups for that tenant
+- ListByUser → returns groups user is member of
+- Archive → sets status to archived
+- AddMember → success / ErrAlreadyMember on duplicate
+- RemoveMember → success / ErrNotMember / ErrOwnerCannotLeave
+- GetMembers → returns all members with roles
+- MemberCount → correct count
+- IsMember → true/false
+
+- [ ] **Step 2: Implement MemoryStore**
+
+Create `internal/group/store_memory.go`:
+- Struct with `sync.RWMutex`, `groups map[string]*Group`, `members map[string][]Member`
+- `NewMemoryStore() *MemoryStore`
+- All Store interface methods
+- Create auto-generates ID and join code, adds creator as owner member
+
+- [ ] **Step 3: Run tests, verify green**
+
+Run: `go test ./internal/group/ -v`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/group/
+git commit -m "feat: add group memory store with full test coverage"
+```
+
+---
+
+## Task 4: Postgres Store
+
+**Files:**
+- Create: `internal/group/store_postgres.go`
+
+- [ ] **Step 1: Implement PostgresStore**
+
+```go
+type PostgresStore struct {
+	pool *pgxpool.Pool
+}
+
+func NewPostgresStore(pool *pgxpool.Pool) *PostgresStore
+```
+
+Note: tenantID passed per method call (not embedded), since shared by engine + admin API with different tenant contexts.
+
+Implement all Store methods with parameterized SQL:
+- Create: INSERT groups + INSERT group_members (owner), retry on join code collision (up to 8 attempts)
+- GetByJoinCode: always filter `WHERE tenant_id = $1 AND join_code = $2`
+- All queries include tenant_id where applicable
+
+- [ ] **Step 2: Run `make test-all`**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/group/store_postgres.go
+git commit -m "feat: add group postgres store"
+```
+
+---
+
+## Task 5: ConversationStore Extensions
+
+**Files:**
+- Modify: `internal/agent/store.go`
+- Modify: `internal/agent/store_postgres.go`
+
+- [ ] **Step 1: Add to ConversationStore interface**
+
+```go
+GetUserTenantID(userID string) (string, bool)
+GetUserRole(userID string) (string, bool)
+GetUserInternalID(userID string) (string, bool)
+```
+
+- [ ] **Step 2: Implement on MemoryStore**
+
+Add `userTenantID`, `userRole` maps. `GetUserInternalID` returns the same ID (memory store uses external IDs). Add `SetUserTenantID`, `SetUserRole` helpers for test setup.
+
+- [ ] **Step 3: Implement on PostgresStore**
+
+Query `users` table by tenant_id + channel + external_id, return tenant_id/role/id::text.
+
+- [ ] **Step 4: Run `make test-all`**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/agent/store.go internal/agent/store_postgres.go
+git commit -m "feat: add GetUserTenantID, GetUserRole, GetUserInternalID to ConversationStore"
+```
+
+---
+
+## Task 6: i18n Messages
+
+**Files:**
+- Modify: `internal/i18n/messages.go`
+
+- [ ] **Step 1: Add message keys and translations (ms/en/zh)**
+
+Keys: `MsgGroupCreated`, `MsgGroupJoined`, `MsgGroupLeft`, `MsgGroupList`, `MsgGroupListEmpty`, `MsgGroupNotFound`, `MsgGroupAlreadyMember`, `MsgGroupOwnerCannotLeave`, `MsgGroupArchived`, `MsgGroupCreateDenied`, `MsgGroupSyllabusMismatch`, `MsgGroupUsage`
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add internal/i18n/messages.go
+git commit -m "feat: add group i18n messages"
+```
+
+---
+
+## Task 7: Bot Command Handlers
+
+**Files:**
+- Create: `internal/agent/group_command.go`
+- Create: `internal/agent/group_command_test.go`
+- Modify: `internal/agent/engine.go`
+
+- [ ] **Step 1: Write tests for all command handlers**
+
+Test: create (teacher success, student denied), join (success, invalid code, cross-tenant denied, already member, syllabus mismatch, archived), leave (success, owner denied), list (with/without groups), `/join` alias.
+
+- [ ] **Step 2: Implement `handleGroupCommand` entry point with subcommand routing**
+
+- [ ] **Step 3: Implement `handleGroupCreate`**
+
+Check role → get tenant/internal ID → create group → return join code.
+
+- [ ] **Step 4: Implement `handleGroupJoin`**
+
+Normalize code → get tenant/internal ID/form → lookup by join code → validate status + syllabus → add member → return success.
+
+- [ ] **Step 5: Implement `handleGroupLeave` and `handleGroupList`**
+
+- [ ] **Step 6: Wire into engine.go**
+
+Add `Groups group.Store` to EngineConfig and Engine. Add `/group` and `/join` cases to handleCommand switch.
+
+- [ ] **Step 7: Run `make test-all`**
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/agent/group_command.go internal/agent/group_command_test.go internal/agent/engine.go
+git commit -m "feat: add /group and /join bot commands"
+```
+
+---
+
+## Task 8: Admin API
+
+**Files:**
+- Modify: `internal/adminapi/service.go`
+- Modify: `cmd/server/main.go`
+
+- [ ] **Step 1: Add group store to adminapi.Service**
+
+- [ ] **Step 2: Implement ListClasses, CreateClass, GetClassDetail, UpdateClass methods**
+
+- [ ] **Step 3: Add HTTP handlers and routes in main.go**
+
+```go
+mux.Handle("GET /api/admin/classes", teacherOrAbove(handleAdminListClasses(adminProvider)))
+mux.Handle("POST /api/admin/classes", teacherOrAbove(handleAdminCreateClass(adminProvider)))
+mux.Handle("GET /api/admin/classes/{id}", teacherOrAbove(handleAdminGetClassDetail(adminProvider)))
+mux.Handle("PATCH /api/admin/classes/{id}", teacherOrAbove(handleAdminUpdateClass(adminProvider)))
+```
+
+- [ ] **Step 4: Wire GroupStore into main.go**
+
+```go
+groupStore := group.NewPostgresStore(db.Pool)
+```
+
+Pass to engine config and admin service.
+
+- [ ] **Step 5: Run `make test-all`**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/adminapi/service.go cmd/server/main.go
+git commit -m "feat: add admin API endpoints for class management"
+```
+
+---
+
+## Task 9: Seed Data + Final Verification
+
+**Files:**
+- Modify: `internal/platform/seed/seed.go`
+- Modify: `docs/development-timeline.md`
+
+- [ ] **Step 1: Add demo groups to seed data**
+
+2 groups in default tenant, 1 in second tenant. Fixed UUIDs (`70000000-...`). Add member entries linking existing seed students.
+
+- [ ] **Step 2: Run `make test-all`**
+
+- [ ] **Step 3: Live test via terminal-chat**
+
+- [ ] **Step 4: Mark P-W3D12-1 complete in development-timeline.md**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/platform/seed/seed.go docs/development-timeline.md
+git commit -m "feat: add group seed data and mark P-W3D12-1 complete"
+```

--- a/docs/superpowers/specs/2026-03-27-ab-test-infra-design.md
+++ b/docs/superpowers/specs/2026-03-27-ab-test-infra-design.md
@@ -1,0 +1,152 @@
+# A/B Test Infrastructure Design
+
+**Task:** `P-W3D13-1`
+**Date:** 2026-03-27
+**Status:** Approved
+
+## Goal
+
+Randomly assign new students to group A (all motivation features) or group B (no motivation features) to measure whether gamification improves retention and mastery gains.
+
+## Flag Storage
+
+Use the existing `users.config` JSONB column. Add `"ab_group": "A"` or `"B"`.
+
+No new migration for the column — it already exists. One migration to backfill existing users to group A.
+
+## Assignment Logic
+
+- **New students:** 50/50 random assignment during `/start` and auto-start flows. Determined by `rand.Intn(2)` — 0 = A, 1 = B.
+- **Existing students:** Backfill all to group A via migration (`UPDATE users SET config = config || '{"ab_group":"A"}' WHERE config->>'ab_group' IS NULL`).
+
+Assignment happens in `resolveOrCreateUser` or immediately after user creation in `handleStart`/auto-start. Once assigned, the group never changes (unless manually overridden via `/dev-ab`).
+
+## Feature Gating
+
+Group B disables:
+- **Milestone celebrations** — `milestones.add()` calls in `assessMasteryAsync`, `recordActivityAsync`, `recordQuizOutcomeAsync` are skipped
+- **Streak celebration messages** — `FormatStreakRecordCelebration` is skipped, but `RecordActivity` still runs (streaks are tracked, just not celebrated)
+- **Proactive nudges** — scheduler's `checkUser` skips group B users entirely
+
+Group B still gets:
+- All tutoring and AI responses
+- Quizzes (entry, grading, hints, summary)
+- Progress tracking (`/progress` command works normally)
+- XP and streaks are recorded internally (for fair post-experiment comparison)
+- Daily summary at 22:00 MYT (this is informational, not motivational)
+- All events logged (essential for analysis)
+
+## Implementation Approach
+
+### Reading the flag
+
+Add a helper to the `ConversationStore` interface or a standalone function:
+
+```go
+func (e *Engine) userABGroup(userID string) string
+```
+
+Returns `"A"`, `"B"`, or `"A"` as default if unset. Reads from `users.config->>'ab_group'` via the store.
+
+### Store interface addition
+
+Add to `ConversationStore`:
+
+```go
+GetUserABGroup(userID string) (string, bool)
+SetUserABGroup(userID, group string) error
+```
+
+Memory and Postgres implementations.
+
+### Gating milestones
+
+In `assessMasteryAsync`, `recordActivityAsync`, and `recordQuizOutcomeAsync`, wrap milestone adds:
+
+```go
+if e.milestones != nil && e.userABGroup(userID) == "A" {
+    e.milestones.add(userID, FormatTopicMasteredCelebration(...))
+}
+```
+
+### Gating nudges
+
+In `Scheduler.checkUser`, skip if user is in group B. The scheduler needs access to the AB group — pass it via the store (already available as `nudgeLanguageStore`). Extend the store interface or add a new `abGroupStore` interface.
+
+### Event tagging
+
+Modify `logEventAsync` to automatically inject `ab_group` into every event's Data map:
+
+```go
+func (e *Engine) logEventAsync(event Event) {
+    if group := e.userABGroup(event.UserID); group != "" {
+        if event.Data == nil {
+            event.Data = map[string]any{}
+        }
+        event.Data["ab_group"] = group
+    }
+    go func() { ... }()
+}
+```
+
+This ensures ALL events (30+ types) get tagged without modifying each call site.
+
+### Migration
+
+```sql
+-- +goose Up
+UPDATE users SET config = config || '{"ab_group":"A"}'
+WHERE config->>'ab_group' IS NULL;
+
+-- +goose Down
+UPDATE users SET config = config - 'ab_group';
+```
+
+### Dev command
+
+`/dev-ab A` or `/dev-ab B` — manually override a user's group. Requires `LEARN_DEV_MODE=true`.
+
+## Analytics Queries
+
+```sql
+-- Retention by group (7-day)
+SELECT data->>'ab_group' AS grp, COUNT(DISTINCT user_id)
+FROM events
+WHERE event_type = 'session_started'
+  AND created_at > NOW() - INTERVAL '7 days'
+GROUP BY grp;
+
+-- Average mastery gain by group
+SELECT data->>'ab_group' AS grp, AVG(mastery_score)
+FROM learning_progress lp
+JOIN users u ON lp.user_id = u.id
+GROUP BY u.config->>'ab_group';
+
+-- Messages per session by group
+SELECT data->>'ab_group' AS grp, COUNT(*)::float / COUNT(DISTINCT data->>'conversation_id')
+FROM events
+WHERE event_type = 'message_sent'
+GROUP BY grp;
+```
+
+## Files Affected
+
+| File | Change |
+|------|--------|
+| `internal/agent/store.go` | Add `GetUserABGroup`, `SetUserABGroup` to interface + MemoryStore |
+| `internal/agent/store_postgres.go` | Postgres implementation |
+| `internal/agent/engine.go` | `userABGroup` helper, gate milestones, AB assignment in handleStart/auto-start, inject AB group in logEventAsync |
+| `internal/agent/quiz_progress.go` | Gate quiz milestone celebration |
+| `internal/agent/scheduler.go` | Skip nudges for group B |
+| `internal/agent/dev_commands.go` | `/dev-ab` command |
+| `migrations/YYYYMMDD_ab_group_backfill.sql` | Backfill existing users to group A |
+| `docs/development-timeline.md` | Mark P-W3D13-1 complete |
+
+## Testing
+
+- Unit: AB group assignment is 50/50 over N=1000 trials
+- Unit: Group A gets milestones, group B does not
+- Unit: Group B events still include `ab_group: "B"`
+- Unit: Scheduler skips group B for nudges
+- Unit: `/dev-ab` overrides group
+- Integration: terminal-chat session with group B user shows no celebrations

--- a/docs/superpowers/specs/2026-03-30-exam-style-mimicry-design.md
+++ b/docs/superpowers/specs/2026-03-30-exam-style-mimicry-design.md
@@ -1,0 +1,133 @@
+# Exam-Style Question Mimicry Design
+
+**Task:** `P-W2D7-4`
+**Date:** 2026-03-30
+**Status:** Approved
+
+## Goal
+
+When a student exhausts static questions during a quiz, transparently generate more questions in UASA/SPM exam style using AI, so the quiz continues seamlessly up to 10 questions per session.
+
+## Trigger
+
+Quiz engine detects `currentIndex >= len(staticQuestions)` and total questions served < 10.
+
+## Flow
+
+1. Quiz starts with static questions from `assessments.yaml` (filtered by intensity/difficulty)
+2. Student answers through static pool normally
+3. When static questions are exhausted and total < 10:
+   a. Pick 2-3 random exemplar questions from the same topic, filtered by quiz intensity first. If <2 match the intensity, use any available and specify target difficulty in the prompt.
+   b. Load the topic's teaching notes for curriculum context
+   c. Call `CompleteJSON` (cheapest model, `ai.TaskGrading`) with exam-mimicry prompt
+   d. Request 3 questions as structured JSON matching `QuizQuestion` schema
+   e. Parse response, append to session question list
+   f. Continue quiz — student sees no difference
+4. Quiz ends when: student answers question 10 OR clicks [Stop] OR all generated questions are served
+
+## Question Cap
+
+- Maximum 10 questions per quiz session (static + generated combined)
+- If static pool has >= 10 questions for the intensity, no generation needed
+- Generation requests only enough to reach 10: if 7 static served, generate 3
+
+## Prompt Template
+
+```
+You are a KSSM Mathematics exam question writer for Malaysian secondary students.
+
+Generate {n} new questions for:
+- Topic: {topic_name} ({topic_id})
+- Syllabus: {syllabus_id}
+- Difficulty: {intensity}
+
+Curriculum context:
+{teaching_notes_excerpt}
+
+Use these real exam questions as style and format references:
+{exemplar_questions_json}
+
+Requirements:
+- Match the style, format, and difficulty of the examples
+- Each question must have: text, answer (type + value + working), difficulty, hints (2 levels), and distractors (for multiple_choice)
+- Use Bahasa Melayu or English matching the exemplar language
+- Include LaTeX math notation where appropriate (e.g., $2x + 3$)
+- Do not duplicate any of the example questions
+
+Return a JSON array of questions.
+```
+
+## Structured Output Schema
+
+The `CompleteJSON` call expects this JSON schema:
+
+```json
+[
+  {
+    "text": "Solve: $3x + 5 = 20$",
+    "difficulty": "medium",
+    "answer_type": "exact",
+    "answer": "5",
+    "working": "3x + 5 = 20\n3x = 15\nx = 5",
+    "hints": [
+      {"level": 1, "text": "Start by subtracting 5 from both sides."},
+      {"level": 2, "text": "After subtracting: 3x = 15. Now divide by 3."}
+    ],
+    "distractors": []
+  }
+]
+```
+
+For `multiple_choice` type:
+```json
+{
+  "text": "Simplify: $(2x + 3) - (x - 1)$\n\nA) $x + 4$\nB) $x + 2$\nC) $3x + 2$\nD) $3x + 4$",
+  "difficulty": "medium",
+  "answer_type": "multiple_choice",
+  "answer": "A",
+  "working": "= 2x + 3 - x + 1 = x + 4",
+  "hints": [
+    {"level": 1, "text": "Be careful with the negative sign when removing brackets."},
+    {"level": 2, "text": "-(x - 1) becomes -x + 1, not -x - 1."}
+  ],
+  "distractors": [
+    {"value": "B", "feedback": "You may have subtracted 1 instead of adding it."},
+    {"value": "C", "feedback": "You forgot to subtract x from 2x."},
+    {"value": "D", "feedback": "Check both the x terms and constant terms."}
+  ]
+}
+```
+
+## Exemplar Selection
+
+1. Get all static questions for the topic
+2. Filter by current quiz intensity (difficulty match)
+3. If >= 2 match: pick 2-3 at random
+4. If < 2 match: use all available questions (any difficulty) and specify target difficulty explicitly in the prompt
+5. Serialize selected exemplars as JSON for the prompt
+
+## Error Handling
+
+- `CompleteJSON` fails (network, provider down): end quiz with current score summary, log warning
+- AI returns invalid JSON: end quiz gracefully, log warning
+- AI returns fewer questions than requested: use what we got, generate more on next exhaustion if still < 10
+- AI returns duplicate of existing question: serve it anyway (deterministic dedup is complex, not worth the effort for v1)
+
+## Files
+
+| File | Change |
+|------|--------|
+| `internal/agent/quiz_generate.go` | New: generation logic, prompt template, exemplar selection, response parsing |
+| `internal/agent/quiz_generate_test.go` | New: unit tests for generation |
+| `internal/agent/quiz_runtime.go` | Modify: detect exhaustion, call generator, append to session |
+| `internal/agent/quiz.go` | Modify: add method to append questions to session, expose max question cap |
+
+## Testing
+
+- Unit: exemplar selection filters by difficulty correctly
+- Unit: exemplar selection falls back when <2 match
+- Unit: prompt template renders correctly with exemplars + teaching notes
+- Unit: generated questions parse into QuizQuestion structs
+- Unit: quiz session respects 10-question cap
+- Unit: graceful end on generation failure
+- Integration: terminal-chat quiz goes past static questions into AI-generated ones

--- a/docs/superpowers/specs/2026-03-31-groups-design.md
+++ b/docs/superpowers/specs/2026-03-31-groups-design.md
@@ -1,0 +1,235 @@
+# Groups (Classes) Design
+
+**Task:** `P-W3D12-1`
+**Date:** 2026-03-31
+**Status:** Approved
+
+## Goal
+
+Teachers create groups (displayed as "classes" in admin panel), students join via code. This enables leaderboards and Monday recaps.
+
+## Terminology
+
+- **Database:** `groups` table, `group_members` table
+- **Go code:** `internal/group` package, `GroupStore` interface
+- **Bot commands:** `/group create`, `/group join` (alias: `/join`)
+- **Admin panel/API:** "classes" (`/api/admin/classes`) — maps to groups table
+
+## Schema
+
+```sql
+CREATE TABLE groups (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id   UUID NOT NULL REFERENCES tenants(id),
+    name        TEXT NOT NULL,
+    syllabus_id TEXT,
+    join_code   TEXT NOT NULL UNIQUE,
+    status      TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'archived')),
+    created_by  UUID REFERENCES users(id) ON DELETE SET NULL,
+    created_at  TIMESTAMPTZ DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_groups_tenant_status ON groups(tenant_id, status);
+CREATE INDEX idx_groups_join_code ON groups(join_code);
+
+CREATE TABLE group_members (
+    group_id        UUID NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+    user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    membership_role TEXT NOT NULL DEFAULT 'member'
+                    CHECK (membership_role IN ('owner', 'admin', 'member')),
+    joined_at       TIMESTAMPTZ DEFAULT NOW(),
+    PRIMARY KEY (group_id, user_id)
+);
+
+CREATE INDEX idx_group_members_user ON group_members(user_id);
+```
+
+### Key decisions
+
+- `membership_role` on `group_members` — `'owner'`, `'admin'`, `'member'`. Distinct name from `users.role` to avoid shadowing.
+- `created_by` kept on `groups` as audit trail. `membership_role = 'owner'` is the access control mechanism.
+- `status` column — supports archiving without hard deletes
+- `ON DELETE SET NULL` for `created_by` — group survives teacher removal
+- `join_code` is globally unique but join validation includes `tenant_id` check
+- `syllabus_id` is nullable — not all groups need a syllabus (future study groups)
+
+## Package Structure
+
+New package: `internal/group/`
+
+```go
+// internal/group/store.go
+type Group struct {
+    ID         string
+    TenantID   string
+    Name       string
+    SyllabusID string
+    JoinCode   string
+    Status     string
+    CreatedBy  string
+    CreatedAt  time.Time
+}
+
+type Member struct {
+    UserID         string
+    MembershipRole string // "owner", "admin", "member"
+    JoinedAt       time.Time
+}
+
+type Store interface {
+    Create(ctx context.Context, g Group) (*Group, error)
+    GetByID(ctx context.Context, tenantID, groupID string) (*Group, error)
+    GetByJoinCode(ctx context.Context, tenantID, code string) (*Group, error)
+    ListByTenant(ctx context.Context, tenantID string) ([]Group, error)
+    ListByUser(ctx context.Context, userID string) ([]Group, error)
+    Archive(ctx context.Context, tenantID, groupID string) error
+    AddMember(ctx context.Context, groupID, userID, membershipRole string) error
+    RemoveMember(ctx context.Context, groupID, userID string) error
+    GetMembers(ctx context.Context, groupID string) ([]Member, error)
+    MemberCount(ctx context.Context, groupID string) (int, error)
+    IsMember(ctx context.Context, groupID, userID string) (bool, error)
+}
+```
+
+Memory and Postgres implementations. Follows the same pattern as `internal/progress` — imported by both agent engine and admin API.
+
+## Bot Commands
+
+Primary command `/group` with subcommands. `/join` is an alias for `/group join`.
+
+### `/group create [name]`
+- **Who:** Teachers and admins only (check `users.role`)
+- **Flow:** If no name provided, ask interactively. Ask for Form (1/2/3) via inline buttons. Generate 6-char join code.
+- **Response:** "Group created! Share this code with your students: **ABC123**"
+- **Needs:** Engine must know user's role. Add `GetUserRole(userID string) (string, bool)` to ConversationStore.
+
+### `/group join [code]` (alias: `/join [code]`)
+- **Who:** Any user (primarily students)
+- **Validation:**
+  1. Look up group by join code
+  2. Verify group.tenant_id matches user's tenant_id (critical — prevents cross-school joins)
+  3. Verify group.status is 'active'
+  4. Verify group.syllabus_id matches user.form (if both are set)
+  5. Verify user is not already a member
+- **Response:** "Joined **Form 1 Algebra A**! You now have X classmates."
+- **Error messages:** code not found, already a member, wrong form level, group archived
+
+### `/group leave`
+- **Who:** Any member
+- **Response:** "You've left **Form 1 Algebra A**."
+- **Owner cannot leave** — checked via `membership_role = 'owner'`, must archive instead
+
+### `/group list`
+- **Who:** Any user
+- **Response:** Lists user's active groups with names and member counts
+
+## Admin API
+
+All scoped to the authenticated user's tenant.
+
+### `GET /api/admin/classes`
+Returns all active groups for the tenant with member counts.
+```json
+[
+  {
+    "id": "uuid",
+    "name": "Form 1 Algebra A",
+    "syllabus_id": "malaysia-kssm-matematik-tingkatan-1",
+    "join_code": "ABC123",
+    "status": "active",
+    "member_count": 24,
+    "created_at": "2026-03-31T..."
+  }
+]
+```
+
+### `POST /api/admin/classes`
+Create a new group. Requires teacher/admin role.
+```json
+{
+  "name": "Form 1 Algebra A",
+  "syllabus_id": "malaysia-kssm-matematik-tingkatan-1"
+}
+```
+
+### `GET /api/admin/classes/:id`
+Group detail with member list + mastery data.
+
+### `PATCH /api/admin/classes/:id`
+Update name or archive.
+
+## Tenant Isolation
+
+- Join code is globally unique but `GetByJoinCode(tenantID, code)` filters by tenant
+- If no match in the user's tenant, return "code not found" — don't reveal other tenants' codes exist
+- All list queries scoped by `tenant_id`
+
+## Syllabus Validation on Join
+
+- If group has `syllabus_id` AND user has `form` set: validate compatibility
+- Form "Form 1" → syllabus contains "tingkatan-1", etc.
+- If mismatch: "This class is for Form 2 students. Your profile is set to Form 1."
+- If either is null: allow join (flexible for cross-form study groups)
+
+## Join Code Generation
+
+6 characters, uppercase alphanumeric, excluding ambiguous characters (0/O, 1/I/L):
+```
+charset: ABCDEFGHJKMNPQRSTUVWXYZ23456789
+```
+Generated with `crypto/rand`. Retry on collision (unlikely with 30^6 ≈ 729M combinations).
+
+## Engine Wiring
+
+Add to `EngineConfig`:
+```go
+Groups group.Store
+```
+
+Add `/group` and `/join` to `handleCommand` switch — `/group` delegates to `handleGroupCommand(ctx, msg, args)`, `/join` aliases to `handleGroupCommand(ctx, msg, ["join"] + args)`.
+
+Engine needs access to user's tenant_id and role for validation. Add to `ConversationStore`:
+```go
+GetUserTenantID(userID string) (string, bool)
+GetUserRole(userID string) (string, bool)
+```
+
+## What This Does NOT Include
+
+- Leaderboard (`P-W3D12-2`) — separate task, depends on this
+- Monday recap (`P-W3D12-3`) — separate task, depends on leaderboard
+- Assigned topics per class (`P-W4D18-2`) — separate feature
+- Class management admin UI wiring — frontend already has mock scaffold, just needs real API
+
+## Files
+
+| File | Change |
+|------|--------|
+| `internal/group/store.go` | New: Store interface, Group/Member types |
+| `internal/group/store_memory.go` | New: in-memory implementation for tests |
+| `internal/group/store_postgres.go` | New: Postgres implementation |
+| `internal/group/store_test.go` | New: unit tests |
+| `internal/group/joincode.go` | New: join code generation |
+| `internal/agent/engine.go` | Add Groups field, `/class` command routing |
+| `internal/agent/group_command.go` | New: `/group create/join/leave/list` handlers |
+| `internal/agent/group_command_test.go` | New: command handler tests |
+| `internal/agent/store.go` | Add GetUserTenantID, GetUserRole to interface |
+| `internal/agent/store_postgres.go` | Postgres implementation of new methods |
+| `internal/adminapi/service.go` | Add class list/detail/create endpoints |
+| `cmd/server/main.go` | Wire GroupStore into engine + admin API |
+| `internal/i18n/messages.go` | Add class-related messages (ms/en/zh) |
+| `migrations/YYYYMMDD_groups.sql` | New: groups + group_members tables |
+| `internal/platform/seed/seed.go` | Add demo classes to seed data |
+| `docs/development-timeline.md` | Mark P-W3D12-1 complete |
+
+## Testing
+
+- Unit: join code generation (uniqueness, charset, length)
+- Unit: MemoryStore CRUD (create, join, leave, list, archive)
+- Unit: tenant isolation (can't join cross-tenant)
+- Unit: syllabus validation on join
+- Unit: role check (only teacher/admin can create)
+- Unit: `/class` command handlers
+- Integration: Postgres store with testcontainers
+- Live: terminal-chat create + join flow

--- a/internal/adminapi/service.go
+++ b/internal/adminapi/service.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/p-n-ai/pai-bot/internal/group"
 )
 
 var ErrNotFound = errors.New("admin resource not found")
@@ -136,10 +137,32 @@ type ClassProgress struct {
 	TopicIDs []string       `json:"topic_ids"`
 }
 
+type ClassListItem struct {
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	SyllabusID  string    `json:"syllabus_id,omitempty"`
+	JoinCode    string    `json:"join_code"`
+	Status      string    `json:"status"`
+	MemberCount int       `json:"member_count"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
+type ClassDetail struct {
+	ClassListItem
+	Members []ClassMember `json:"members"`
+}
+
+type ClassMember struct {
+	UserID         string    `json:"user_id"`
+	MembershipRole string    `json:"membership_role"`
+	JoinedAt       time.Time `json:"joined_at"`
+}
+
 type Service struct {
 	pool       *pgxpool.Pool
 	tenantID   string
 	allTenants bool
+	groupStore group.Store
 }
 
 type retentionCohortSample struct {
@@ -150,12 +173,12 @@ type retentionCohortSample struct {
 	Day14Users int
 }
 
-func New(pool *pgxpool.Pool, tenantID string) *Service {
-	return &Service{pool: pool, tenantID: tenantID}
+func New(pool *pgxpool.Pool, tenantID string, groupStore group.Store) *Service {
+	return &Service{pool: pool, tenantID: tenantID, groupStore: groupStore}
 }
 
-func NewPlatform(pool *pgxpool.Pool) *Service {
-	return &Service{pool: pool, allTenants: true}
+func NewPlatform(pool *pgxpool.Pool, groupStore group.Store) *Service {
+	return &Service{pool: pool, allTenants: true, groupStore: groupStore}
 }
 
 func (s *Service) tenantPredicate(column string, argPos int) string {
@@ -1075,4 +1098,147 @@ func computeStreakSummary(dates []time.Time) (int, int) {
 	}
 
 	return current, longest
+}
+
+// ListClasses returns all active classes (groups) for the tenant with member counts.
+func (s *Service) ListClasses(ctx context.Context) ([]ClassListItem, error) {
+	if s.groupStore == nil {
+		return nil, fmt.Errorf("group store not configured")
+	}
+	if s.allTenants {
+		return nil, fmt.Errorf("ListClasses requires a tenant-scoped service")
+	}
+
+	groups, err := s.groupStore.ListByTenant(ctx, s.tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("list classes: %w", err)
+	}
+
+	items := make([]ClassListItem, 0, len(groups))
+	for _, g := range groups {
+		count, err := s.groupStore.MemberCount(ctx, g.ID)
+		if err != nil {
+			return nil, fmt.Errorf("member count for %s: %w", g.ID, err)
+		}
+		items = append(items, ClassListItem{
+			ID:          g.ID,
+			Name:        g.Name,
+			SyllabusID:  g.SyllabusID,
+			JoinCode:    g.JoinCode,
+			Status:      g.Status,
+			MemberCount: count,
+			CreatedAt:   g.CreatedAt,
+		})
+	}
+	return items, nil
+}
+
+// CreateClass creates a new class for the tenant.
+func (s *Service) CreateClass(ctx context.Context, name, syllabusID, createdByUserID string) (*ClassListItem, error) {
+	if s.groupStore == nil {
+		return nil, fmt.Errorf("group store not configured")
+	}
+	if s.allTenants {
+		return nil, fmt.Errorf("CreateClass requires a tenant-scoped service")
+	}
+
+	created, err := s.groupStore.Create(ctx, group.Group{
+		TenantID:   s.tenantID,
+		Name:       name,
+		SyllabusID: syllabusID,
+		CreatedBy:  createdByUserID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create class: %w", err)
+	}
+
+	count, err := s.groupStore.MemberCount(ctx, created.ID)
+	if err != nil {
+		return nil, fmt.Errorf("member count after create: %w", err)
+	}
+
+	return &ClassListItem{
+		ID:          created.ID,
+		Name:        created.Name,
+		SyllabusID:  created.SyllabusID,
+		JoinCode:    created.JoinCode,
+		Status:      created.Status,
+		MemberCount: count,
+		CreatedAt:   created.CreatedAt,
+	}, nil
+}
+
+// GetClassDetail returns a class with its member list.
+func (s *Service) GetClassDetail(ctx context.Context, classID string) (*ClassDetail, error) {
+	if s.groupStore == nil {
+		return nil, fmt.Errorf("group store not configured")
+	}
+	if s.allTenants {
+		return nil, fmt.Errorf("GetClassDetail requires a tenant-scoped service")
+	}
+
+	g, err := s.groupStore.GetByID(ctx, s.tenantID, classID)
+	if err != nil {
+		if errors.Is(err, group.ErrGroupNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get class: %w", err)
+	}
+
+	rawMembers, err := s.groupStore.GetMembers(ctx, classID)
+	if err != nil {
+		return nil, fmt.Errorf("get members: %w", err)
+	}
+
+	members := make([]ClassMember, 0, len(rawMembers))
+	for _, m := range rawMembers {
+		members = append(members, ClassMember{
+			UserID:         m.UserID,
+			MembershipRole: m.MembershipRole,
+			JoinedAt:       m.JoinedAt,
+		})
+	}
+
+	return &ClassDetail{
+		ClassListItem: ClassListItem{
+			ID:          g.ID,
+			Name:        g.Name,
+			SyllabusID:  g.SyllabusID,
+			JoinCode:    g.JoinCode,
+			Status:      g.Status,
+			MemberCount: len(members),
+			CreatedAt:   g.CreatedAt,
+		},
+		Members: members,
+	}, nil
+}
+
+// UpdateClass renames or archives a class.
+func (s *Service) UpdateClass(ctx context.Context, classID string, name *string, status *string) error {
+	if s.groupStore == nil {
+		return fmt.Errorf("group store not configured")
+	}
+	if s.allTenants {
+		return fmt.Errorf("UpdateClass requires a tenant-scoped service")
+	}
+
+	if name != nil {
+		if err := s.groupStore.Rename(ctx, s.tenantID, classID, *name); err != nil {
+			if errors.Is(err, group.ErrGroupNotFound) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("rename class: %w", err)
+		}
+	}
+
+	if status != nil && *status == "archived" {
+		if err := s.groupStore.Archive(ctx, s.tenantID, classID); err != nil {
+			if errors.Is(err, group.ErrGroupNotFound) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("archive class: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -13,6 +13,7 @@ import (
 	"github.com/p-n-ai/pai-bot/internal/ai"
 	"github.com/p-n-ai/pai-bot/internal/chat"
 	"github.com/p-n-ai/pai-bot/internal/curriculum"
+	"github.com/p-n-ai/pai-bot/internal/group"
 	"github.com/p-n-ai/pai-bot/internal/i18n"
 	"github.com/p-n-ai/pai-bot/internal/progress"
 )
@@ -47,6 +48,7 @@ type EngineConfig struct {
 	XP                    progress.XPTracker
 	Goals                 GoalStore
 	Challenges            ChallengeStore
+	Groups                group.Store
 	DevMode               bool
 }
 
@@ -67,6 +69,7 @@ type Engine struct {
 	xp                    progress.XPTracker
 	goals                 GoalStore
 	challenges            ChallengeStore
+	groups                group.Store
 	devMode               bool
 	prereqGraph           *curriculum.PrereqGraph
 	unlocks               *pendingUnlocks
@@ -128,6 +131,7 @@ func NewEngine(cfg EngineConfig) *Engine {
 		xp:                    cfg.XP,
 		goals:                 cfg.Goals,
 		challenges:            challenges,
+		groups:                cfg.Groups,
 		devMode:               cfg.DevMode,
 		prereqGraph:           buildPrereqGraph(cfg.CurriculumLoader),
 		unlocks:               newPendingUnlocks(),
@@ -632,6 +636,10 @@ func (e *Engine) handleCommand(ctx context.Context, msg chat.InboundMessage) (st
 		return e.handleGoalCommand(ctx, msg, fields[1:])
 	case "/challenge":
 		return e.handleChallengeCommand(ctx, msg, fields[1:])
+	case "/group":
+		return e.handleGroupCommand(ctx, msg, fields[1:])
+	case "/join":
+		return e.handleGroupCommand(ctx, msg, append([]string{"join"}, fields[1:]...))
 	case "/learn":
 		return e.handleLearnCommand(ctx, msg, fields[1:])
 	case "/dev-reset", "/dev_reset":

--- a/internal/agent/group_command.go
+++ b/internal/agent/group_command.go
@@ -1,0 +1,180 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/p-n-ai/pai-bot/internal/chat"
+	"github.com/p-n-ai/pai-bot/internal/group"
+	"github.com/p-n-ai/pai-bot/internal/i18n"
+)
+
+func (e *Engine) handleGroupCommand(ctx context.Context, msg chat.InboundMessage, args []string) (string, error) {
+	locale := e.messageLocale(msg, nil)
+	if e.groups == nil {
+		return i18n.S(locale, i18n.MsgGroupUsage), nil
+	}
+	if len(args) == 0 {
+		return e.handleGroupList(ctx, msg)
+	}
+	switch strings.ToLower(args[0]) {
+	case "create":
+		return e.handleGroupCreate(ctx, msg, args[1:])
+	case "join":
+		return e.handleGroupJoin(ctx, msg, args[1:])
+	case "leave":
+		return e.handleGroupLeave(ctx, msg)
+	case "list":
+		return e.handleGroupList(ctx, msg)
+	default:
+		// If it looks like a join code, treat as join.
+		if len(args[0]) >= 4 {
+			return e.handleGroupJoin(ctx, msg, args)
+		}
+		return i18n.S(locale, i18n.MsgGroupUsage), nil
+	}
+}
+
+func (e *Engine) handleGroupCreate(ctx context.Context, msg chat.InboundMessage, args []string) (string, error) {
+	locale := e.messageLocale(msg, nil)
+
+	role, _ := e.store.GetUserRole(msg.UserID)
+	if role != "teacher" && role != "admin" && role != "platform_admin" {
+		return i18n.S(locale, i18n.MsgGroupCreateDenied), nil
+	}
+
+	tenantID, _ := e.store.GetUserTenantID(msg.UserID)
+	internalID, _ := e.store.GetUserInternalID(msg.UserID)
+
+	name := strings.TrimSpace(strings.Join(args, " "))
+	if name == "" {
+		name = "New Group"
+	}
+
+	g, err := e.groups.Create(ctx, group.Group{
+		TenantID:  tenantID,
+		Name:      name,
+		CreatedBy: internalID,
+	})
+	if err != nil {
+		return i18n.S(locale, i18n.MsgTechnicalIssue), nil
+	}
+
+	return i18n.S(locale, i18n.MsgGroupCreated, g.Name, g.JoinCode), nil
+}
+
+func (e *Engine) handleGroupJoin(ctx context.Context, msg chat.InboundMessage, args []string) (string, error) {
+	locale := e.messageLocale(msg, nil)
+
+	if len(args) == 0 {
+		return i18n.S(locale, i18n.MsgGroupUsage), nil
+	}
+
+	code := group.NormalizeJoinCode(args[0])
+	tenantID, _ := e.store.GetUserTenantID(msg.UserID)
+	internalID, _ := e.store.GetUserInternalID(msg.UserID)
+
+	g, err := e.groups.GetByJoinCode(ctx, tenantID, code)
+	if err != nil {
+		return i18n.S(locale, i18n.MsgGroupNotFound), nil
+	}
+
+	if g.Status == "archived" {
+		return i18n.S(locale, i18n.MsgGroupArchived), nil
+	}
+
+	// Syllabus validation.
+	userForm, _ := e.store.GetUserForm(msg.UserID)
+	if !validateSyllabusMatch(userForm, g.SyllabusID) {
+		return i18n.S(locale, i18n.MsgGroupSyllabusMismatch, g.SyllabusID, userForm), nil
+	}
+
+	err = e.groups.AddMember(ctx, g.ID, internalID, "member")
+	if err != nil {
+		if err == group.ErrAlreadyMember {
+			return i18n.S(locale, i18n.MsgGroupAlreadyMember), nil
+		}
+		if err == group.ErrGroupArchived {
+			return i18n.S(locale, i18n.MsgGroupArchived), nil
+		}
+		return i18n.S(locale, i18n.MsgTechnicalIssue), nil
+	}
+
+	count, _ := e.groups.MemberCount(ctx, g.ID)
+	// Subtract 1 for "classmates" (excluding self).
+	classmates := count - 1
+	if classmates < 0 {
+		classmates = 0
+	}
+
+	return i18n.S(locale, i18n.MsgGroupJoined, g.Name, classmates), nil
+}
+
+func (e *Engine) handleGroupLeave(ctx context.Context, msg chat.InboundMessage) (string, error) {
+	locale := e.messageLocale(msg, nil)
+	internalID, _ := e.store.GetUserInternalID(msg.UserID)
+
+	groups, err := e.groups.ListByUser(ctx, internalID)
+	if err != nil || len(groups) == 0 {
+		return i18n.S(locale, i18n.MsgGroupListEmpty), nil
+	}
+
+	// Leave the first group (v1 simplicity).
+	g := groups[0]
+	err = e.groups.RemoveMember(ctx, g.ID, internalID)
+	if err != nil {
+		if err == group.ErrOwnerCannotLeave {
+			return i18n.S(locale, i18n.MsgGroupOwnerCannotLeave), nil
+		}
+		return i18n.S(locale, i18n.MsgTechnicalIssue), nil
+	}
+
+	return i18n.S(locale, i18n.MsgGroupLeft, g.Name), nil
+}
+
+func (e *Engine) handleGroupList(ctx context.Context, msg chat.InboundMessage) (string, error) {
+	locale := e.messageLocale(msg, nil)
+	internalID, _ := e.store.GetUserInternalID(msg.UserID)
+
+	groups, err := e.groups.ListByUser(ctx, internalID)
+	if err != nil || len(groups) == 0 {
+		return i18n.S(locale, i18n.MsgGroupListEmpty), nil
+	}
+
+	var lines []string
+	for _, g := range groups {
+		count, _ := e.groups.MemberCount(ctx, g.ID)
+		lines = append(lines, fmt.Sprintf("- %s (kod: %s, %d ahli)", g.Name, g.JoinCode, count))
+	}
+
+	return i18n.S(locale, i18n.MsgGroupList, strings.Join(lines, "\n")), nil
+}
+
+// validateSyllabusMatch checks if the user's form is compatible with the group's syllabus.
+func validateSyllabusMatch(userForm, groupSyllabusID string) bool {
+	if userForm == "" || groupSyllabusID == "" {
+		return true
+	}
+	// Extract form number from user's form string.
+	formNum := extractFormNumber(userForm)
+	if formNum == "" {
+		return true
+	}
+	// Check if syllabus_id contains a matching tingkatan reference.
+	lower := strings.ToLower(groupSyllabusID)
+	return strings.Contains(lower, "tingkatan-"+formNum) ||
+		strings.Contains(lower, "form-"+formNum) ||
+		strings.Contains(lower, "form"+formNum)
+}
+
+// extractFormNumber pulls the digit from strings like "Form 1", "Tingkatan 2", "3".
+func extractFormNumber(form string) string {
+	form = strings.TrimSpace(form)
+	for _, c := range form {
+		if c >= '1' && c <= '5' {
+			return string(c)
+		}
+	}
+	return ""
+}

--- a/internal/agent/group_command_test.go
+++ b/internal/agent/group_command_test.go
@@ -1,0 +1,383 @@
+package agent_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/p-n-ai/pai-bot/internal/agent"
+	"github.com/p-n-ai/pai-bot/internal/chat"
+	"github.com/p-n-ai/pai-bot/internal/group"
+)
+
+func setupGroupTestEngine(t *testing.T) (*agent.Engine, *agent.MemoryStore, *group.MemoryStore) {
+	t.Helper()
+	store := agent.NewMemoryStore()
+	groupStore := group.NewMemoryStore()
+	engine := agent.NewEngine(agent.EngineConfig{
+		Store:                store,
+		EventLogger:          agent.NewMemoryEventLogger(),
+		Groups:               groupStore,
+		DisableMultiLanguage: true,
+	})
+	return engine, store, groupStore
+}
+
+func setGroupTestUser(t *testing.T, store *agent.MemoryStore, userID, role, tenantID string) {
+	t.Helper()
+	if err := store.SetUserRole(userID, role); err != nil {
+		t.Fatalf("SetUserRole(%s): %v", userID, err)
+	}
+	if err := store.SetUserTenantID(userID, tenantID); err != nil {
+		t.Fatalf("SetUserTenantID(%s): %v", userID, err)
+	}
+}
+
+func TestGroupCreate_TeacherSuccess(t *testing.T) {
+	engine, store, _ := setupGroupTestEngine(t)
+	setGroupTestUser(t, store, "teacher-1", "teacher", "tenant-1")
+
+	resp, err := engine.ProcessMessage(context.Background(), chat.InboundMessage{
+		Channel: "terminal",
+		UserID:  "teacher-1",
+		Text:    "/group create Math Class",
+	})
+	if err != nil {
+		t.Fatalf("ProcessMessage: %v", err)
+	}
+
+	if !strings.Contains(resp, "Math Class") {
+		t.Errorf("expected response to contain group name, got: %s", resp)
+	}
+	// The response should contain a join code (6 uppercase alphanum chars).
+	lower := strings.ToLower(resp)
+	if !strings.Contains(lower, "kod") && !strings.Contains(lower, "code") {
+		t.Errorf("expected response to contain a join code reference, got: %s", resp)
+	}
+}
+
+func TestGroupCreate_StudentDenied(t *testing.T) {
+	engine, store, _ := setupGroupTestEngine(t)
+	setGroupTestUser(t, store, "student-1", "student", "tenant-1")
+
+	resp, err := engine.ProcessMessage(context.Background(), chat.InboundMessage{
+		Channel: "terminal",
+		UserID:  "student-1",
+		Text:    "/group create Study Group",
+	})
+	if err != nil {
+		t.Fatalf("ProcessMessage: %v", err)
+	}
+
+	// Should get denied message (ms locale default: "Hanya guru dan pentadbir").
+	if !strings.Contains(resp, "guru") && !strings.Contains(resp, "teacher") && !strings.Contains(resp, "admin") {
+		t.Errorf("expected denial message, got: %s", resp)
+	}
+}
+
+func TestGroupCreate_AdminSuccess(t *testing.T) {
+	engine, store, _ := setupGroupTestEngine(t)
+	setGroupTestUser(t, store, "admin-1", "admin", "tenant-1")
+
+	resp, err := engine.ProcessMessage(context.Background(), chat.InboundMessage{
+		Channel: "terminal",
+		UserID:  "admin-1",
+		Text:    "/group create Admin Group",
+	})
+	if err != nil {
+		t.Fatalf("ProcessMessage: %v", err)
+	}
+
+	if !strings.Contains(resp, "Admin Group") {
+		t.Errorf("expected response to contain group name, got: %s", resp)
+	}
+}
+
+func TestGroupJoin_Success(t *testing.T) {
+	engine, store, groupStore := setupGroupTestEngine(t)
+
+	// Teacher creates a group first.
+	setGroupTestUser(t, store, "teacher-1", "teacher", "tenant-1")
+	g, err := groupStore.Create(context.Background(), group.Group{
+		TenantID:  "tenant-1",
+		Name:      "Math Class",
+		CreatedBy: "teacher-1",
+	})
+	if err != nil {
+		t.Fatalf("Create group: %v", err)
+	}
+
+	// Student joins.
+	setGroupTestUser(t, store, "student-1", "student", "tenant-1")
+
+	resp, err := engine.ProcessMessage(context.Background(), chat.InboundMessage{
+		Channel: "terminal",
+		UserID:  "student-1",
+		Text:    "/group join " + g.JoinCode,
+	})
+	if err != nil {
+		t.Fatalf("ProcessMessage: %v", err)
+	}
+
+	if !strings.Contains(resp, "Math Class") {
+		t.Errorf("expected response to contain group name, got: %s", resp)
+	}
+}
+
+func TestGroupJoin_InvalidCode(t *testing.T) {
+	engine, store, _ := setupGroupTestEngine(t)
+	setGroupTestUser(t, store, "student-1", "student", "tenant-1")
+
+	resp, err := engine.ProcessMessage(context.Background(), chat.InboundMessage{
+		Channel: "terminal",
+		UserID:  "student-1",
+		Text:    "/group join ZZZZZZ",
+	})
+	if err != nil {
+		t.Fatalf("ProcessMessage: %v", err)
+	}
+
+	// Should contain "not found" or Malay equivalent.
+	if !strings.Contains(resp, "tidak dijumpai") && !strings.Contains(resp, "not found") && !strings.Contains(resp, "tidak") {
+		t.Errorf("expected not-found message, got: %s", resp)
+	}
+}
+
+func TestGroupJoin_AlreadyMember(t *testing.T) {
+	engine, store, groupStore := setupGroupTestEngine(t)
+
+	setGroupTestUser(t, store, "teacher-1", "teacher", "tenant-1")
+	g, err := groupStore.Create(context.Background(), group.Group{
+		TenantID:  "tenant-1",
+		Name:      "Math Class",
+		CreatedBy: "teacher-1",
+	})
+	if err != nil {
+		t.Fatalf("Create group: %v", err)
+	}
+
+	setGroupTestUser(t, store, "student-1", "student", "tenant-1")
+
+	// Join once.
+	_, err = engine.ProcessMessage(context.Background(), chat.InboundMessage{
+		Channel: "terminal",
+		UserID:  "student-1",
+		Text:    "/group join " + g.JoinCode,
+	})
+	if err != nil {
+		t.Fatalf("first join: %v", err)
+	}
+
+	// Join again.
+	resp, err := engine.ProcessMessage(context.Background(), chat.InboundMessage{
+		Channel: "terminal",
+		UserID:  "student-1",
+		Text:    "/group join " + g.JoinCode,
+	})
+	if err != nil {
+		t.Fatalf("second join: %v", err)
+	}
+
+	if !strings.Contains(resp, "sudah") && !strings.Contains(resp, "already") {
+		t.Errorf("expected already-member message, got: %s", resp)
+	}
+}
+
+func TestGroupLeave_Success(t *testing.T) {
+	engine, store, groupStore := setupGroupTestEngine(t)
+
+	setGroupTestUser(t, store, "teacher-1", "teacher", "tenant-1")
+	g, err := groupStore.Create(context.Background(), group.Group{
+		TenantID:  "tenant-1",
+		Name:      "Math Class",
+		CreatedBy: "teacher-1",
+	})
+	if err != nil {
+		t.Fatalf("Create group: %v", err)
+	}
+
+	setGroupTestUser(t, store, "student-1", "student", "tenant-1")
+
+	// Join first.
+	if err := groupStore.AddMember(context.Background(), g.ID, "student-1", "member"); err != nil {
+		t.Fatalf("AddMember: %v", err)
+	}
+
+	resp, err := engine.ProcessMessage(context.Background(), chat.InboundMessage{
+		Channel: "terminal",
+		UserID:  "student-1",
+		Text:    "/group leave",
+	})
+	if err != nil {
+		t.Fatalf("ProcessMessage: %v", err)
+	}
+
+	if !strings.Contains(resp, "Math Class") {
+		t.Errorf("expected response to mention group name, got: %s", resp)
+	}
+	if !strings.Contains(resp, "keluar") && !strings.Contains(resp, "left") {
+		t.Errorf("expected leave confirmation, got: %s", resp)
+	}
+}
+
+func TestGroupLeave_OwnerDenied(t *testing.T) {
+	engine, store, groupStore := setupGroupTestEngine(t)
+
+	setGroupTestUser(t, store, "teacher-1", "teacher", "tenant-1")
+	_, err := groupStore.Create(context.Background(), group.Group{
+		TenantID:  "tenant-1",
+		Name:      "Math Class",
+		CreatedBy: "teacher-1",
+	})
+	if err != nil {
+		t.Fatalf("Create group: %v", err)
+	}
+
+	resp, err := engine.ProcessMessage(context.Background(), chat.InboundMessage{
+		Channel: "terminal",
+		UserID:  "teacher-1",
+		Text:    "/group leave",
+	})
+	if err != nil {
+		t.Fatalf("ProcessMessage: %v", err)
+	}
+
+	if !strings.Contains(resp, "Pemilik") && !strings.Contains(resp, "Owner") && !strings.Contains(resp, "owner") {
+		t.Errorf("expected owner-cannot-leave message, got: %s", resp)
+	}
+}
+
+func TestGroupList_WithGroups(t *testing.T) {
+	engine, store, groupStore := setupGroupTestEngine(t)
+
+	setGroupTestUser(t, store, "student-1", "student", "tenant-1")
+
+	// Create a group and add student.
+	setGroupTestUser(t, store, "teacher-1", "teacher", "tenant-1")
+	g, err := groupStore.Create(context.Background(), group.Group{
+		TenantID:  "tenant-1",
+		Name:      "Math Class",
+		CreatedBy: "teacher-1",
+	})
+	if err != nil {
+		t.Fatalf("Create group: %v", err)
+	}
+	if err := groupStore.AddMember(context.Background(), g.ID, "student-1", "member"); err != nil {
+		t.Fatalf("AddMember: %v", err)
+	}
+
+	resp, err := engine.ProcessMessage(context.Background(), chat.InboundMessage{
+		Channel: "terminal",
+		UserID:  "student-1",
+		Text:    "/group list",
+	})
+	if err != nil {
+		t.Fatalf("ProcessMessage: %v", err)
+	}
+
+	if !strings.Contains(resp, "Math Class") {
+		t.Errorf("expected group name in list, got: %s", resp)
+	}
+}
+
+func TestGroupList_Empty(t *testing.T) {
+	engine, store, _ := setupGroupTestEngine(t)
+	setGroupTestUser(t, store, "student-1", "student", "tenant-1")
+
+	resp, err := engine.ProcessMessage(context.Background(), chat.InboundMessage{
+		Channel: "terminal",
+		UserID:  "student-1",
+		Text:    "/group list",
+	})
+	if err != nil {
+		t.Fatalf("ProcessMessage: %v", err)
+	}
+
+	if !strings.Contains(resp, "belum") && !strings.Contains(resp, "haven't") && !strings.Contains(resp, "join") {
+		t.Errorf("expected empty-list message, got: %s", resp)
+	}
+}
+
+func TestJoinAlias(t *testing.T) {
+	engine, store, groupStore := setupGroupTestEngine(t)
+
+	setGroupTestUser(t, store, "teacher-1", "teacher", "tenant-1")
+	g, err := groupStore.Create(context.Background(), group.Group{
+		TenantID:  "tenant-1",
+		Name:      "Science Group",
+		CreatedBy: "teacher-1",
+	})
+	if err != nil {
+		t.Fatalf("Create group: %v", err)
+	}
+
+	setGroupTestUser(t, store, "student-1", "student", "tenant-1")
+
+	// Use /join directly instead of /group join.
+	resp, err := engine.ProcessMessage(context.Background(), chat.InboundMessage{
+		Channel: "terminal",
+		UserID:  "student-1",
+		Text:    "/join " + g.JoinCode,
+	})
+	if err != nil {
+		t.Fatalf("ProcessMessage: %v", err)
+	}
+
+	if !strings.Contains(resp, "Science Group") {
+		t.Errorf("expected response to contain group name, got: %s", resp)
+	}
+}
+
+func TestGroupUsage_NoSubcommand(t *testing.T) {
+	engine, store, _ := setupGroupTestEngine(t)
+	setGroupTestUser(t, store, "student-1", "student", "tenant-1")
+
+	// /group with no args should show list (not usage)
+	resp, err := engine.ProcessMessage(context.Background(), chat.InboundMessage{
+		Channel: "terminal",
+		UserID:  "student-1",
+		Text:    "/group",
+	})
+	if err != nil {
+		t.Fatalf("ProcessMessage: %v", err)
+	}
+
+	// With no groups, should show empty list message.
+	if !strings.Contains(resp, "belum") && !strings.Contains(resp, "haven't") {
+		t.Errorf("expected empty list message for bare /group, got: %s", resp)
+	}
+}
+
+func TestGroupJoin_ArchivedGroup(t *testing.T) {
+	engine, store, groupStore := setupGroupTestEngine(t)
+
+	setGroupTestUser(t, store, "teacher-1", "teacher", "tenant-1")
+	g, err := groupStore.Create(context.Background(), group.Group{
+		TenantID:  "tenant-1",
+		Name:      "Old Group",
+		CreatedBy: "teacher-1",
+	})
+	if err != nil {
+		t.Fatalf("Create group: %v", err)
+	}
+
+	// Archive it.
+	if err := groupStore.Archive(context.Background(), "tenant-1", g.ID); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+
+	setGroupTestUser(t, store, "student-1", "student", "tenant-1")
+
+	resp, err := engine.ProcessMessage(context.Background(), chat.InboundMessage{
+		Channel: "terminal",
+		UserID:  "student-1",
+		Text:    "/join " + g.JoinCode,
+	})
+	if err != nil {
+		t.Fatalf("ProcessMessage: %v", err)
+	}
+
+	if !strings.Contains(resp, "diarkibkan") && !strings.Contains(resp, "archived") {
+		t.Errorf("expected archived message, got: %s", resp)
+	}
+}

--- a/internal/agent/store.go
+++ b/internal/agent/store.go
@@ -68,6 +68,9 @@ type ConversationStore interface {
 	SetUserPreferredQuizIntensity(userID, intensity string) error
 	GetUserABGroup(userID string) (string, bool)
 	SetUserABGroup(userID, group string) error
+	GetUserTenantID(userID string) (string, bool)
+	GetUserRole(userID string) (string, bool)
+	GetUserInternalID(userID string) (string, bool)
 	CreateConversation(conv Conversation) (string, error)
 	GetConversation(id string) (*Conversation, error)
 	GetActiveConversation(userID string) (*Conversation, bool)
@@ -91,6 +94,8 @@ type MemoryStore struct {
 	userLang      map[string]string
 	userQuizLevel map[string]string
 	userABGroup   map[string]string
+	userTenantID  map[string]string
+	userRole      map[string]string
 	mu            sync.RWMutex
 }
 
@@ -103,6 +108,8 @@ func NewMemoryStore() *MemoryStore {
 		userLang:      make(map[string]string),
 		userQuizLevel: make(map[string]string),
 		userABGroup:   make(map[string]string),
+		userTenantID:  make(map[string]string),
+		userRole:      make(map[string]string),
 	}
 }
 
@@ -136,6 +143,12 @@ func (s *MemoryStore) UserExists(userID string) bool {
 		return true
 	}
 	if _, ok := s.userABGroup[userID]; ok {
+		return true
+	}
+	if _, ok := s.userTenantID[userID]; ok {
+		return true
+	}
+	if _, ok := s.userRole[userID]; ok {
 		return true
 	}
 	for _, conv := range s.conversations {
@@ -251,6 +264,81 @@ func (s *MemoryStore) SetUserABGroup(userID, group string) error {
 	}
 	s.userABGroup[userID] = group
 	return nil
+}
+
+func (s *MemoryStore) GetUserTenantID(userID string) (string, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	tenantID, ok := s.userTenantID[userID]
+	return tenantID, ok
+}
+
+func (s *MemoryStore) SetUserTenantID(userID, tenantID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if userID == "" {
+		return fmt.Errorf("user_id is required")
+	}
+	if tenantID == "" {
+		delete(s.userTenantID, userID)
+		return nil
+	}
+	s.userTenantID[userID] = tenantID
+	return nil
+}
+
+func (s *MemoryStore) GetUserRole(userID string) (string, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	role, ok := s.userRole[userID]
+	return role, ok
+}
+
+func (s *MemoryStore) SetUserRole(userID, role string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if userID == "" {
+		return fmt.Errorf("user_id is required")
+	}
+	if role == "" {
+		delete(s.userRole, userID)
+		return nil
+	}
+	s.userRole[userID] = role
+	return nil
+}
+
+func (s *MemoryStore) GetUserInternalID(userID string) (string, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	// MemoryStore uses external IDs as-is; return the userID itself if it exists.
+	if _, ok := s.userName[userID]; ok {
+		return userID, true
+	}
+	if _, ok := s.userForm[userID]; ok {
+		return userID, true
+	}
+	if _, ok := s.userLang[userID]; ok {
+		return userID, true
+	}
+	if _, ok := s.userQuizLevel[userID]; ok {
+		return userID, true
+	}
+	if _, ok := s.userABGroup[userID]; ok {
+		return userID, true
+	}
+	if _, ok := s.userTenantID[userID]; ok {
+		return userID, true
+	}
+	if _, ok := s.userRole[userID]; ok {
+		return userID, true
+	}
+	for _, conv := range s.conversations {
+		if conv.UserID == userID {
+			return userID, true
+		}
+	}
+	return "", false
 }
 
 func (s *MemoryStore) GetConversation(id string) (*Conversation, error) {

--- a/internal/agent/store_postgres.go
+++ b/internal/agent/store_postgres.go
@@ -398,6 +398,54 @@ func (s *PostgresStore) SetUserABGroup(externalID, group string) error {
 	return nil
 }
 
+func (s *PostgresStore) GetUserTenantID(externalID string) (string, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), dbTimeout)
+	defer cancel()
+	var tenantID *string
+	err := s.pool.QueryRow(ctx,
+		`SELECT tenant_id::text FROM users
+		 WHERE tenant_id = $1::uuid AND channel = $2 AND external_id = $3
+		 ORDER BY created_at ASC LIMIT 1`,
+		s.tenantID, s.channel, externalID,
+	).Scan(&tenantID)
+	if err != nil || tenantID == nil || *tenantID == "" {
+		return "", false
+	}
+	return *tenantID, true
+}
+
+func (s *PostgresStore) GetUserRole(externalID string) (string, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), dbTimeout)
+	defer cancel()
+	var role *string
+	err := s.pool.QueryRow(ctx,
+		`SELECT NULLIF(role, '') FROM users
+		 WHERE tenant_id = $1::uuid AND channel = $2 AND external_id = $3
+		 ORDER BY created_at ASC LIMIT 1`,
+		s.tenantID, s.channel, externalID,
+	).Scan(&role)
+	if err != nil || role == nil || *role == "" {
+		return "", false
+	}
+	return *role, true
+}
+
+func (s *PostgresStore) GetUserInternalID(externalID string) (string, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), dbTimeout)
+	defer cancel()
+	var id *string
+	err := s.pool.QueryRow(ctx,
+		`SELECT id::text FROM users
+		 WHERE tenant_id = $1::uuid AND channel = $2 AND external_id = $3
+		 ORDER BY created_at ASC LIMIT 1`,
+		s.tenantID, s.channel, externalID,
+	).Scan(&id)
+	if err != nil || id == nil || *id == "" {
+		return "", false
+	}
+	return *id, true
+}
+
 // NewPostgresStore creates a PostgreSQL-backed conversation store for the default channel.
 func NewPostgresStore(ctx context.Context, pool *pgxpool.Pool) (*PostgresStore, error) {
 	return NewPostgresStoreForChannel(ctx, pool, defaultChannel)

--- a/internal/group/joincode.go
+++ b/internal/group/joincode.go
@@ -1,0 +1,27 @@
+package group
+
+import (
+	"crypto/rand"
+	"math/big"
+	"strings"
+)
+
+const joinCodeCharset = "ABCDEFGHJKMNPQRSTUVWXYZ23456789"
+const joinCodeLength = 6
+
+func GenerateJoinCode() (string, error) {
+	b := make([]byte, joinCodeLength)
+	max := big.NewInt(int64(len(joinCodeCharset)))
+	for i := range b {
+		n, err := rand.Int(rand.Reader, max)
+		if err != nil {
+			return "", err
+		}
+		b[i] = joinCodeCharset[n.Int64()]
+	}
+	return string(b), nil
+}
+
+func NormalizeJoinCode(code string) string {
+	return strings.ToUpper(strings.TrimSpace(code))
+}

--- a/internal/group/joincode_test.go
+++ b/internal/group/joincode_test.go
@@ -1,0 +1,53 @@
+package group
+
+import (
+	"strings"
+	"testing"
+)
+
+const validCharset = "ABCDEFGHJKMNPQRSTUVWXYZ23456789"
+
+func TestGenerateJoinCode_Length(t *testing.T) {
+	code, err := GenerateJoinCode()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(code) != 6 {
+		t.Errorf("len = %d, want 6", len(code))
+	}
+}
+
+func TestGenerateJoinCode_Charset(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		code, _ := GenerateJoinCode()
+		for _, c := range code {
+			if !strings.ContainsRune(validCharset, c) {
+				t.Errorf("invalid char %c in code %s", c, code)
+			}
+		}
+	}
+}
+
+func TestGenerateJoinCode_Unique(t *testing.T) {
+	seen := make(map[string]bool)
+	for i := 0; i < 1000; i++ {
+		code, _ := GenerateJoinCode()
+		if seen[code] {
+			t.Fatalf("duplicate: %s", code)
+		}
+		seen[code] = true
+	}
+}
+
+func TestNormalizeJoinCode(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"abc123", "ABC123"},
+		{"  XYZ  ", "XYZ"},
+	}
+	for _, tt := range tests {
+		got := NormalizeJoinCode(tt.in)
+		if got != tt.want {
+			t.Errorf("NormalizeJoinCode(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/group/store.go
+++ b/internal/group/store.go
@@ -1,0 +1,46 @@
+package group
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var (
+	ErrGroupNotFound    = errors.New("group not found")
+	ErrAlreadyMember    = errors.New("already a member")
+	ErrNotMember        = errors.New("not a member")
+	ErrOwnerCannotLeave = errors.New("owner cannot leave group")
+	ErrGroupArchived    = errors.New("group is archived")
+)
+
+type Group struct {
+	ID         string
+	TenantID   string
+	Name       string
+	SyllabusID string
+	JoinCode   string
+	Status     string
+	CreatedBy  string
+	CreatedAt  time.Time
+}
+
+type Member struct {
+	UserID         string
+	MembershipRole string
+	JoinedAt       time.Time
+}
+
+type Store interface {
+	Create(ctx context.Context, g Group) (*Group, error)
+	GetByID(ctx context.Context, tenantID, groupID string) (*Group, error)
+	GetByJoinCode(ctx context.Context, tenantID, code string) (*Group, error)
+	ListByTenant(ctx context.Context, tenantID string) ([]Group, error)
+	ListByUser(ctx context.Context, userID string) ([]Group, error)
+	Archive(ctx context.Context, tenantID, groupID string) error
+	AddMember(ctx context.Context, groupID, userID, membershipRole string) error
+	RemoveMember(ctx context.Context, groupID, userID string) error
+	GetMembers(ctx context.Context, groupID string) ([]Member, error)
+	MemberCount(ctx context.Context, groupID string) (int, error)
+	IsMember(ctx context.Context, groupID, userID string) (bool, error)
+}

--- a/internal/group/store.go
+++ b/internal/group/store.go
@@ -38,6 +38,7 @@ type Store interface {
 	ListByTenant(ctx context.Context, tenantID string) ([]Group, error)
 	ListByUser(ctx context.Context, userID string) ([]Group, error)
 	Archive(ctx context.Context, tenantID, groupID string) error
+	Rename(ctx context.Context, tenantID, groupID, newName string) error
 	AddMember(ctx context.Context, groupID, userID, membershipRole string) error
 	RemoveMember(ctx context.Context, groupID, userID string) error
 	GetMembers(ctx context.Context, groupID string) ([]Member, error)

--- a/internal/group/store_memory.go
+++ b/internal/group/store_memory.go
@@ -144,6 +144,19 @@ func (s *MemoryStore) Archive(ctx context.Context, tenantID, groupID string) err
 	return nil
 }
 
+// Rename updates the name of a group.
+func (s *MemoryStore) Rename(ctx context.Context, tenantID, groupID, newName string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	g, ok := s.groups[groupID]
+	if !ok || g.TenantID != tenantID {
+		return ErrGroupNotFound
+	}
+	g.Name = newName
+	return nil
+}
+
 // AddMember adds userID to the group with the given role.
 // Returns ErrAlreadyMember if already present, ErrGroupArchived if group is archived.
 func (s *MemoryStore) AddMember(ctx context.Context, groupID, userID, membershipRole string) error {

--- a/internal/group/store_memory.go
+++ b/internal/group/store_memory.go
@@ -1,0 +1,230 @@
+package group
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"sync"
+	"time"
+)
+
+// MemoryStore is an in-memory implementation of Store, suitable for testing.
+type MemoryStore struct {
+	mu      sync.RWMutex
+	groups  map[string]*Group   // id → Group
+	members map[string][]Member // groupID → members
+	codes   map[string]string   // joinCode → groupID
+}
+
+// NewMemoryStore creates a new empty MemoryStore.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{
+		groups:  make(map[string]*Group),
+		members: make(map[string][]Member),
+		codes:   make(map[string]string),
+	}
+}
+
+func generateID() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// Create stores a new group and adds the creator as owner.
+func (s *MemoryStore) Create(ctx context.Context, g Group) (*Group, error) {
+	id, err := generateID()
+	if err != nil {
+		return nil, err
+	}
+	code, err := GenerateJoinCode()
+	if err != nil {
+		return nil, err
+	}
+
+	g.ID = id
+	g.JoinCode = code
+	g.Status = "active"
+	if g.CreatedAt.IsZero() {
+		g.CreatedAt = time.Now().UTC()
+	}
+
+	s.mu.Lock()
+	s.groups[id] = &g
+	s.codes[code] = id
+	s.mu.Unlock()
+
+	// Add creator as owner (uses AddMember which locks internally).
+	if err := s.AddMember(ctx, id, g.CreatedBy, "owner"); err != nil {
+		return nil, err
+	}
+
+	// Return a copy.
+	cp := g
+	return &cp, nil
+}
+
+// GetByID returns the group if it belongs to tenantID.
+func (s *MemoryStore) GetByID(ctx context.Context, tenantID, groupID string) (*Group, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	g, ok := s.groups[groupID]
+	if !ok || g.TenantID != tenantID {
+		return nil, ErrGroupNotFound
+	}
+	cp := *g
+	return &cp, nil
+}
+
+// GetByJoinCode looks up a group by join code and enforces tenant isolation.
+func (s *MemoryStore) GetByJoinCode(ctx context.Context, tenantID, code string) (*Group, error) {
+	code = NormalizeJoinCode(code)
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	groupID, ok := s.codes[code]
+	if !ok {
+		return nil, ErrGroupNotFound
+	}
+	g, ok := s.groups[groupID]
+	if !ok || g.TenantID != tenantID {
+		return nil, ErrGroupNotFound
+	}
+	cp := *g
+	return &cp, nil
+}
+
+// ListByTenant returns all groups belonging to tenantID.
+func (s *MemoryStore) ListByTenant(ctx context.Context, tenantID string) ([]Group, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var result []Group
+	for _, g := range s.groups {
+		if g.TenantID == tenantID {
+			result = append(result, *g)
+		}
+	}
+	return result, nil
+}
+
+// ListByUser returns all groups where userID is a member.
+func (s *MemoryStore) ListByUser(ctx context.Context, userID string) ([]Group, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var result []Group
+	for groupID, members := range s.members {
+		for _, m := range members {
+			if m.UserID == userID {
+				if g, ok := s.groups[groupID]; ok {
+					result = append(result, *g)
+				}
+				break
+			}
+		}
+	}
+	return result, nil
+}
+
+// Archive sets the group's status to "archived".
+func (s *MemoryStore) Archive(ctx context.Context, tenantID, groupID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	g, ok := s.groups[groupID]
+	if !ok || g.TenantID != tenantID {
+		return ErrGroupNotFound
+	}
+	g.Status = "archived"
+	return nil
+}
+
+// AddMember adds userID to the group with the given role.
+// Returns ErrAlreadyMember if already present, ErrGroupArchived if group is archived.
+func (s *MemoryStore) AddMember(ctx context.Context, groupID, userID, membershipRole string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	g, ok := s.groups[groupID]
+	if !ok {
+		return ErrGroupNotFound
+	}
+	if g.Status == "archived" {
+		return ErrGroupArchived
+	}
+
+	for _, m := range s.members[groupID] {
+		if m.UserID == userID {
+			return ErrAlreadyMember
+		}
+	}
+
+	s.members[groupID] = append(s.members[groupID], Member{
+		UserID:         userID,
+		MembershipRole: membershipRole,
+		JoinedAt:       time.Now().UTC(),
+	})
+	return nil
+}
+
+// RemoveMember removes userID from the group.
+// Returns ErrNotMember if not present, ErrOwnerCannotLeave if they are the owner.
+func (s *MemoryStore) RemoveMember(ctx context.Context, groupID, userID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	members := s.members[groupID]
+	idx := -1
+	for i, m := range members {
+		if m.UserID == userID {
+			if m.MembershipRole == "owner" {
+				return ErrOwnerCannotLeave
+			}
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		return ErrNotMember
+	}
+
+	s.members[groupID] = append(members[:idx], members[idx+1:]...)
+	return nil
+}
+
+// GetMembers returns all members of a group.
+func (s *MemoryStore) GetMembers(ctx context.Context, groupID string) ([]Member, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	members := s.members[groupID]
+	result := make([]Member, len(members))
+	copy(result, members)
+	return result, nil
+}
+
+// MemberCount returns the number of members in a group.
+func (s *MemoryStore) MemberCount(ctx context.Context, groupID string) (int, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return len(s.members[groupID]), nil
+}
+
+// IsMember reports whether userID is a member of groupID.
+func (s *MemoryStore) IsMember(ctx context.Context, groupID, userID string) (bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for _, m := range s.members[groupID] {
+		if m.UserID == userID {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/internal/group/store_postgres.go
+++ b/internal/group/store_postgres.go
@@ -1,0 +1,367 @@
+package group
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	dbTimeout               = 5 * time.Second
+	joinCodeInsertMaxAttempts = 8
+)
+
+// PostgresStore is a PostgreSQL-backed implementation of Store.
+type PostgresStore struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgresStore creates a new PostgresStore backed by the given connection pool.
+func NewPostgresStore(pool *pgxpool.Pool) *PostgresStore {
+	return &PostgresStore{pool: pool}
+}
+
+// Create inserts a new group and adds the creator as owner in a single transaction.
+// It retries up to joinCodeInsertMaxAttempts times on join_code uniqueness collisions.
+func (s *PostgresStore) Create(ctx context.Context, g Group) (*Group, error) {
+	ctx, cancel := context.WithTimeout(ctx, dbTimeout)
+	defer cancel()
+
+	for attempt := 0; attempt < joinCodeInsertMaxAttempts; attempt++ {
+		code, err := GenerateJoinCode()
+		if err != nil {
+			return nil, fmt.Errorf("generate join code: %w", err)
+		}
+
+		tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("begin create group tx: %w", err)
+		}
+		defer func() { _ = tx.Rollback(ctx) }()
+
+		var created Group
+		err = tx.QueryRow(ctx,
+			`INSERT INTO groups (tenant_id, name, syllabus_id, join_code, status, created_by)
+			 VALUES ($1::uuid, $2, $3, $4, 'active', $5::uuid)
+			 RETURNING id::text, tenant_id::text, name, COALESCE(syllabus_id, ''), join_code, status, COALESCE(created_by::text, ''), created_at`,
+			g.TenantID,
+			g.Name,
+			nilIfEmpty(g.SyllabusID),
+			code,
+			nilIfEmpty(g.CreatedBy),
+		).Scan(
+			&created.ID,
+			&created.TenantID,
+			&created.Name,
+			&created.SyllabusID,
+			&created.JoinCode,
+			&created.Status,
+			&created.CreatedBy,
+			&created.CreatedAt,
+		)
+		if err != nil {
+			_ = tx.Rollback(ctx)
+			if isGroupUniqueViolation(err) {
+				continue
+			}
+			return nil, fmt.Errorf("insert group: %w", err)
+		}
+
+		// Add creator as owner.
+		if created.CreatedBy != "" {
+			_, err = tx.Exec(ctx,
+				`INSERT INTO group_members (group_id, user_id, membership_role)
+				 VALUES ($1::uuid, $2::uuid, 'owner')`,
+				created.ID,
+				created.CreatedBy,
+			)
+			if err != nil {
+				_ = tx.Rollback(ctx)
+				return nil, fmt.Errorf("insert owner member: %w", err)
+			}
+		}
+
+		if err := tx.Commit(ctx); err != nil {
+			return nil, fmt.Errorf("commit create group: %w", err)
+		}
+		return &created, nil
+	}
+
+	return nil, fmt.Errorf("create group: exhausted join code retries")
+}
+
+// GetByID returns the group identified by groupID within tenantID.
+func (s *PostgresStore) GetByID(ctx context.Context, tenantID, groupID string) (*Group, error) {
+	ctx, cancel := context.WithTimeout(ctx, dbTimeout)
+	defer cancel()
+
+	var g Group
+	err := s.pool.QueryRow(ctx,
+		`SELECT id::text, tenant_id::text, name, COALESCE(syllabus_id, ''), join_code, status,
+		        COALESCE(created_by::text, ''), created_at
+		 FROM groups
+		 WHERE tenant_id = $1::uuid AND id = $2::uuid`,
+		tenantID, groupID,
+	).Scan(&g.ID, &g.TenantID, &g.Name, &g.SyllabusID, &g.JoinCode, &g.Status, &g.CreatedBy, &g.CreatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrGroupNotFound
+		}
+		return nil, fmt.Errorf("get group by id: %w", err)
+	}
+	return &g, nil
+}
+
+// GetByJoinCode returns an active group matching the given join code within tenantID.
+func (s *PostgresStore) GetByJoinCode(ctx context.Context, tenantID, code string) (*Group, error) {
+	ctx, cancel := context.WithTimeout(ctx, dbTimeout)
+	defer cancel()
+
+	code = NormalizeJoinCode(code)
+
+	var g Group
+	err := s.pool.QueryRow(ctx,
+		`SELECT id::text, tenant_id::text, name, COALESCE(syllabus_id, ''), join_code, status,
+		        COALESCE(created_by::text, ''), created_at
+		 FROM groups
+		 WHERE tenant_id = $1::uuid AND join_code = $2 AND status = 'active'`,
+		tenantID, code,
+	).Scan(&g.ID, &g.TenantID, &g.Name, &g.SyllabusID, &g.JoinCode, &g.Status, &g.CreatedBy, &g.CreatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrGroupNotFound
+		}
+		return nil, fmt.Errorf("get group by join code: %w", err)
+	}
+	return &g, nil
+}
+
+// ListByTenant returns all active groups belonging to tenantID, ordered by creation time descending.
+func (s *PostgresStore) ListByTenant(ctx context.Context, tenantID string) ([]Group, error) {
+	ctx, cancel := context.WithTimeout(ctx, dbTimeout)
+	defer cancel()
+
+	rows, err := s.pool.Query(ctx,
+		`SELECT id::text, tenant_id::text, name, COALESCE(syllabus_id, ''), join_code, status,
+		        COALESCE(created_by::text, ''), created_at
+		 FROM groups
+		 WHERE tenant_id = $1::uuid AND status = 'active'
+		 ORDER BY created_at DESC`,
+		tenantID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list groups by tenant: %w", err)
+	}
+	defer rows.Close()
+
+	return scanGroups(rows)
+}
+
+// ListByUser returns all active groups where userID is a member.
+func (s *PostgresStore) ListByUser(ctx context.Context, userID string) ([]Group, error) {
+	ctx, cancel := context.WithTimeout(ctx, dbTimeout)
+	defer cancel()
+
+	rows, err := s.pool.Query(ctx,
+		`SELECT g.id::text, g.tenant_id::text, g.name, COALESCE(g.syllabus_id, ''), g.join_code,
+		        g.status, COALESCE(g.created_by::text, ''), g.created_at
+		 FROM groups g
+		 JOIN group_members gm ON gm.group_id = g.id
+		 WHERE gm.user_id = $1::uuid AND g.status = 'active'
+		 ORDER BY g.created_at DESC`,
+		userID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list groups by user: %w", err)
+	}
+	defer rows.Close()
+
+	return scanGroups(rows)
+}
+
+// Archive sets the group's status to "archived".
+func (s *PostgresStore) Archive(ctx context.Context, tenantID, groupID string) error {
+	ctx, cancel := context.WithTimeout(ctx, dbTimeout)
+	defer cancel()
+
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE groups SET status = 'archived', updated_at = NOW()
+		 WHERE tenant_id = $1::uuid AND id = $2::uuid`,
+		tenantID, groupID,
+	)
+	if err != nil {
+		return fmt.Errorf("archive group: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrGroupNotFound
+	}
+	return nil
+}
+
+// AddMember adds userID to the group with the given membership role.
+// Returns ErrGroupNotFound if the group does not exist, ErrGroupArchived if archived,
+// and ErrAlreadyMember if the user is already in the group.
+func (s *PostgresStore) AddMember(ctx context.Context, groupID, userID, membershipRole string) error {
+	ctx, cancel := context.WithTimeout(ctx, dbTimeout)
+	defer cancel()
+
+	// Verify group exists and is active.
+	var status string
+	err := s.pool.QueryRow(ctx,
+		`SELECT status FROM groups WHERE id = $1::uuid`,
+		groupID,
+	).Scan(&status)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrGroupNotFound
+		}
+		return fmt.Errorf("check group status: %w", err)
+	}
+	if status == "archived" {
+		return ErrGroupArchived
+	}
+
+	_, err = s.pool.Exec(ctx,
+		`INSERT INTO group_members (group_id, user_id, membership_role)
+		 VALUES ($1::uuid, $2::uuid, $3)`,
+		groupID, userID, membershipRole,
+	)
+	if err != nil {
+		if isGroupUniqueViolation(err) {
+			return ErrAlreadyMember
+		}
+		return fmt.Errorf("add member: %w", err)
+	}
+	return nil
+}
+
+// RemoveMember removes userID from the group.
+// Returns ErrNotMember if not present, ErrOwnerCannotLeave if the user is the owner.
+func (s *PostgresStore) RemoveMember(ctx context.Context, groupID, userID string) error {
+	ctx, cancel := context.WithTimeout(ctx, dbTimeout)
+	defer cancel()
+
+	var role string
+	err := s.pool.QueryRow(ctx,
+		`SELECT membership_role FROM group_members WHERE group_id = $1::uuid AND user_id = $2::uuid`,
+		groupID, userID,
+	).Scan(&role)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrNotMember
+		}
+		return fmt.Errorf("check member role: %w", err)
+	}
+	if role == "owner" {
+		return ErrOwnerCannotLeave
+	}
+
+	_, err = s.pool.Exec(ctx,
+		`DELETE FROM group_members WHERE group_id = $1::uuid AND user_id = $2::uuid`,
+		groupID, userID,
+	)
+	if err != nil {
+		return fmt.Errorf("remove member: %w", err)
+	}
+	return nil
+}
+
+// GetMembers returns all members of the given group.
+func (s *PostgresStore) GetMembers(ctx context.Context, groupID string) ([]Member, error) {
+	ctx, cancel := context.WithTimeout(ctx, dbTimeout)
+	defer cancel()
+
+	rows, err := s.pool.Query(ctx,
+		`SELECT user_id::text, membership_role, joined_at
+		 FROM group_members
+		 WHERE group_id = $1::uuid
+		 ORDER BY joined_at ASC`,
+		groupID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get members: %w", err)
+	}
+	defer rows.Close()
+
+	var members []Member
+	for rows.Next() {
+		var m Member
+		if err := rows.Scan(&m.UserID, &m.MembershipRole, &m.JoinedAt); err != nil {
+			return nil, fmt.Errorf("scan member: %w", err)
+		}
+		members = append(members, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate members: %w", err)
+	}
+	return members, nil
+}
+
+// MemberCount returns the number of members in a group.
+func (s *PostgresStore) MemberCount(ctx context.Context, groupID string) (int, error) {
+	ctx, cancel := context.WithTimeout(ctx, dbTimeout)
+	defer cancel()
+
+	var count int
+	err := s.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM group_members WHERE group_id = $1::uuid`,
+		groupID,
+	).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("member count: %w", err)
+	}
+	return count, nil
+}
+
+// IsMember reports whether userID is a member of groupID.
+func (s *PostgresStore) IsMember(ctx context.Context, groupID, userID string) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, dbTimeout)
+	defer cancel()
+
+	var exists bool
+	err := s.pool.QueryRow(ctx,
+		`SELECT EXISTS(
+		   SELECT 1 FROM group_members WHERE group_id = $1::uuid AND user_id = $2::uuid
+		 )`,
+		groupID, userID,
+	).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("is member: %w", err)
+	}
+	return exists, nil
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+func isGroupUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505"
+}
+
+// nilIfEmpty returns nil for an empty string so PostgreSQL receives NULL instead of ''.
+func nilIfEmpty(s string) interface{} {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+func scanGroups(rows pgx.Rows) ([]Group, error) {
+	var groups []Group
+	for rows.Next() {
+		var g Group
+		if err := rows.Scan(&g.ID, &g.TenantID, &g.Name, &g.SyllabusID, &g.JoinCode, &g.Status, &g.CreatedBy, &g.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan group: %w", err)
+		}
+		groups = append(groups, g)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate groups: %w", err)
+	}
+	return groups, nil
+}

--- a/internal/group/store_postgres.go
+++ b/internal/group/store_postgres.go
@@ -203,6 +203,25 @@ func (s *PostgresStore) Archive(ctx context.Context, tenantID, groupID string) e
 	return nil
 }
 
+// Rename updates the name of a group.
+func (s *PostgresStore) Rename(ctx context.Context, tenantID, groupID, newName string) error {
+	ctx, cancel := context.WithTimeout(ctx, dbTimeout)
+	defer cancel()
+
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE groups SET name = $3, updated_at = NOW()
+		 WHERE tenant_id = $1::uuid AND id = $2::uuid`,
+		tenantID, groupID, newName,
+	)
+	if err != nil {
+		return fmt.Errorf("rename group: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrGroupNotFound
+	}
+	return nil
+}
+
 // AddMember adds userID to the group with the given membership role.
 // Returns ErrGroupNotFound if the group does not exist, ErrGroupArchived if archived,
 // and ErrAlreadyMember if the user is already in the group.

--- a/internal/group/store_test.go
+++ b/internal/group/store_test.go
@@ -1,0 +1,362 @@
+package group
+
+import (
+	"context"
+	"testing"
+)
+
+func newMemoryStoreForTest() *MemoryStore {
+	return NewMemoryStore()
+}
+
+func TestMemoryStore_Create(t *testing.T) {
+	ctx := context.Background()
+	s := newMemoryStoreForTest()
+
+	g := Group{
+		TenantID:   "tenant1",
+		Name:       "Algebra Class",
+		SyllabusID: "math-f1",
+		CreatedBy:  "user1",
+	}
+
+	got, err := s.Create(ctx, g)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if got.ID == "" {
+		t.Error("Create() expected non-empty ID")
+	}
+	if got.JoinCode == "" {
+		t.Error("Create() expected non-empty JoinCode")
+	}
+	if got.Status != "active" {
+		t.Errorf("Create() status = %q, want %q", got.Status, "active")
+	}
+	if got.TenantID != "tenant1" {
+		t.Errorf("Create() tenantID = %q, want %q", got.TenantID, "tenant1")
+	}
+	if got.Name != "Algebra Class" {
+		t.Errorf("Create() name = %q, want %q", got.Name, "Algebra Class")
+	}
+	if got.CreatedAt.IsZero() {
+		t.Error("Create() expected non-zero CreatedAt")
+	}
+}
+
+func TestMemoryStore_Create_AddsCreatorAsOwner(t *testing.T) {
+	ctx := context.Background()
+	s := newMemoryStoreForTest()
+
+	g := Group{
+		TenantID:  "tenant1",
+		Name:      "Test Group",
+		CreatedBy: "creator1",
+	}
+
+	got, err := s.Create(ctx, g)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	members, err := s.GetMembers(ctx, got.ID)
+	if err != nil {
+		t.Fatalf("GetMembers() error = %v", err)
+	}
+	if len(members) != 1 {
+		t.Fatalf("expected 1 member after create, got %d", len(members))
+	}
+	if members[0].UserID != "creator1" {
+		t.Errorf("member UserID = %q, want %q", members[0].UserID, "creator1")
+	}
+	if members[0].MembershipRole != "owner" {
+		t.Errorf("member MembershipRole = %q, want %q", members[0].MembershipRole, "owner")
+	}
+}
+
+func TestMemoryStore_GetByID(t *testing.T) {
+	ctx := context.Background()
+	s := newMemoryStoreForTest()
+
+	created, _ := s.Create(ctx, Group{TenantID: "t1", Name: "G1", CreatedBy: "u1"})
+
+	tests := []struct {
+		name     string
+		tenantID string
+		groupID  string
+		wantErr  error
+	}{
+		{"found", "t1", created.ID, nil},
+		{"not found by id", "t1", "nonexistent", ErrGroupNotFound},
+		{"wrong tenant", "t2", created.ID, ErrGroupNotFound},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := s.GetByID(ctx, tt.tenantID, tt.groupID)
+			if err != tt.wantErr {
+				t.Errorf("GetByID() error = %v, want %v", err, tt.wantErr)
+			}
+			if tt.wantErr == nil && got.ID != created.ID {
+				t.Errorf("GetByID() ID = %q, want %q", got.ID, created.ID)
+			}
+		})
+	}
+}
+
+func TestMemoryStore_GetByJoinCode(t *testing.T) {
+	ctx := context.Background()
+	s := newMemoryStoreForTest()
+
+	created, _ := s.Create(ctx, Group{TenantID: "t1", Name: "G1", CreatedBy: "u1"})
+
+	tests := []struct {
+		name     string
+		tenantID string
+		code     string
+		wantErr  error
+	}{
+		{"found", "t1", created.JoinCode, nil},
+		{"not found code", "t1", "XXXXXX", ErrGroupNotFound},
+		{"wrong tenant isolation", "t2", created.JoinCode, ErrGroupNotFound},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := s.GetByJoinCode(ctx, tt.tenantID, tt.code)
+			if err != tt.wantErr {
+				t.Errorf("GetByJoinCode() error = %v, want %v", err, tt.wantErr)
+			}
+			if tt.wantErr == nil && got.JoinCode != created.JoinCode {
+				t.Errorf("GetByJoinCode() JoinCode = %q, want %q", got.JoinCode, created.JoinCode)
+			}
+		})
+	}
+}
+
+func TestMemoryStore_ListByTenant(t *testing.T) {
+	ctx := context.Background()
+	s := newMemoryStoreForTest()
+
+	if _, err := s.Create(ctx, Group{TenantID: "t1", Name: "G1", CreatedBy: "u1"}); err != nil {
+		t.Fatalf("Create G1 error = %v", err)
+	}
+	if _, err := s.Create(ctx, Group{TenantID: "t1", Name: "G2", CreatedBy: "u1"}); err != nil {
+		t.Fatalf("Create G2 error = %v", err)
+	}
+	if _, err := s.Create(ctx, Group{TenantID: "t2", Name: "G3", CreatedBy: "u2"}); err != nil {
+		t.Fatalf("Create G3 error = %v", err)
+	}
+
+	list, err := s.ListByTenant(ctx, "t1")
+	if err != nil {
+		t.Fatalf("ListByTenant() error = %v", err)
+	}
+	if len(list) != 2 {
+		t.Errorf("ListByTenant() len = %d, want 2", len(list))
+	}
+
+	list2, _ := s.ListByTenant(ctx, "t2")
+	if len(list2) != 1 {
+		t.Errorf("ListByTenant(t2) len = %d, want 1", len(list2))
+	}
+
+	list3, _ := s.ListByTenant(ctx, "t9")
+	if len(list3) != 0 {
+		t.Errorf("ListByTenant(unknown) len = %d, want 0", len(list3))
+	}
+}
+
+func TestMemoryStore_ListByUser(t *testing.T) {
+	ctx := context.Background()
+	s := newMemoryStoreForTest()
+
+	g1, _ := s.Create(ctx, Group{TenantID: "t1", Name: "G1", CreatedBy: "alice"})
+	g2, _ := s.Create(ctx, Group{TenantID: "t1", Name: "G2", CreatedBy: "bob"})
+	// Add alice to g2 as a regular member
+	if err := s.AddMember(ctx, g2.ID, "alice", "member"); err != nil {
+		t.Fatalf("AddMember alice error = %v", err)
+	}
+	// bob is owner of g2 only; alice is owner of g1 and member of g2
+
+	list, err := s.ListByUser(ctx, "alice")
+	if err != nil {
+		t.Fatalf("ListByUser() error = %v", err)
+	}
+	if len(list) != 2 {
+		t.Errorf("ListByUser(alice) len = %d, want 2", len(list))
+	}
+
+	listBob, _ := s.ListByUser(ctx, "bob")
+	if len(listBob) != 1 {
+		t.Errorf("ListByUser(bob) len = %d, want 1", len(listBob))
+	}
+
+	_ = g1
+}
+
+func TestMemoryStore_Archive(t *testing.T) {
+	ctx := context.Background()
+	s := newMemoryStoreForTest()
+
+	g, _ := s.Create(ctx, Group{TenantID: "t1", Name: "G1", CreatedBy: "u1"})
+
+	err := s.Archive(ctx, "t1", g.ID)
+	if err != nil {
+		t.Fatalf("Archive() error = %v", err)
+	}
+
+	got, _ := s.GetByID(ctx, "t1", g.ID)
+	if got.Status != "archived" {
+		t.Errorf("after Archive() status = %q, want %q", got.Status, "archived")
+	}
+
+	// Archive wrong tenant should fail
+	g2, _ := s.Create(ctx, Group{TenantID: "t1", Name: "G2", CreatedBy: "u1"})
+	err = s.Archive(ctx, "t2", g2.ID)
+	if err != ErrGroupNotFound {
+		t.Errorf("Archive wrong tenant error = %v, want %v", err, ErrGroupNotFound)
+	}
+}
+
+func TestMemoryStore_AddMember(t *testing.T) {
+	ctx := context.Background()
+	s := newMemoryStoreForTest()
+
+	g, _ := s.Create(ctx, Group{TenantID: "t1", Name: "G1", CreatedBy: "owner1"})
+
+	// Add a new member
+	err := s.AddMember(ctx, g.ID, "user2", "member")
+	if err != nil {
+		t.Fatalf("AddMember() error = %v", err)
+	}
+
+	count, _ := s.MemberCount(ctx, g.ID)
+	if count != 2 {
+		t.Errorf("MemberCount after add = %d, want 2", count)
+	}
+
+	// Duplicate member
+	err = s.AddMember(ctx, g.ID, "user2", "member")
+	if err != ErrAlreadyMember {
+		t.Errorf("duplicate AddMember error = %v, want %v", err, ErrAlreadyMember)
+	}
+
+	// Add to archived group
+	if err := s.Archive(ctx, "t1", g.ID); err != nil {
+		t.Fatalf("Archive error = %v", err)
+	}
+	err = s.AddMember(ctx, g.ID, "user3", "member")
+	if err != ErrGroupArchived {
+		t.Errorf("AddMember on archived error = %v, want %v", err, ErrGroupArchived)
+	}
+}
+
+func TestMemoryStore_RemoveMember(t *testing.T) {
+	ctx := context.Background()
+	s := newMemoryStoreForTest()
+
+	g, _ := s.Create(ctx, Group{TenantID: "t1", Name: "G1", CreatedBy: "owner1"})
+	if err := s.AddMember(ctx, g.ID, "user2", "member"); err != nil {
+		t.Fatalf("AddMember user2 error = %v", err)
+	}
+
+	// Remove regular member
+	err := s.RemoveMember(ctx, g.ID, "user2")
+	if err != nil {
+		t.Fatalf("RemoveMember() error = %v", err)
+	}
+
+	isMember, _ := s.IsMember(ctx, g.ID, "user2")
+	if isMember {
+		t.Error("user2 should not be a member after remove")
+	}
+
+	// Not a member
+	err = s.RemoveMember(ctx, g.ID, "nonexistent")
+	if err != ErrNotMember {
+		t.Errorf("RemoveMember non-member error = %v, want %v", err, ErrNotMember)
+	}
+
+	// Owner cannot leave
+	err = s.RemoveMember(ctx, g.ID, "owner1")
+	if err != ErrOwnerCannotLeave {
+		t.Errorf("RemoveMember owner error = %v, want %v", err, ErrOwnerCannotLeave)
+	}
+}
+
+func TestMemoryStore_GetMembers(t *testing.T) {
+	ctx := context.Background()
+	s := newMemoryStoreForTest()
+
+	g, _ := s.Create(ctx, Group{TenantID: "t1", Name: "G1", CreatedBy: "owner1"})
+	if err := s.AddMember(ctx, g.ID, "user2", "member"); err != nil {
+		t.Fatalf("AddMember user2 error = %v", err)
+	}
+	if err := s.AddMember(ctx, g.ID, "user3", "member"); err != nil {
+		t.Fatalf("AddMember user3 error = %v", err)
+	}
+
+	members, err := s.GetMembers(ctx, g.ID)
+	if err != nil {
+		t.Fatalf("GetMembers() error = %v", err)
+	}
+	if len(members) != 3 {
+		t.Errorf("GetMembers() len = %d, want 3", len(members))
+	}
+}
+
+func TestMemoryStore_MemberCount(t *testing.T) {
+	ctx := context.Background()
+	s := newMemoryStoreForTest()
+
+	g, _ := s.Create(ctx, Group{TenantID: "t1", Name: "G1", CreatedBy: "owner1"})
+
+	count, err := s.MemberCount(ctx, g.ID)
+	if err != nil {
+		t.Fatalf("MemberCount() error = %v", err)
+	}
+	if count != 1 {
+		t.Errorf("MemberCount() = %d, want 1", count)
+	}
+
+	if err := s.AddMember(ctx, g.ID, "user2", "member"); err != nil {
+		t.Fatalf("AddMember user2 error = %v", err)
+	}
+	count, _ = s.MemberCount(ctx, g.ID)
+	if count != 2 {
+		t.Errorf("MemberCount after add = %d, want 2", count)
+	}
+}
+
+func TestMemoryStore_IsMember(t *testing.T) {
+	ctx := context.Background()
+	s := newMemoryStoreForTest()
+
+	g, _ := s.Create(ctx, Group{TenantID: "t1", Name: "G1", CreatedBy: "owner1"})
+	if err := s.AddMember(ctx, g.ID, "user2", "member"); err != nil {
+		t.Fatalf("AddMember user2 error = %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		userID string
+		want   bool
+	}{
+		{"owner is member", "owner1", true},
+		{"added member is member", "user2", true},
+		{"non-member is not", "user3", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := s.IsMember(ctx, g.ID, tt.userID)
+			if err != nil {
+				t.Fatalf("IsMember() error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("IsMember(%q) = %v, want %v", tt.userID, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/i18n/messages.go
+++ b/internal/i18n/messages.go
@@ -36,6 +36,19 @@ const (
 	MsgMilestoneXP            Key = "milestone_xp"
 	MsgMilestoneSubjectDone   Key = "milestone_subject_done"
 	MsgMilestoneStreakRecord   Key = "milestone_streak_record"
+
+	MsgGroupCreated          Key = "group_created"
+	MsgGroupJoined           Key = "group_joined"
+	MsgGroupLeft             Key = "group_left"
+	MsgGroupList             Key = "group_list"
+	MsgGroupListEmpty        Key = "group_list_empty"
+	MsgGroupNotFound         Key = "group_not_found"
+	MsgGroupAlreadyMember    Key = "group_already_member"
+	MsgGroupOwnerCannotLeave Key = "group_owner_cannot_leave"
+	MsgGroupArchived         Key = "group_archived"
+	MsgGroupCreateDenied     Key = "group_create_denied"
+	MsgGroupSyllabusMismatch Key = "group_syllabus_mismatch"
+	MsgGroupUsage            Key = "group_usage"
 )
 
 var catalog = map[string]map[Key]string{
@@ -89,6 +102,18 @@ Tingkatan berapa anda sekarang?`,
 		MsgMilestoneXP:            "🌟 *Pencapaian XP!*\n\nAnda telah mencapai *%d XP*!\n\nKerja keras anda membuahkan hasil! 🎉",
 		MsgMilestoneSubjectDone:   "🎓 *LUAR BIASA!*\n\nAnda telah menguasai semua topik dalam *%s*!\n\nAnda seorang juara matematik! 🏅",
 		MsgMilestoneStreakRecord:   "🔥 *Rekod Baru!*\n\nStreak terpanjang anda: *%d hari*!\n\nDedikasi yang mengagumkan! 🏅",
+		MsgGroupCreated:          "Kumpulan berjaya dicipta!\n\nNama: %s\nKod: *%s*\n\nKongsi kod ini dengan pelajar anda.",
+		MsgGroupJoined:           "Berjaya menyertai *%s*! Anda kini mempunyai %d rakan sekelas.",
+		MsgGroupLeft:             "Anda telah keluar dari *%s*.",
+		MsgGroupList:             "Kumpulan anda:\n%s",
+		MsgGroupListEmpty:        "Anda belum menyertai sebarang kumpulan. Guna /join <kod> untuk menyertai.",
+		MsgGroupNotFound:         "Kod kumpulan tidak dijumpai. Sila semak dan cuba lagi.",
+		MsgGroupAlreadyMember:    "Anda sudah menjadi ahli kumpulan ini.",
+		MsgGroupOwnerCannotLeave: "Pemilik tidak boleh keluar dari kumpulan. Arkibkan kumpulan ini dahulu.",
+		MsgGroupArchived:         "Kumpulan ini telah diarkibkan.",
+		MsgGroupCreateDenied:     "Hanya guru dan pentadbir boleh mencipta kumpulan.",
+		MsgGroupSyllabusMismatch: "Kumpulan ini untuk pelajar %s. Profil anda ditetapkan kepada %s.",
+		MsgGroupUsage:            "Guna:\n/group create <nama> — Cipta kumpulan\n/group join <kod> atau /join <kod> — Sertai kumpulan\n/group leave — Keluar dari kumpulan\n/group list — Senarai kumpulan anda",
 	},
 	"en": {
 		MsgTechnicalIssue:        "Sorry, I'm facing a technical issue right now. Please try again shortly.",
@@ -140,6 +165,18 @@ Which form are you in now?`,
 		MsgMilestoneXP:            "🌟 *XP Milestone!*\n\nYou've reached *%d XP*!\n\nYour hard work is paying off! 🎉",
 		MsgMilestoneSubjectDone:   "🎓 *AMAZING!*\n\nYou've mastered all topics in *%s*!\n\nYou're a math champion! 🏅",
 		MsgMilestoneStreakRecord:   "🔥 *New Record!*\n\nYour longest streak: *%d days*!\n\nIncredible dedication! 🏅",
+		MsgGroupCreated:          "Group created!\n\nName: %s\nCode: *%s*\n\nShare this code with your students.",
+		MsgGroupJoined:           "Joined *%s*! You now have %d classmates.",
+		MsgGroupLeft:             "You've left *%s*.",
+		MsgGroupList:             "Your groups:\n%s",
+		MsgGroupListEmpty:        "You haven't joined any groups yet. Use /join <code> to join one.",
+		MsgGroupNotFound:         "Group code not found. Please check and try again.",
+		MsgGroupAlreadyMember:    "You're already a member of this group.",
+		MsgGroupOwnerCannotLeave: "Owner cannot leave the group. Archive it instead.",
+		MsgGroupArchived:         "This group has been archived.",
+		MsgGroupCreateDenied:     "Only teachers and admins can create groups.",
+		MsgGroupSyllabusMismatch: "This group is for %s students. Your profile is set to %s.",
+		MsgGroupUsage:            "Usage:\n/group create <name> — Create a group\n/group join <code> or /join <code> — Join a group\n/group leave — Leave a group\n/group list — List your groups",
 	},
 	"zh": {
 		MsgTechnicalIssue:        "抱歉，我目前遇到技术问题。请稍后再试。",
@@ -191,6 +228,18 @@ Which form are you in now?`,
 		MsgMilestoneXP:            "🌟 *XP 里程碑！*\n\n你已达到 *%d XP*！\n\n你的努力正在得到回报！🎉",
 		MsgMilestoneSubjectDone:   "🎓 *太厉害了！*\n\n你已掌握 *%s* 的所有主题！\n\n你是数学冠军！🏅",
 		MsgMilestoneStreakRecord:   "🔥 *新纪录！*\n\n你最长的连续学习记录：*%d 天*！\n\n令人敬佩的毅力！🏅",
+		MsgGroupCreated:          "群组创建成功！\n\n名称：%s\n代码：*%s*\n\n将此代码分享给你的学生。",
+		MsgGroupJoined:           "已加入 *%s*！你现在有 %d 位同学。",
+		MsgGroupLeft:             "你已退出 *%s*。",
+		MsgGroupList:             "你的群组：\n%s",
+		MsgGroupListEmpty:        "你还没有加入任何群组。使用 /join <代码> 加入。",
+		MsgGroupNotFound:         "找不到群组代码。请检查后重试。",
+		MsgGroupAlreadyMember:    "你已经是这个群组的成员了。",
+		MsgGroupOwnerCannotLeave: "群主不能退出群组。请先归档群组。",
+		MsgGroupArchived:         "这个群组已被归档。",
+		MsgGroupCreateDenied:     "只有老师和管理员可以创建群组。",
+		MsgGroupSyllabusMismatch: "这个群组是为 %s 的学生设立的。你的资料设置为 %s。",
+		MsgGroupUsage:            "用法：\n/group create <名称> — 创建群组\n/group join <代码> 或 /join <代码> — 加入群组\n/group leave — 退出群组\n/group list — 列出你的群组",
 	},
 }
 

--- a/migrations/20260331100000_groups.sql
+++ b/migrations/20260331100000_groups.sql
@@ -1,0 +1,30 @@
+-- +goose Up
+CREATE TABLE groups (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id   UUID NOT NULL REFERENCES tenants(id),
+    name        TEXT NOT NULL,
+    syllabus_id TEXT,
+    join_code   TEXT NOT NULL UNIQUE,
+    status      TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'archived')),
+    created_by  UUID REFERENCES users(id) ON DELETE SET NULL,
+    created_at  TIMESTAMPTZ DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_groups_tenant_status ON groups(tenant_id, status);
+CREATE INDEX idx_groups_join_code ON groups(join_code);
+
+CREATE TABLE group_members (
+    group_id        UUID NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+    user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    membership_role TEXT NOT NULL DEFAULT 'member'
+                    CHECK (membership_role IN ('owner', 'admin', 'member')),
+    joined_at       TIMESTAMPTZ DEFAULT NOW(),
+    PRIMARY KEY (group_id, user_id)
+);
+
+CREATE INDEX idx_group_members_user ON group_members(user_id);
+
+-- +goose Down
+DROP TABLE IF EXISTS group_members;
+DROP TABLE IF EXISTS groups;


### PR DESCRIPTION
## Summary

Full groups feature — teachers create groups (displayed as "classes" in admin), students join via code.

- **New `internal/group` package** with `Store` interface, Memory + Postgres implementations
- **Migration**: `groups` + `group_members` tables with tenant isolation, membership roles (owner/admin/member), archive support
- **Bot commands**: `/group create|join|leave|list` + `/join` alias
- **Admin API**: `GET/POST /api/admin/classes`, `GET/PATCH /api/admin/classes/{id}`
- **Tenant isolation**: Join code lookup always scoped by tenant_id
- **Syllabus validation**: User form vs group syllabus checked on join
- **Role gating**: Only teachers/admins can create groups
- **ConversationStore extensions**: `GetUserTenantID`, `GetUserRole`, `GetUserInternalID`
- **i18n**: All group messages in ms/en/zh

## Test plan

- [x] `make test-all` passes (lint + all unit tests)
- [x] Join code generator: 6-char, unambiguous charset, unique
- [x] MemoryStore: 17 tests covering all Store methods
- [x] Tenant isolation: cross-tenant join code lookup returns not found
- [x] Bot commands: create (teacher/student/admin), join (success/invalid/already member), leave (success/owner denied), list, /join alias
- [x] Admin API: list, create, get detail, update (rename/archive), not-found
- [x] Syllabus mismatch validation