### PR TITLE
fix: use env var for Postgres password in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       - "5432:5432"
     environment:
       POSTGRES_USER: pai
-      POSTGRES_PASSWORD: pai
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-pai}
       POSTGRES_DB: pai
     volumes:
       - postgres-data:/var/lib/postgresql/data
@@ -58,7 +58,7 @@ services:
     env_file:
       - .env
     environment:
-      LEARN_DATABASE_URL: postgres://pai:pai@postgres:5432/pai?sslmode=disable
+      LEARN_DATABASE_URL: postgres://pai:${POSTGRES_PASSWORD:-pai}@postgres:5432/pai?sslmode=disable
       LEARN_CACHE_URL: redis://dragonfly:6379
       LEARN_NATS_URL: nats://nats:4222
     dns:


### PR DESCRIPTION
## Summary
- Postgres password was hardcoded as `pai` in `docker-compose.yml` (both the postgres service and `LEARN_DATABASE_URL`)
- When `.env` sets `POSTGRES_PASSWORD` to the real secret, the app can't authenticate — causing the crash loop and 500s on production
- Changed to `${POSTGRES_PASSWORD:-pai}` so local dev defaults to `pai` without needing `.env`, while production picks up the real password

## After merge
Redeploy to server. The Postgres user password has already been updated on the server via `ALTER USER`.

## Test plan
- [ ] `docker compose up` without `.env` still works (defaults to `pai`)
- [ ] `docker compose up` with `POSTGRES_PASSWORD=secret` in `.env` uses `secret`
- [ ] Production: app connects to postgres after redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)