### PR TITLE
feat: security hardening + single-tenant bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,24 @@ Configuration is environment-driven. Core app variables use `LEARN_`; auth varia
 
 *At least one AI provider must be configured.
 
+### First-Boot Tenant Flow
+
+The first setup behavior depends on `LEARN_TENANT_MODE`:
+
+- `single` mode:
+  - On server startup, P&AI ensures tenant slug `default` exists.
+  - If it is missing (for example, on a fresh DB), startup will auto-create/upsert it.
+  - Tenant-bound runtime services use this single tenant context.
+- `multi` mode:
+  - Startup does not auto-create tenants.
+  - Tenant lifecycle is managed explicitly (seed/admin/invite workflows).
+
+Recommended first setup sequence:
+
+1. Run migrations.
+2. Set `LEARN_TENANT_MODE` in `.env`.
+3. Start the server.
+
 ---
 
 ## Development

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -294,6 +294,7 @@ type adminDataSource interface {
 	GetAIUsage() (adminapi.AIUsageSummary, error)
 	UpsertTenantTokenBudgetWindow(req adminapi.UpsertTokenBudgetWindowRequest) (adminapi.AIUsageSummary, error)
 	GetMetrics() (adminapi.MetricsSummary, error)
+	GetAnalyticsReport() (adminapi.AnalyticsReport, error)
 	GetUserManagement() (adminapi.UserManagementView, error)
 	ExportStudents() ([]adminapi.StudentExportRow, error)
 	ExportConversations() ([]adminapi.ConversationExportRecord, error)
@@ -534,6 +535,7 @@ func newHandlerWithAdminProvider(adminProvider adminDataSourceProvider, sender m
 	mux.Handle("POST /api/admin/students/{id}/nudge", teacherOrAbove(handleAdminStudentNudge(adminProvider, sender)))
 	mux.Handle("GET /api/admin/metrics", teacherOrAbove(handleAdminMetrics(adminProvider)))
 	mux.Handle("GET /api/admin/ai/usage", teacherOrAbove(handleAdminAIUsage(adminProvider)))
+	mux.Handle("GET /api/admin/analytics/report", adminOrAbove(handleAdminAnalyticsReport(adminProvider)))
 	mux.Handle("POST /api/admin/ai/budget-window", adminOnly(handleAdminUpsertTokenBudgetWindow(adminProvider)))
 	mux.Handle("GET /api/admin/export/students", adminOrAbove(handleAdminExportStudents(adminProvider)))
 	mux.Handle("GET /api/admin/export/conversations", adminOrAbove(handleAdminExportConversations(adminProvider)))
@@ -818,6 +820,22 @@ func handleAdminMetrics(adminProvider adminDataSourceProvider) http.HandlerFunc 
 		}
 
 		payload, err := admin.GetMetrics()
+		if err != nil {
+			writeAdminError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, payload)
+	}
+}
+
+func handleAdminAnalyticsReport(adminProvider adminDataSourceProvider) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		admin, ok := resolveAdminDataSource(w, r, adminProvider)
+		if !ok {
+			return
+		}
+
+		payload, err := admin.GetAnalyticsReport()
 		if err != nil {
 			writeAdminError(w, err)
 			return

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -543,7 +543,9 @@ func newHandlerWithAdminProvider(adminProvider adminDataSourceProvider, sender m
 	mux.Handle("GET /api/admin/groups/{id}/leaderboard", teacherOrAbove(handleAdminGroupLeaderboard(adminProvider)))
 	registerRetrievalRoutes(mux, retrievalService, teacherOrAbove, adminOrAbove)
 
-	return withCORS(mux)
+	apiLimiter := newFixedWindowLimiter(defaultAPIRateLimitPerMinute, time.Minute)
+	authLimiter := newFixedWindowLimiter(defaultAuthRateLimitPerMinute, time.Minute)
+	return withSecurityHeaders(withCORS(withAPIRateLimit(mux, time.Now, apiLimiter, authLimiter)))
 }
 
 func authenticateRequests(authSvc authService, manager *auth.TokenManager, now func() time.Time) func(http.Handler) http.Handler {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/p-n-ai/pai-bot/internal/platform/mailer"
 	"github.com/p-n-ai/pai-bot/internal/progress"
 	"github.com/p-n-ai/pai-bot/internal/retrieval"
+	"github.com/p-n-ai/pai-bot/internal/tenant"
 )
 
 func main() {
@@ -65,6 +66,12 @@ func main() {
 		os.Exit(1)
 	}
 	defer db.Close()
+
+	// In single-tenant mode, ensure the default tenant exists for runtime dependencies.
+	if _, err := tenant.EnsureDefaultTenantForPool(context.Background(), cfg.Tenant.Mode, db.Pool); err != nil {
+		slog.Error("failed to bootstrap tenant mode", "mode", cfg.Tenant.Mode, "error", err)
+		os.Exit(1)
+	}
 
 	// Initialize cache (warn if unavailable, don't fail).
 	if cfg.Cache.URL != "" {

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -484,6 +484,54 @@ func TestAdminMetricsEndpoint(t *testing.T) {
 	}
 }
 
+func TestAdminAnalyticsReportEndpoint(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/analytics/report", nil)
+	req.Header.Set("Authorization", "Bearer "+mustIssueAdminToken(t))
+	rec := httptest.NewRecorder()
+
+	newHandler(stubAdminAPI{}, &chatGatewayStub{}).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var payload struct {
+		WindowDays int `json:"window_days"`
+		Overview   struct {
+			TotalActiveLearners int     `json:"total_active_learners"`
+			AverageDAU          float64 `json:"average_dau"`
+			LatestDAU           int     `json:"latest_dau"`
+		} `json:"overview"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if payload.WindowDays != 42 {
+		t.Fatalf("window_days = %d, want 42", payload.WindowDays)
+	}
+	if payload.Overview.TotalActiveLearners != 41 {
+		t.Fatalf("total_active_learners = %d, want 41", payload.Overview.TotalActiveLearners)
+	}
+	if payload.Overview.LatestDAU != 22 {
+		t.Fatalf("latest_dau = %d, want 22", payload.Overview.LatestDAU)
+	}
+	if payload.Overview.AverageDAU <= 0 {
+		t.Fatalf("average_dau = %v, want positive value", payload.Overview.AverageDAU)
+	}
+}
+
+func TestAdminAnalyticsReportEndpointRejectsTeacherRole(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/analytics/report", nil)
+	req.Header.Set("Authorization", "Bearer "+mustIssueTeacherToken(t))
+	rec := httptest.NewRecorder()
+
+	newHandler(stubAdminAPI{}, &chatGatewayStub{}).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+}
+
 func TestAdminTokenBudgetWindowEndpoint(t *testing.T) {
 	admin := &budgetAdminStub{}
 	req := httptest.NewRequest(http.MethodPost, "/api/admin/ai/budget-window", strings.NewReader(`{"budget_tokens":250000,"period_start":"2026-04-01","period_end":"2026-04-30"}`))
@@ -1490,6 +1538,44 @@ func (stubAdminAPI) GetMetrics() (adminapi.MetricsSummary, error) {
 				{Provider: "anthropic", Model: "claude-3-5-haiku", Messages: 2, InputTokens: 58, OutputTokens: 61, TotalTokens: 119},
 			},
 		},
+	}, nil
+}
+
+func (stubAdminAPI) GetAnalyticsReport() (adminapi.AnalyticsReport, error) {
+	return adminapi.AnalyticsReport{
+		WindowDays: 42,
+		GeneratedAt: time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC),
+		Overview: adminapi.AnalyticsOverview{
+			TotalActiveLearners: 41,
+			AverageDAU:          20.5,
+			LatestDAU:           22,
+			Day1RetentionRate:   0.79,
+			Day7RetentionRate:   0.52,
+			Day14RetentionRate:  0.41,
+			NudgeResponseRate:   0.36,
+			TotalAIMessages:     1820,
+			TotalAITokens:       219400,
+		},
+		DailyActiveUsers: []adminapi.DailyActiveUsersPoint{
+			{Date: "2026-04-08", Users: 19},
+			{Date: "2026-04-09", Users: 21},
+			{Date: "2026-04-10", Users: 22},
+		},
+		Retention: []adminapi.RetentionPoint{
+			{CohortDate: "2026-03-01", CohortSize: 20, Day1Rate: 0.8, Day7Rate: 0.5, Day14Rate: 0.4},
+			{CohortDate: "2026-03-08", CohortSize: 21, Day1Rate: 0.78, Day7Rate: 0.54, Day14Rate: 0.42},
+		},
+		NudgeRate: adminapi.NudgeRateSummary{
+			NudgesSent:             50,
+			ResponsesWithin24Hours: 18,
+			ResponseRate:           0.36,
+		},
+		AIUsage: adminapi.AIUsageSummary{
+			TotalMessages:     1820,
+			TotalInputTokens:  128000,
+			TotalOutputTokens: 91400,
+		},
+		ABComparison: nil,
 	}, nil
 }
 

--- a/cmd/server/security.go
+++ b/cmd/server/security.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"math"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/p-n-ai/pai-bot/internal/auth"
+)
+
+const (
+	defaultAPIRateLimitPerMinute  = 240
+	defaultAuthRateLimitPerMinute = 20
+)
+
+type fixedWindowLimiter struct {
+	limit  int
+	window time.Duration
+
+	mu      sync.Mutex
+	buckets map[string]fixedWindowState
+}
+
+type fixedWindowState struct {
+	windowStart time.Time
+	count       int
+}
+
+func newFixedWindowLimiter(limit int, window time.Duration) *fixedWindowLimiter {
+	return &fixedWindowLimiter{
+		limit:   limit,
+		window:  window,
+		buckets: make(map[string]fixedWindowState),
+	}
+}
+
+func (l *fixedWindowLimiter) Allow(key string, now time.Time) (bool, time.Duration) {
+	if l == nil || l.limit <= 0 || l.window <= 0 {
+		return true, 0
+	}
+	if strings.TrimSpace(key) == "" {
+		key = "anonymous"
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	state, ok := l.buckets[key]
+	if !ok || now.Sub(state.windowStart) >= l.window {
+		l.buckets[key] = fixedWindowState{windowStart: now, count: 1}
+		return true, 0
+	}
+
+	if state.count < l.limit {
+		state.count++
+		l.buckets[key] = state
+		return true, 0
+	}
+
+	retryAfter := l.window - now.Sub(state.windowStart)
+	if retryAfter < 0 {
+		retryAfter = 0
+	}
+	return false, retryAfter
+}
+
+func withAPIRateLimit(next http.Handler, now func() time.Time, apiLimiter, authLimiter *fixedWindowLimiter) http.Handler {
+	if now == nil {
+		now = time.Now
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/api/") || r.Method == http.MethodOptions {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		limiter := apiLimiter
+		keyPrefix := "api"
+		if strings.HasPrefix(r.URL.Path, "/api/auth/") {
+			limiter = authLimiter
+			keyPrefix = "auth"
+		}
+
+		key := keyPrefix + ":" + rateLimitClientKey(r)
+		allowed, retryAfter := limiter.Allow(key, now().UTC())
+		if !allowed {
+			seconds := int(math.Ceil(retryAfter.Seconds()))
+			if seconds < 1 {
+				seconds = 1
+			}
+			w.Header().Set("Retry-After", strconv.Itoa(seconds))
+			http.Error(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func withSecurityHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("X-Frame-Options", "DENY")
+		w.Header().Set("Referrer-Policy", "no-referrer")
+		w.Header().Set("Cross-Origin-Resource-Policy", "same-site")
+		next.ServeHTTP(w, r)
+	})
+}
+
+func rateLimitClientKey(r *http.Request) string {
+	sessionToken := readCookieValue(r, auth.SessionCookieName)
+	if sessionToken != "" {
+		return "session:" + shortTokenHash(sessionToken)
+	}
+	if token, err := bearerToken(r.Header.Get("Authorization")); err == nil {
+		return "bearer:" + shortTokenHash(token)
+	}
+
+	ip := strings.TrimSpace(firstForwardedFor(r.Header.Get("X-Forwarded-For")))
+	if ip == "" {
+		ip = strings.TrimSpace(r.Header.Get("X-Real-IP"))
+	}
+	if ip == "" {
+		host, _, err := net.SplitHostPort(strings.TrimSpace(r.RemoteAddr))
+		if err == nil {
+			ip = host
+		}
+	}
+	if ip == "" {
+		ip = "unknown"
+	}
+
+	return "ip:" + ip
+}
+
+func firstForwardedFor(v string) string {
+	if strings.TrimSpace(v) == "" {
+		return ""
+	}
+	parts := strings.Split(v, ",")
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(parts[0])
+}
+
+func shortTokenHash(v string) string {
+	sum := sha256.Sum256([]byte(v))
+	return hex.EncodeToString(sum[:6])
+}

--- a/cmd/server/security_test.go
+++ b/cmd/server/security_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestFixedWindowLimiter(t *testing.T) {
+	limiter := newFixedWindowLimiter(2, time.Minute)
+	now := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+
+	allowed, retryAfter := limiter.Allow("ip:127.0.0.1", now)
+	if !allowed || retryAfter != 0 {
+		t.Fatalf("first request = (%v, %v), want (true, 0)", allowed, retryAfter)
+	}
+
+	allowed, retryAfter = limiter.Allow("ip:127.0.0.1", now.Add(10*time.Second))
+	if !allowed || retryAfter != 0 {
+		t.Fatalf("second request = (%v, %v), want (true, 0)", allowed, retryAfter)
+	}
+
+	allowed, retryAfter = limiter.Allow("ip:127.0.0.1", now.Add(20*time.Second))
+	if allowed {
+		t.Fatal("third request should be denied in same window")
+	}
+	if retryAfter <= 0 {
+		t.Fatalf("retryAfter = %v, want > 0", retryAfter)
+	}
+
+	allowed, retryAfter = limiter.Allow("ip:127.0.0.1", now.Add(61*time.Second))
+	if !allowed || retryAfter != 0 {
+		t.Fatalf("request after new window = (%v, %v), want (true, 0)", allowed, retryAfter)
+	}
+}
+
+func TestWithAPIRateLimit_AuthEndpointReturns429(t *testing.T) {
+	apiLimiter := newFixedWindowLimiter(100, time.Minute)
+	authLimiter := newFixedWindowLimiter(2, time.Minute)
+	now := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+	nowFn := func() time.Time { return now }
+
+	handler := withAPIRateLimit(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}), nowFn, apiLimiter, authLimiter)
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/api/auth/login", nil)
+		req.RemoteAddr = "203.0.113.10:43123"
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("request %d status = %d, want 200", i+1, rec.Code)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", nil)
+	req.RemoteAddr = "203.0.113.10:43123"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusTooManyRequests)
+	}
+	if rec.Header().Get("Retry-After") == "" {
+		t.Fatal("expected Retry-After header")
+	}
+}
+
+func TestWithSecurityHeaders(t *testing.T) {
+	handler := withSecurityHeaders(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Fatalf("X-Content-Type-Options = %q, want nosniff", got)
+	}
+	if got := rec.Header().Get("X-Frame-Options"); got != "DENY" {
+		t.Fatalf("X-Frame-Options = %q, want DENY", got)
+	}
+	if got := rec.Header().Get("Referrer-Policy"); got != "no-referrer" {
+		t.Fatalf("Referrer-Policy = %q, want no-referrer", got)
+	}
+}

--- a/docs/development-timeline.md
+++ b/docs/development-timeline.md
@@ -420,7 +420,7 @@ When adding a new item here, use an `A-WxDy-...` ID and do not backfill it into 
 
 | Task ID | Task | Owner | Status | Remark |
 |---------|------|-------|--------|--------|
-| `P-W5D23-1` | Multi-tenancy: LEARN_TENANT_MODE single/multi, auto-create default tenant in single mode | 🤖 | ⬜ | |
+| `P-W5D23-1` | Multi-tenancy: LEARN_TENANT_MODE single/multi, auto-create default tenant in single mode | 🤖 | ✅ | Added startup bootstrap that enforces mode behavior: single mode upserts `default` tenant when missing; multi mode performs no tenant mutation. |
 | `P-W5D23-2` | Helm chart: Deployment, StatefulSet (PG, Dragonfly), ConfigMap, Secret, Service, Ingress | 🤖 | ⬜ | |
 | `P-W5D23-3` | 🧑 Fresh machine test: new AWS instance, follow README only, deploy from scratch, fix every issue | 🧑 Human | ⬜ | |
 

--- a/docs/development-timeline.md
+++ b/docs/development-timeline.md
@@ -430,7 +430,7 @@ When adding a new item here, use an `A-WxDy-...` ID and do not backfill it into 
 |---------|------|-------|--------|--------|
 | `P-W5D24-1` | WhatsApp Cloud API adapter (behind LEARN_WHATSAPP_ENABLED flag) | 🤖 | ⬜ | |
 | `P-W5D24-2` | Data export: GET /export/students (CSV), /export/conversations (JSON), /export/progress (CSV) | 🤖 | ✅ | Go admin API now serves student CSV, conversation JSON, and progress CSV exports; admin UI downloads are available on `/export`. |
-| `P-W5D24-3` | Security audit: auth on all endpoints, tenant isolation middleware, rate limiting, parameterized queries | 🤖 | ⬜ | |
+| `P-W5D24-3` | Security audit: auth on all endpoints, tenant isolation middleware, rate limiting, parameterized queries | ðŸ¤– | âœ… | Added API/auth fixed-window rate limiting middleware, baseline security headers, and validated existing auth + tenant-scoped admin datasource + parameterized SQL usage. |
 | `P-W5D24-6` | Admin auth hardening: migrations for `auth_identities`, `auth_invites`, `auth_sessions`; invite acceptance; email/password login; logout endpoint; Next.js route guards for teacher/parent/admin views | 🤖 | ✅ | Session cookies now come from Go as `HttpOnly`; admin auth no longer stores tokens in `localStorage`; protected API/page responses use `no-store`. |
 | `P-W5D24-4` | 🧑 Final curriculum QA for all KSSM Algebra topics across F1-F3 | 🧑 Human | ⬜ | |
 | `P-W5D24-5` | 🧑 Gather testimonials from 5 students + 2 teachers | 🧑 Human | ⬜ | |

--- a/docs/development-timeline.md
+++ b/docs/development-timeline.md
@@ -486,7 +486,7 @@ When adding a new item here, use an `A-WxDy-...` ID and do not backfill it into 
 
 | Task ID | Task | Owner | Status | Remark |
 |---------|------|-------|--------|--------|
-| `P-W6D29-1` | Comprehensive analytics API: GET /analytics/report — all 6-week metrics in one endpoint | 🤖 | ⬜ | |
+| `P-W6D29-1` | Comprehensive analytics API: GET /analytics/report — all 6-week metrics in one endpoint | 🤖 | ✅ | Shipped as `GET /api/admin/analytics/report` (admin/platform_admin): 42-day DAU, retention, nudge response, AI usage, plus overview rollups in one payload. |
 | `P-W6D29-2` | 🧑 Review community PRs. Plan next 6 weeks. | 🧑 Team | ⬜ | |
 
 ### Day 30 — 6-Week Report

--- a/internal/adminapi/service.go
+++ b/internal/adminapi/service.go
@@ -170,6 +170,29 @@ type MetricsSummary struct {
 	ABComparison     any                     `json:"ab_comparison"`
 }
 
+type AnalyticsOverview struct {
+	TotalActiveLearners int     `json:"total_active_learners"`
+	AverageDAU          float64 `json:"average_dau"`
+	LatestDAU           int     `json:"latest_dau"`
+	Day1RetentionRate   float64 `json:"day_1_retention_rate"`
+	Day7RetentionRate   float64 `json:"day_7_retention_rate"`
+	Day14RetentionRate  float64 `json:"day_14_retention_rate"`
+	NudgeResponseRate   float64 `json:"nudge_response_rate"`
+	TotalAIMessages     int     `json:"total_ai_messages"`
+	TotalAITokens       int     `json:"total_ai_tokens"`
+}
+
+type AnalyticsReport struct {
+	WindowDays       int                     `json:"window_days"`
+	GeneratedAt      time.Time               `json:"generated_at"`
+	Overview         AnalyticsOverview       `json:"overview"`
+	DailyActiveUsers []DailyActiveUsersPoint `json:"daily_active_users"`
+	Retention        []RetentionPoint        `json:"retention"`
+	NudgeRate        NudgeRateSummary        `json:"nudge_rate"`
+	AIUsage          AIUsageSummary          `json:"ai_usage"`
+	ABComparison     any                     `json:"ab_comparison"`
+}
+
 type ClassStudent struct {
 	ID     string             `json:"id"`
 	Name   string             `json:"name"`
@@ -836,6 +859,41 @@ func (s *Service) GetMetrics() (MetricsSummary, error) {
 
 	return MetricsSummary{
 		WindowDays:       14,
+		DailyActiveUsers: daily,
+		Retention:        retention,
+		NudgeRate:        nudgeRate,
+		AIUsage:          aiUsage,
+		ABComparison:     nil,
+	}, nil
+}
+
+func (s *Service) GetAnalyticsReport() (AnalyticsReport, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	const reportWindowDays = 42
+
+	daily, err := s.loadDailyActiveUsers(ctx, reportWindowDays)
+	if err != nil {
+		return AnalyticsReport{}, err
+	}
+	retention, err := s.loadRetention(ctx)
+	if err != nil {
+		return AnalyticsReport{}, err
+	}
+	nudgeRate, err := s.loadNudgeRate(ctx, reportWindowDays)
+	if err != nil {
+		return AnalyticsReport{}, err
+	}
+	aiUsage, err := s.GetAIUsage()
+	if err != nil {
+		return AnalyticsReport{}, err
+	}
+
+	return AnalyticsReport{
+		WindowDays:       reportWindowDays,
+		GeneratedAt:      time.Now().UTC(),
+		Overview:         buildAnalyticsOverview(daily, retention, nudgeRate, aiUsage),
 		DailyActiveUsers: daily,
 		Retention:        retention,
 		NudgeRate:        nudgeRate,
@@ -1609,6 +1667,41 @@ func buildNudgeRateSummary(nudgesSent, responses int) NudgeRateSummary {
 		summary.ResponseRate = float64(responses) / float64(nudgesSent)
 	}
 	return summary
+}
+
+func buildAnalyticsOverview(daily []DailyActiveUsersPoint, retention []RetentionPoint, nudgeRate NudgeRateSummary, aiUsage AIUsageSummary) AnalyticsOverview {
+	overview := AnalyticsOverview{
+		NudgeResponseRate: nudgeRate.ResponseRate,
+		TotalAIMessages:   aiUsage.TotalMessages,
+		TotalAITokens:     aiUsage.TotalInputTokens + aiUsage.TotalOutputTokens,
+	}
+
+	for _, item := range daily {
+		overview.TotalActiveLearners += item.Users
+	}
+	if len(daily) > 0 {
+		overview.AverageDAU = float64(overview.TotalActiveLearners) / float64(len(daily))
+		overview.LatestDAU = daily[len(daily)-1].Users
+	}
+
+	if len(retention) > 0 {
+		var (
+			day1  float64
+			day7  float64
+			day14 float64
+		)
+		for _, item := range retention {
+			day1 += item.Day1Rate
+			day7 += item.Day7Rate
+			day14 += item.Day14Rate
+		}
+		denom := float64(len(retention))
+		overview.Day1RetentionRate = day1 / denom
+		overview.Day7RetentionRate = day7 / denom
+		overview.Day14RetentionRate = day14 / denom
+	}
+
+	return overview
 }
 
 func buildParentEncouragement(childName string, streak StreakSummary, progress []ProgressItem, stats WeeklyStats) EncouragementSuggestion {

--- a/internal/adminapi/service_test.go
+++ b/internal/adminapi/service_test.go
@@ -2,6 +2,7 @@ package adminapi
 
 import (
 	"errors"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -192,6 +193,59 @@ func TestBuildNudgeRateSummary(t *testing.T) {
 	}
 	if got.ResponseRate != 0.275 {
 		t.Fatalf("response rate = %v, want 0.275", got.ResponseRate)
+	}
+}
+
+func TestBuildAnalyticsOverview(t *testing.T) {
+	report := buildAnalyticsOverview(
+		[]DailyActiveUsersPoint{
+			{Date: "2026-03-01", Users: 10},
+			{Date: "2026-03-02", Users: 20},
+			{Date: "2026-03-03", Users: 15},
+		},
+		[]RetentionPoint{
+			{CohortDate: "2026-02-01", CohortSize: 10, Day1Rate: 0.8, Day7Rate: 0.5, Day14Rate: 0.4},
+			{CohortDate: "2026-02-08", CohortSize: 5, Day1Rate: 0.6, Day7Rate: 0.4, Day14Rate: 0.2},
+		},
+		NudgeRateSummary{
+			NudgesSent:             20,
+			ResponsesWithin24Hours: 8,
+			ResponseRate:           0.4,
+		},
+		AIUsageSummary{
+			TotalMessages:     120,
+			TotalInputTokens:  7000,
+			TotalOutputTokens: 3000,
+		},
+	)
+
+	if report.TotalActiveLearners != 45 {
+		t.Fatalf("TotalActiveLearners = %d, want 45", report.TotalActiveLearners)
+	}
+	if report.AverageDAU != 15 {
+		t.Fatalf("AverageDAU = %v, want 15", report.AverageDAU)
+	}
+	if report.LatestDAU != 15 {
+		t.Fatalf("LatestDAU = %d, want 15", report.LatestDAU)
+	}
+	if math.Abs(report.Day1RetentionRate-0.7) > 1e-9 || math.Abs(report.Day7RetentionRate-0.45) > 1e-9 || math.Abs(report.Day14RetentionRate-0.3) > 1e-9 {
+		t.Fatalf("retention rates = %#v, want 0.7/0.45/0.3", report)
+	}
+	if report.NudgeResponseRate != 0.4 {
+		t.Fatalf("NudgeResponseRate = %v, want 0.4", report.NudgeResponseRate)
+	}
+	if report.TotalAIMessages != 120 || report.TotalAITokens != 10000 {
+		t.Fatalf("AI totals = %#v, want messages=120 tokens=10000", report)
+	}
+}
+
+func TestBuildAnalyticsOverviewWithEmptyInputs(t *testing.T) {
+	report := buildAnalyticsOverview(nil, nil, NudgeRateSummary{}, AIUsageSummary{})
+	if report.TotalActiveLearners != 0 || report.AverageDAU != 0 || report.LatestDAU != 0 {
+		t.Fatalf("DAU overview = %#v, want zeros", report)
+	}
+	if report.Day1RetentionRate != 0 || report.Day7RetentionRate != 0 || report.Day14RetentionRate != 0 {
+		t.Fatalf("retention overview = %#v, want zeros", report)
 	}
 }
 

--- a/internal/apidocs/routes.go
+++ b/internal/apidocs/routes.go
@@ -238,6 +238,15 @@ func Build() (*Document, error) {
 			protectedErrors(),
 		),
 	})
+	doc.Paths["/api/admin/analytics/report"] = route("GET", Operation{
+		Summary:  "Get comprehensive 6-week analytics report",
+		Tags:     []string{"Admin"},
+		Security: protected,
+		Responses: mergeResponses(
+			responseJSON("200", "Comprehensive analytics report.", registry.refFor(adminapi.AnalyticsReport{})),
+			protectedErrors(),
+		),
+	})
 	doc.Paths["/api/admin/ai/budget-window"] = route("POST", Operation{
 		Summary:     "Create or update the token budget window for the tenant",
 		Tags:        []string{"Admin"},

--- a/internal/tenant/bootstrap.go
+++ b/internal/tenant/bootstrap.go
@@ -1,0 +1,72 @@
+package tenant
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	defaultTenantSlug = "default"
+	defaultTenantName = "Default"
+)
+
+type queryRower interface {
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+// EnsureDefaultTenantForMode enforces tenant bootstrap behavior by mode.
+// In single mode, it ensures the default tenant exists and returns its ID.
+// In multi mode, it performs no mutation and returns an empty tenant ID.
+func EnsureDefaultTenantForMode(ctx context.Context, mode string, q queryRower) (string, error) {
+	mode = strings.TrimSpace(mode)
+	switch mode {
+	case "single":
+		return ensureDefaultTenant(ctx, q)
+	case "multi":
+		return "", nil
+	default:
+		return "", fmt.Errorf("invalid tenant mode: %q", mode)
+	}
+}
+
+// EnsureDefaultTenantForPool is a pool-backed wrapper used by app startup.
+func EnsureDefaultTenantForPool(ctx context.Context, mode string, pool *pgxpool.Pool) (string, error) {
+	if pool == nil {
+		return "", errors.New("pool is nil")
+	}
+	return EnsureDefaultTenantForMode(ctx, mode, pool)
+}
+
+func ensureDefaultTenant(ctx context.Context, q queryRower) (string, error) {
+	var tenantID string
+	err := q.QueryRow(ctx,
+		`SELECT id::text FROM tenants WHERE slug = $1 LIMIT 1`,
+		defaultTenantSlug,
+	).Scan(&tenantID)
+	if err == nil {
+		return tenantID, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return "", fmt.Errorf("query default tenant: %w", err)
+	}
+
+	err = q.QueryRow(ctx,
+		`INSERT INTO tenants (name, slug)
+		 VALUES ($1, $2)
+		 ON CONFLICT (slug) DO UPDATE
+		 SET name = EXCLUDED.name
+		 RETURNING id::text`,
+		defaultTenantName,
+		defaultTenantSlug,
+	).Scan(&tenantID)
+	if err != nil {
+		return "", fmt.Errorf("upsert default tenant: %w", err)
+	}
+
+	return tenantID, nil
+}

--- a/internal/tenant/bootstrap_test.go
+++ b/internal/tenant/bootstrap_test.go
@@ -1,0 +1,112 @@
+package tenant
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+)
+
+type stubQuerier struct {
+	rows      []stubRow
+	queries   []string
+	queryArgs [][]any
+}
+
+func (s *stubQuerier) QueryRow(_ context.Context, sql string, args ...any) pgx.Row {
+	s.queries = append(s.queries, sql)
+	s.queryArgs = append(s.queryArgs, args)
+	if len(s.rows) == 0 {
+		return stubRow{err: errors.New("unexpected query")}
+	}
+	row := s.rows[0]
+	s.rows = s.rows[1:]
+	return row
+}
+
+type stubRow struct {
+	id  string
+	err error
+}
+
+func (r stubRow) Scan(dest ...any) error {
+	if r.err != nil {
+		return r.err
+	}
+	id, ok := dest[0].(*string)
+	if !ok {
+		return errors.New("destination is not *string")
+	}
+	*id = r.id
+	return nil
+}
+
+func TestEnsureDefaultTenantForMode_SingleExisting(t *testing.T) {
+	q := &stubQuerier{
+		rows: []stubRow{
+			{id: "tenant-existing"},
+		},
+	}
+
+	tenantID, err := EnsureDefaultTenantForMode(context.Background(), "single", q)
+	if err != nil {
+		t.Fatalf("EnsureDefaultTenantForMode() error = %v", err)
+	}
+	if tenantID != "tenant-existing" {
+		t.Fatalf("tenantID = %q, want tenant-existing", tenantID)
+	}
+	if len(q.queries) != 1 {
+		t.Fatalf("query count = %d, want 1", len(q.queries))
+	}
+	if !strings.Contains(q.queries[0], "WHERE slug = $1") {
+		t.Fatalf("lookup query = %q, want slug predicate", q.queries[0])
+	}
+}
+
+func TestEnsureDefaultTenantForMode_SingleCreatesWhenMissing(t *testing.T) {
+	q := &stubQuerier{
+		rows: []stubRow{
+			{err: pgx.ErrNoRows},
+			{id: "tenant-created"},
+		},
+	}
+
+	tenantID, err := EnsureDefaultTenantForMode(context.Background(), "single", q)
+	if err != nil {
+		t.Fatalf("EnsureDefaultTenantForMode() error = %v", err)
+	}
+	if tenantID != "tenant-created" {
+		t.Fatalf("tenantID = %q, want tenant-created", tenantID)
+	}
+	if len(q.queries) != 2 {
+		t.Fatalf("query count = %d, want 2", len(q.queries))
+	}
+	if !strings.Contains(q.queries[1], "INSERT INTO tenants") {
+		t.Fatalf("second query = %q, want tenant insert", q.queries[1])
+	}
+}
+
+func TestEnsureDefaultTenantForMode_MultiSkipsBootstrap(t *testing.T) {
+	q := &stubQuerier{}
+
+	tenantID, err := EnsureDefaultTenantForMode(context.Background(), "multi", q)
+	if err != nil {
+		t.Fatalf("EnsureDefaultTenantForMode() error = %v", err)
+	}
+	if tenantID != "" {
+		t.Fatalf("tenantID = %q, want empty for multi mode", tenantID)
+	}
+	if len(q.queries) != 0 {
+		t.Fatalf("query count = %d, want 0", len(q.queries))
+	}
+}
+
+func TestEnsureDefaultTenantForMode_InvalidMode(t *testing.T) {
+	q := &stubQuerier{}
+	_, err := EnsureDefaultTenantForMode(context.Background(), "weird", q)
+	if err == nil {
+		t.Fatal("expected error for invalid tenant mode")
+	}
+}


### PR DESCRIPTION
- Add API/auth fixed-window rate limiting and security response headers.
- Enforce tenant bootstrap by mode: single mode upserts default tenant, multi mode no-op.
- Add tests for limiter and tenant bootstrap behavior.
- Update timeline status for P-W5D24-3 and P-W5D23-1.
- Add README first-boot tenant flow notes