### PR TITLE
fix: preserve curriculum assessment working steps

### DIFF
--- a/internal/curriculum/loader.go
+++ b/internal/curriculum/loader.go
@@ -230,6 +230,16 @@ func (l *Loader) loadAssessment(path string) error {
 		return nil
 	}
 
+	for i := range assessment.Questions {
+		question := &assessment.Questions[i]
+		if question.Answer.Working == "" && question.Working != "" {
+			question.Answer.Working = question.Working
+		}
+		if question.Working == "" && question.Answer.Working != "" {
+			question.Working = question.Answer.Working
+		}
+	}
+
 	l.mu.Lock()
 	l.assessments[assessment.TopicID] = assessment
 	l.mu.Unlock()

--- a/internal/curriculum/loader_test.go
+++ b/internal/curriculum/loader_test.go
@@ -91,6 +91,47 @@ func TestLoader_GetAssessment(t *testing.T) {
 	if assessment.Questions[0].Answer.Type != "exact" {
 		t.Fatalf("assessment.Questions[0].Answer.Type = %q, want exact", assessment.Questions[0].Answer.Type)
 	}
+	if assessment.Questions[0].Answer.Working == "" {
+		t.Fatal("assessment.Questions[0].Answer.Working is empty")
+	}
+}
+
+func TestLoader_GetAssessment_QuestionLevelWorkingFallback(t *testing.T) {
+	dir := t.TempDir()
+
+	topicsDir := filepath.Join(dir, "curricula", "malaysia", "kssm", "topics", "algebra")
+	_ = os.MkdirAll(topicsDir, 0o755)
+
+	_ = os.WriteFile(filepath.Join(topicsDir, "01-variables.assessments.yaml"), []byte(`
+topic_id: F1-01
+provenance: human
+questions:
+  - id: Q1
+    text: "Evaluate 3x when x=2."
+    difficulty: easy
+    learning_objective: LO1
+    working: "Substitute x=2, then multiply."
+    answer:
+      type: exact
+      value: "6"
+    marks: 1
+`), 0o644)
+
+	loader, err := curriculum.NewLoader(dir)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+
+	assessment, found := loader.GetAssessment("F1-01")
+	if !found {
+		t.Fatal("GetAssessment(F1-01) not found")
+	}
+	if got := assessment.Questions[0].Answer.Working; got != "Substitute x=2, then multiply." {
+		t.Fatalf("assessment.Questions[0].Answer.Working = %q", got)
+	}
+	if got := assessment.Questions[0].Working; got != "Substitute x=2, then multiply." {
+		t.Fatalf("assessment.Questions[0].Working = %q", got)
+	}
 }
 
 func TestLoader_LoadsSubjectMetadata(t *testing.T) {

--- a/internal/curriculum/types.go
+++ b/internal/curriculum/types.go
@@ -64,6 +64,7 @@ type AssessmentQuestion struct {
 	Text              string                 `yaml:"text"`
 	Difficulty        string                 `yaml:"difficulty"`
 	LearningObjective string                 `yaml:"learning_objective"`
+	Working           string                 `yaml:"working"`
 	Answer            AssessmentAnswer       `yaml:"answer"`
 	Marks             int                    `yaml:"marks"`
 	Rubric            []AssessmentRubricItem `yaml:"rubric"`


### PR DESCRIPTION
## Summary
- preserve question-level `working` text when loading curriculum assessments
- backfill `answer.working` from legacy/current OSS assessment shape
- add regression coverage so retrieval and quiz flows keep worked solutions

## Context
- during the curriculum validity pass, assessment YAML was found to store `questions[].working` while the runtime only consumed `answer.working`
- this caused worked-solution text to be silently dropped at runtime

## Follow-up
- broader OSS validator/schema drift exists separately and will need its own pass