### PR TITLE
feat(admin): WhatsApp setup page with QR code UI

### DIFF
--- a/admin/src/app/settings/whatsapp/page.tsx
+++ b/admin/src/app/settings/whatsapp/page.tsx
@@ -1,0 +1,30 @@
+import { redirect } from "next/navigation";
+import { PageHero } from "@/components/page-hero";
+import { WhatsAppSetupPanel } from "@/components/whatsapp-setup-panel";
+import { getServerAuthSession } from "@/lib/server-api";
+
+export const dynamic = "force-dynamic";
+
+export default async function WhatsAppSetupPage() {
+  const session = await getServerAuthSession();
+  const currentUser = session?.user ?? null;
+
+  if (
+    !currentUser ||
+    (currentUser.role !== "admin" && currentUser.role !== "platform_admin")
+  ) {
+    redirect("/dashboard");
+  }
+
+  return (
+    <div className="space-y-6">
+      <PageHero
+        eyebrow="Integration"
+        title="WhatsApp setup"
+        description="Link your WhatsApp account to enable the bot on WhatsApp. Scan the QR code with your phone to connect."
+        surface="plain"
+      />
+      <WhatsAppSetupPanel />
+    </div>
+  );
+}

--- a/admin/src/components/whatsapp-setup-panel.tsx
+++ b/admin/src/components/whatsapp-setup-panel.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { AdminSurface, AdminSurfaceHeader } from "@/components/admin-surface";
+import { StatePanel } from "@/components/state-panel";
+import { getWhatsAppStatus, disconnectWhatsApp } from "@/lib/api";
+
+export function WhatsAppSetupPanel() {
+  const queryClient = useQueryClient();
+  const [isPending, startTransition] = useTransition();
+  const [disconnectError, setDisconnectError] = useState("");
+
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: ["whatsapp", "status"],
+    queryFn: getWhatsAppStatus,
+    refetchInterval: 5000,
+  });
+
+  function handleDisconnect() {
+    setDisconnectError("");
+    startTransition(async () => {
+      try {
+        await disconnectWhatsApp();
+        queryClient.invalidateQueries({ queryKey: ["whatsapp", "status"] });
+      } catch (err) {
+        setDisconnectError(
+          err instanceof Error ? err.message : "Failed to disconnect",
+        );
+      }
+    });
+  }
+
+  if (isLoading) {
+    return <StatePanel tone="loading" title="Loading WhatsApp status..." description="Checking connection to WhatsApp server." />;
+  }
+
+  if (error) {
+    return (
+      <StatePanel
+        tone="error"
+        title="Could not load WhatsApp status"
+        description={
+          error instanceof Error
+            ? error.message
+            : "Check that WhatsApp is enabled on the server."
+        }
+      />
+    );
+  }
+
+  if (data?.connected) {
+    return (
+      <AdminSurface>
+        <AdminSurfaceHeader
+          title="WhatsApp connected"
+          description="Your WhatsApp account is linked and the bot is active."
+        />
+        <div className="mt-6 flex items-center justify-between rounded-lg border border-emerald-200 bg-emerald-50 p-4 dark:border-emerald-800 dark:bg-emerald-950/30">
+          <div className="flex items-center gap-3">
+            <span className="text-2xl">&#9989;</span>
+            <div>
+              <p className="font-medium text-emerald-900 dark:text-emerald-100">
+                Session active
+              </p>
+              <p className="text-sm text-emerald-700 dark:text-emerald-300">
+                Messages are being sent and received via WhatsApp.
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={handleDisconnect}
+            disabled={isPending}
+            className="rounded-md border border-red-300 bg-white px-4 py-2 text-sm font-medium text-red-700 hover:bg-red-50 disabled:opacity-50 dark:border-red-700 dark:bg-red-950/30 dark:text-red-300 dark:hover:bg-red-950/50"
+          >
+            {isPending ? "Disconnecting..." : "Disconnect"}
+          </button>
+        </div>
+        {disconnectError && (
+          <p className="mt-2 text-sm text-destructive">{disconnectError}</p>
+        )}
+      </AdminSurface>
+    );
+  }
+
+  return (
+    <AdminSurface>
+      <AdminSurfaceHeader
+        title="Link WhatsApp"
+        description="Scan the QR code below with your phone to connect."
+      />
+      <div className="mt-6 space-y-4">
+        {data?.qr_image ? (
+          <div className="flex flex-col items-center gap-4">
+            <img
+              src={data.qr_image}
+              alt="WhatsApp QR Code"
+              className="h-64 w-64 rounded-lg border"
+            />
+            <div className="text-center text-sm text-muted-foreground">
+              <p>
+                Open WhatsApp on your phone &rarr; <strong>Settings</strong>{" "}
+                &rarr; <strong>Linked Devices</strong> &rarr;{" "}
+                <strong>Link a Device</strong>
+              </p>
+              <p className="mt-1">Page refreshes automatically every 5 seconds.</p>
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-col items-center gap-4 py-8">
+            <div className="h-8 w-8 animate-spin rounded-full border-4 border-muted border-t-foreground" />
+            <p className="text-sm text-muted-foreground">
+              Waiting for QR code from server...
+            </p>
+            <button
+              onClick={() => refetch()}
+              className="text-sm text-primary underline hover:no-underline"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+      </div>
+    </AdminSurface>
+  );
+}

--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -591,3 +591,19 @@ export async function removeGroupMember(groupId: string, userId: string): Promis
     throw new Error(text || `Failed to remove member: ${res.status}`);
   }
 }
+
+// ── WhatsApp ──────────────────────────────────────────────────────────
+
+export interface WhatsAppStatus {
+  connected: boolean;
+  qr?: string;
+  qr_image?: string;
+}
+
+export async function getWhatsAppStatus(): Promise<WhatsAppStatus> {
+  return fetchJSON<WhatsAppStatus>("/api/admin/whatsapp/status");
+}
+
+export async function disconnectWhatsApp(): Promise<void> {
+  await postJSON("/api/admin/whatsapp/disconnect");
+}

--- a/admin/src/lib/navigation.mjs
+++ b/admin/src/lib/navigation.mjs
@@ -34,6 +34,13 @@ export const primaryNavigation = [
     group: "Administration",
     roles: ["admin", "platform_admin"],
   },
+  {
+    title: "WhatsApp",
+    href: "/settings/whatsapp",
+    description: "Link your WhatsApp account via QR code.",
+    group: "Integration",
+    roles: ["admin", "platform_admin"],
+  },
 ];
 
 export function getNavigationForUser(user) {
@@ -106,6 +113,14 @@ export function getCurrentSection(pathname) {
     };
   }
 
+  if (pathname.startsWith("/settings/whatsapp")) {
+    return {
+      eyebrow: "Integration",
+      title: "WhatsApp setup",
+      description: "Link your WhatsApp account via QR code to enable the bot on WhatsApp.",
+    };
+  }
+
   if (pathname.startsWith("/settings/users")) {
     return {
       eyebrow: "Administration",
@@ -175,6 +190,13 @@ export function getBreadcrumbs(pathname, user) {
     return [
       { label: "Dashboard", href: "/dashboard" },
       { label: "Classes", href: "/dashboard/classes" },
+    ];
+  }
+
+  if (pathname.startsWith("/settings/whatsapp")) {
+    return [
+      { label: "Dashboard", href: "/dashboard" },
+      { label: "WhatsApp", href: "/settings/whatsapp" },
     ];
   }
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -302,12 +302,17 @@ func main() {
 		topMux.Handle("/webhook/whatsapp", waCloudChannel.WebhookHandler(handleInbound))
 	}
 	if waMeowChannel != nil {
-		if cfg.WhatsApp.QRToken != "" {
-			topMux.Handle("/whatsapp/qr", requireToken(cfg.WhatsApp.QRToken, waMeowChannel.QRHandler()))
-		} else {
-			slog.Warn("LEARN_WHATSAPP_QR_TOKEN is not set — /whatsapp/qr is unprotected")
-			topMux.Handle("/whatsapp/qr", waMeowChannel.QRHandler())
-		}
+		manager := auth.NewTokenManager(cfg.Auth.JWTSecret, defaultAccessTokenTTL)
+		waAuth := chain(
+			authenticateRequests(authService, manager, time.Now),
+			auth.RequireRoles(auth.RoleAdmin, auth.RolePlatformAdmin),
+		)
+		waStatusHandler := withCORS(waAuth(waMeowChannel.StatusHandler()))
+		topMux.Handle("GET /api/admin/whatsapp/status", waStatusHandler)
+		topMux.Handle("OPTIONS /api/admin/whatsapp/status", waStatusHandler)
+		waDisconnectHandler := withCORS(waAuth(waMeowChannel.DisconnectHandler()))
+		topMux.Handle("POST /api/admin/whatsapp/disconnect", waDisconnectHandler)
+		topMux.Handle("OPTIONS /api/admin/whatsapp/disconnect", waDisconnectHandler)
 	}
 	topMux.Handle("/", apiHandler)
 

--- a/internal/chat/whatsapp_meow.go
+++ b/internal/chat/whatsapp_meow.go
@@ -2,6 +2,8 @@ package chat
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -144,63 +146,97 @@ func (w *WhatsAppMeowChannel) Stop() error {
 	return nil
 }
 
+// Logout disconnects, removes the session, and starts a new QR code flow.
+func (w *WhatsAppMeowChannel) Logout() error {
+	if err := w.client.Logout(context.Background()); err != nil {
+		return fmt.Errorf("whatsmeow logout: %w", err)
+	}
+	slog.Info("whatsapp session logged out")
+
+	// Re-initiate QR flow so the admin can re-link immediately.
+	w.mu.RLock()
+	handler := w.handler
+	w.mu.RUnlock()
+	if err := w.Start(context.Background(), handler); err != nil {
+		slog.Error("failed to restart QR flow after logout", "error", err)
+	}
+	return nil
+}
+
+// DisconnectHandler returns an HTTP handler that logs out the WhatsApp session.
+func (w *WhatsAppMeowChannel) DisconnectHandler() http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		if err := w.Logout(); err != nil {
+			rw.Header().Set("Content-Type", "application/json")
+			rw.WriteHeader(http.StatusInternalServerError)
+			_ = json.NewEncoder(rw).Encode(map[string]string{"error": err.Error()})
+			return
+		}
+		rw.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(rw).Encode(map[string]string{"status": "disconnected"})
+	})
+}
+
 // IsConnected returns true if the client is currently connected.
 func (w *WhatsAppMeowChannel) IsConnected() bool {
 	return w.client.IsConnected()
 }
 
-// QRHandler returns an HTTP handler that serves the QR code as a PNG image.
-// Returns an HTML page with the QR code and auto-refresh, or a status page if already connected.
-func (w *WhatsAppMeowChannel) QRHandler() http.Handler {
+// qrExpired returns true if there's no active QR and the client isn't authenticated.
+func (w *WhatsAppMeowChannel) qrExpired() bool {
+	w.qrMu.RLock()
+	qr := w.latestQR
+	w.qrMu.RUnlock()
+	return qr == "" && w.client.Store.ID == nil && !w.client.IsConnected()
+}
+
+// restartQR disconnects and re-initiates the QR flow.
+func (w *WhatsAppMeowChannel) restartQR() {
+	w.client.Disconnect()
+	w.mu.RLock()
+	handler := w.handler
+	w.mu.RUnlock()
+	if err := w.Start(context.Background(), handler); err != nil {
+		slog.Error("failed to restart QR flow", "error", err)
+	}
+}
+
+// WhatsAppStatus represents the current WhatsApp connection state.
+type WhatsAppStatus struct {
+	Connected bool   `json:"connected"`
+	QR        string `json:"qr,omitempty"`
+	QRImage   string `json:"qr_image,omitempty"` // base64-encoded PNG
+}
+
+// StatusHandler returns an HTTP handler that serves the WhatsApp status as JSON.
+// If the QR has expired, it automatically restarts the QR flow.
+func (w *WhatsAppMeowChannel) StatusHandler() http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		// If already connected, show status.
-		if w.client.Store.ID != nil && w.client.IsConnected() {
-			rw.Header().Set("Content-Type", "text/html")
-			_, _ = fmt.Fprint(rw, `<!DOCTYPE html><html><body style="font-family:sans-serif;text-align:center;padding:60px">
-				<h2>&#9989; WhatsApp Connected</h2>
-				<p>Session is active. Bot is ready to send and receive messages.</p>
-			</body></html>`)
-			return
+		status := WhatsAppStatus{
+			Connected: w.client.Store.ID != nil && w.client.IsConnected(),
 		}
 
-		w.qrMu.RLock()
-		qr := w.latestQR
-		w.qrMu.RUnlock()
-
-		// Preserve query string for auto-refresh so auth tokens carry through.
-		qs := r.URL.RawQuery
-
-		if qr == "" {
-			rw.Header().Set("Content-Type", "text/html")
-			rw.Header().Set("Refresh", "3")
-			_, _ = fmt.Fprint(rw, `<!DOCTYPE html><html><body style="font-family:sans-serif;text-align:center;padding:60px">
-				<h2>Waiting for QR code...</h2>
-				<p>Page will auto-refresh. If this persists, restart the server.</p>
-			</body></html>`)
-			return
-		}
-
-		// Return QR as PNG if ?format=png
-		if r.URL.Query().Get("format") == "png" {
-			png, err := qrcode.Encode(qr, qrcode.Medium, 512)
-			if err != nil {
-				http.Error(rw, "failed to generate QR", http.StatusInternalServerError)
-				return
+		if !status.Connected {
+			// Auto-restart QR flow if it timed out.
+			if w.qrExpired() {
+				go w.restartQR()
 			}
-			rw.Header().Set("Content-Type", "image/png")
-			_, _ = rw.Write(png)
-			return
+
+			w.qrMu.RLock()
+			qr := w.latestQR
+			w.qrMu.RUnlock()
+
+			if qr != "" {
+				status.QR = qr
+				png, err := qrcode.Encode(qr, qrcode.Medium, 512)
+				if err == nil {
+					status.QRImage = "data:image/png;base64," + base64.StdEncoding.EncodeToString(png)
+				}
+			}
 		}
 
-		// Default: HTML page with embedded QR image and auto-refresh.
-		rw.Header().Set("Content-Type", "text/html")
-		_, _ = fmt.Fprintf(rw, `<!DOCTYPE html><html><head><meta http-equiv="refresh" content="5; url=/whatsapp/qr?%s"></head>
-			<body style="font-family:sans-serif;text-align:center;padding:40px">
-			<h2>Scan QR Code with WhatsApp</h2>
-			<p>Open WhatsApp &rarr; Settings &rarr; Linked Devices &rarr; Link a Device</p>
-			<img src="/whatsapp/qr?format=png&%s" style="margin:20px" />
-			<p style="color:#888">Page auto-refreshes every 5 seconds</p>
-		</body></html>`, qs, qs)
+		rw.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(rw).Encode(status)
 	})
 }
 


### PR DESCRIPTION
## Summary

- Add `/settings/whatsapp` admin page for linking WhatsApp via QR code scan
- Backend JSON API (`/api/admin/whatsapp/status`, `/api/admin/whatsapp/disconnect`) behind JWT admin auth
- Auto-restart QR flow when expired — no server restart needed
- Disconnect button to unlink WhatsApp session
- Navigation entry under "Integration" group (admin only)

## Changes

**Backend:**
- Replace old HTML QR handler with JSON status API returning `{connected, qr, qr_image}`
- Add `/api/admin/whatsapp/disconnect` POST endpoint (logs out + restarts QR)
- QR auto-restarts when admin page polls and QR has timed out
- Remove `LEARN_WHATSAPP_QR_TOKEN` — no longer needed (JWT auth protects the endpoint)

**Frontend:**
- `admin/src/app/settings/whatsapp/page.tsx` — server component with admin auth gate
- `admin/src/components/whatsapp-setup-panel.tsx` — client component with 5s auto-poll
- Navigation and breadcrumb entries in `navigation.mjs`
- `getWhatsAppStatus()` and `disconnectWhatsApp()` API functions

## Test plan

- [x] QR code displays in admin panel when not connected
- [x] Connected status shows with disconnect button
- [x] Disconnect clears session and shows QR for re-linking
- [x] QR auto-restarts after timeout without server restart
- [x] Non-admin users redirected to dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)