### PR TITLE
feat: add admin ai usage page

### DIFF
--- a/admin/src/app/(app)/dashboard/ai-usage/page.test.tsx
+++ b/admin/src/app/(app)/dashboard/ai-usage/page.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+import AIUsagePage from "./page";
+
+const { getServerAIUsageMock, getServerAuthSessionMock, getAIUsageBudgetViewModelMock } = vi.hoisted(() => ({
+  getServerAIUsageMock: vi.fn(),
+  getServerAuthSessionMock: vi.fn(),
+  getAIUsageBudgetViewModelMock: vi.fn(),
+}));
+
+vi.mock("@/lib/server-api", () => ({
+  ServerAPIError: class ServerAPIError extends Error {
+    constructor(public path: string, public status: number) {
+      super(`Failed to load ${path}: ${status}`);
+      this.name = "ServerAPIError";
+    }
+  },
+  getServerAIUsage: getServerAIUsageMock,
+  getServerAuthSession: getServerAuthSessionMock,
+}));
+
+vi.mock("@/lib/ai-usage.mjs", () => ({
+  getAIUsageBudgetViewModel: getAIUsageBudgetViewModelMock,
+}));
+
+vi.mock("@/components/ai-usage/overview-section", () => ({
+  AIUsageOverviewSection: () => <div>overview</div>,
+}));
+
+vi.mock("@/components/ai-usage/daily-trend-section", () => ({
+  AIUsageDailyTrendSection: () => <div>daily trend</div>,
+}));
+
+vi.mock("@/components/ai-usage/provider-breakdown-section", () => ({
+  AIUsageProviderBreakdownSection: () => <div>provider breakdown</div>,
+}));
+
+vi.mock("@/components/ai-usage/budget-section", () => ({
+  AIUsageBudgetSection: ({ canManageBudget }: { canManageBudget: boolean }) => (
+    <div>budget:{canManageBudget ? "editable" : "readonly"}</div>
+  ),
+}));
+
+describe("AIUsagePage", () => {
+  beforeEach(() => {
+    getServerAIUsageMock.mockReset();
+    getServerAuthSessionMock.mockReset();
+    getAIUsageBudgetViewModelMock.mockReset();
+
+    getServerAIUsageMock.mockResolvedValue({});
+    getAIUsageBudgetViewModelMock.mockReturnValue({});
+  });
+
+  it("keeps the budget panel read-only for platform admins", async () => {
+    getServerAuthSessionMock.mockResolvedValue({
+      user: {
+        user_id: "platform-admin-1",
+        tenant_id: "tenant-1",
+        role: "platform_admin",
+        name: "Platform Admin",
+        email: "platform@example.com",
+      },
+    });
+
+    render(await AIUsagePage());
+
+    expect(screen.getByText("budget:readonly")).toBeInTheDocument();
+  });
+
+  it("allows tenant admins to edit the budget panel", async () => {
+    getServerAuthSessionMock.mockResolvedValue({
+      user: {
+        user_id: "admin-1",
+        tenant_id: "tenant-1",
+        role: "admin",
+        name: "Admin",
+        email: "admin@example.com",
+      },
+    });
+
+    render(await AIUsagePage());
+
+    expect(screen.getByText("budget:editable")).toBeInTheDocument();
+  });
+});

--- a/admin/src/app/(app)/dashboard/ai-usage/page.tsx
+++ b/admin/src/app/(app)/dashboard/ai-usage/page.tsx
@@ -32,7 +32,7 @@ async function loadAIUsagePageResult(): Promise<AIUsagePageResult> {
 export default async function AIUsagePage() {
   const [session, result] = await Promise.all([getServerAuthSession(), loadAIUsagePageResult()]);
   const currentUser = session?.user ?? null;
-  const canManageBudget = currentUser?.role === "admin" || currentUser?.role === "platform_admin";
+  const canManageBudget = currentUser?.role === "admin";
 
   if (!result.ok) {
     return (

--- a/admin/src/app/(app)/dashboard/ai-usage/page.tsx
+++ b/admin/src/app/(app)/dashboard/ai-usage/page.tsx
@@ -4,7 +4,7 @@ import { AIUsageOverviewSection } from "@/components/ai-usage/overview-section";
 import { AIUsageProviderBreakdownSection } from "@/components/ai-usage/provider-breakdown-section";
 import type { AIUsageView } from "@/components/ai-usage/types";
 import { StatePanel } from "@/components/state-panel";
-import { ServerAPIError, getServerAIUsage } from "@/lib/server-api";
+import { ServerAPIError, getServerAIUsage, getServerAuthSession } from "@/lib/server-api";
 import { getAIUsageBudgetViewModel } from "@/lib/ai-usage.mjs";
 
 export const dynamic = "force-dynamic";
@@ -30,7 +30,9 @@ async function loadAIUsagePageResult(): Promise<AIUsagePageResult> {
 }
 
 export default async function AIUsagePage() {
-  const result = await loadAIUsagePageResult();
+  const [session, result] = await Promise.all([getServerAuthSession(), loadAIUsagePageResult()]);
+  const currentUser = session?.user ?? null;
+  const canManageBudget = currentUser?.role === "admin" || currentUser?.role === "platform_admin";
 
   if (!result.ok) {
     return (
@@ -47,7 +49,7 @@ export default async function AIUsagePage() {
       <AIUsageOverviewSection view={result.view} />
 
       <div className="grid gap-6 xl:grid-cols-[1.25fr_0.95fr]">
-        <AIUsageBudgetSection view={result.view} />
+        <AIUsageBudgetSection view={result.view} canManageBudget={canManageBudget} />
         <AIUsageDailyTrendSection view={result.view} />
       </div>
 

--- a/admin/src/app/(app)/dashboard/ai-usage/page.tsx
+++ b/admin/src/app/(app)/dashboard/ai-usage/page.tsx
@@ -1,0 +1,57 @@
+import { AIUsageBudgetSection } from "@/components/ai-usage/budget-section";
+import { AIUsageDailyTrendSection } from "@/components/ai-usage/daily-trend-section";
+import { AIUsageOverviewSection } from "@/components/ai-usage/overview-section";
+import { AIUsageProviderBreakdownSection } from "@/components/ai-usage/provider-breakdown-section";
+import type { AIUsageView } from "@/components/ai-usage/types";
+import { StatePanel } from "@/components/state-panel";
+import { ServerAPIError, getServerAIUsage } from "@/lib/server-api";
+import { getAIUsageBudgetViewModel } from "@/lib/ai-usage.mjs";
+
+export const dynamic = "force-dynamic";
+
+type AIUsagePageResult =
+  | { ok: true; view: AIUsageView }
+  | { ok: false; description: string };
+
+async function loadAIUsagePageResult(): Promise<AIUsagePageResult> {
+  try {
+    const usage = await getServerAIUsage();
+    return { ok: true, view: getAIUsageBudgetViewModel(usage) as AIUsageView };
+  } catch (error) {
+    const description =
+      error instanceof ServerAPIError
+        ? `The admin API returned ${error.status} while loading AI usage.`
+        : error instanceof Error
+          ? error.message
+          : "The admin AI usage page could not be loaded.";
+
+    return { ok: false, description };
+  }
+}
+
+export default async function AIUsagePage() {
+  const result = await loadAIUsagePageResult();
+
+  if (!result.ok) {
+    return (
+      <StatePanel
+        tone="error"
+        title="Unable to load AI usage"
+        description={result.description}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <AIUsageOverviewSection view={result.view} />
+
+      <div className="grid gap-6 xl:grid-cols-[1.25fr_0.95fr]">
+        <AIUsageBudgetSection view={result.view} />
+        <AIUsageDailyTrendSection view={result.view} />
+      </div>
+
+      <AIUsageProviderBreakdownSection view={result.view} />
+    </div>
+  );
+}

--- a/admin/src/components/ai-usage/budget-section.test.tsx
+++ b/admin/src/components/ai-usage/budget-section.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+import { AIUsageBudgetSection } from "@/components/ai-usage/budget-section";
+import type { AIUsageView } from "@/components/ai-usage/types";
+
+vi.mock("@/components/token-budget-editor", () => ({
+  TokenBudgetEditor: () => <div>Token budget editor</div>,
+}));
+
+const view: AIUsageView = {
+  totalTokens: 413,
+  total_messages: 6,
+  topProvider: {
+    provider: "openai",
+    model: "gpt-5.4-mini",
+    messages: 6,
+    input_tokens: 200,
+    output_tokens: 213,
+    total_tokens: 413,
+  },
+  budgetStatus: { label: "Within token budget", tone: "success" },
+  budget_period_start: "2026-04-01",
+  budget_period_end: "2026-05-01",
+  per_student_average_tokens: 137.7,
+  per_student_average_cost_usd: null,
+  budgetTokenLimit: 5000,
+  budgetTokenRemaining: 4600,
+  daily_usage: [],
+  hasDailyTrend: false,
+  dailyTrendPeak: 0,
+  providers: [],
+  monthlyCost: null,
+  budgetLimit: null,
+};
+
+describe("AIUsageBudgetSection", () => {
+  it("shows the budget editor for admins", () => {
+    render(<AIUsageBudgetSection view={view} canManageBudget />);
+
+    expect(screen.getByText("Token budget editor")).toBeInTheDocument();
+    expect(screen.queryByText("Budget changes require admin access.")).not.toBeInTheDocument();
+  });
+
+  it("hides the budget editor for read-only roles", () => {
+    render(<AIUsageBudgetSection view={view} canManageBudget={false} />);
+
+    expect(screen.queryByText("Token budget editor")).not.toBeInTheDocument();
+    expect(screen.getByText("Budget changes require admin access.")).toBeInTheDocument();
+  });
+});

--- a/admin/src/components/ai-usage/budget-section.tsx
+++ b/admin/src/components/ai-usage/budget-section.tsx
@@ -1,0 +1,47 @@
+import { AdminInsetPanel } from "@/components/admin-inset-panel";
+import { AdminSurface, AdminSurfaceHeader } from "@/components/admin-surface";
+import { TokenBudgetEditor } from "@/components/token-budget-editor";
+import { formatCompactNumber } from "@/lib/ai-usage.mjs";
+import type { AIUsageView } from "@/components/ai-usage/types";
+import { formatBudgetWindowLabel } from "@/components/ai-usage/format";
+
+export function AIUsageBudgetSection({
+  view,
+}: {
+  view: AIUsageView;
+}) {
+  return (
+    <AdminSurface>
+      <div className="space-y-5">
+        <AdminSurfaceHeader
+          title="Token budget window"
+          description="Budget thresholds and remaining allowance for the active tenant-wide token window."
+        />
+
+        <div className="grid gap-4 md:grid-cols-3">
+          <AdminInsetPanel title="Window">
+            <p className="text-lg font-semibold text-slate-950 dark:text-slate-50">
+              {formatBudgetWindowLabel(view.budget_period_start, view.budget_period_end)}
+            </p>
+          </AdminInsetPanel>
+          <AdminInsetPanel title="Limit">
+            <p className="text-lg font-semibold text-slate-950 dark:text-slate-50">
+              {view.budgetTokenLimit !== null ? formatCompactNumber(view.budgetTokenLimit) : "--"}
+            </p>
+          </AdminInsetPanel>
+          <AdminInsetPanel title="Remaining">
+            <p className="text-lg font-semibold text-slate-950 dark:text-slate-50">
+              {view.budgetTokenRemaining !== null ? formatCompactNumber(view.budgetTokenRemaining) : "--"}
+            </p>
+          </AdminInsetPanel>
+        </div>
+
+        <TokenBudgetEditor
+          initialBudgetTokens={view.budgetTokenLimit}
+          initialPeriodStart={view.budget_period_start}
+          initialPeriodEnd={view.budget_period_end}
+        />
+      </div>
+    </AdminSurface>
+  );
+}

--- a/admin/src/components/ai-usage/budget-section.tsx
+++ b/admin/src/components/ai-usage/budget-section.tsx
@@ -7,8 +7,10 @@ import { formatBudgetWindowLabel } from "@/components/ai-usage/format";
 
 export function AIUsageBudgetSection({
   view,
+  canManageBudget,
 }: {
   view: AIUsageView;
+  canManageBudget: boolean;
 }) {
   return (
     <AdminSurface>
@@ -36,11 +38,17 @@ export function AIUsageBudgetSection({
           </AdminInsetPanel>
         </div>
 
-        <TokenBudgetEditor
-          initialBudgetTokens={view.budgetTokenLimit}
-          initialPeriodStart={view.budget_period_start}
-          initialPeriodEnd={view.budget_period_end}
-        />
+        {canManageBudget ? (
+          <TokenBudgetEditor
+            initialBudgetTokens={view.budgetTokenLimit}
+            initialPeriodStart={view.budget_period_start}
+            initialPeriodEnd={view.budget_period_end}
+          />
+        ) : (
+          <p className="text-sm text-slate-600 dark:text-slate-300">
+            Budget changes require admin access.
+          </p>
+        )}
       </div>
     </AdminSurface>
   );

--- a/admin/src/components/ai-usage/daily-trend-section.tsx
+++ b/admin/src/components/ai-usage/daily-trend-section.tsx
@@ -1,0 +1,68 @@
+import { AdminSurface, AdminSurfaceHeader } from "@/components/admin-surface";
+import { StatePanel } from "@/components/state-panel";
+import { formatCompactNumber } from "@/lib/ai-usage.mjs";
+import type { AIUsageView } from "@/components/ai-usage/types";
+import { formatAIUsageDateLabel } from "@/components/ai-usage/format";
+
+function DailyTrendBars({
+  view,
+}: {
+  view: AIUsageView;
+}) {
+  return (
+    <div className="space-y-3">
+      {view.daily_usage.map((point) => {
+        const width =
+          view.dailyTrendPeak > 0
+            ? `${Math.max((point.tokens / view.dailyTrendPeak) * 100, 4)}%`
+            : "4%";
+
+        return (
+          <div key={point.date} className="space-y-1.5">
+            <div className="flex items-center justify-between gap-3 text-sm">
+              <span className="font-medium text-slate-700 dark:text-slate-200">
+                {formatAIUsageDateLabel(point.date)}
+              </span>
+              <span className="text-slate-500 dark:text-slate-400">
+                {formatCompactNumber(point.tokens)} tokens
+              </span>
+            </div>
+            <div className="h-2.5 rounded-full bg-slate-100 dark:bg-slate-800">
+              <div
+                className="h-full rounded-full bg-primary/85 transition-[width]"
+                style={{ width }}
+              />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function AIUsageDailyTrendSection({
+  view,
+}: {
+  view: AIUsageView;
+}) {
+  return (
+    <AdminSurface>
+      <div className="space-y-5">
+        <AdminSurfaceHeader
+          title="Daily token trend"
+          description="Recent day-by-day token volume from the admin AI usage API."
+        />
+
+        {view.hasDailyTrend ? (
+          <DailyTrendBars view={view} />
+        ) : (
+          <StatePanel
+            tone="empty"
+            title="No daily token trend yet"
+            description="Daily usage bars will appear once the tenant starts generating AI traffic."
+          />
+        )}
+      </div>
+    </AdminSurface>
+  );
+}

--- a/admin/src/components/ai-usage/format.ts
+++ b/admin/src/components/ai-usage/format.ts
@@ -1,0 +1,34 @@
+const dayFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  timeZone: "UTC",
+});
+
+export function formatAIUsageDateLabel(value: string) {
+  if (!value) {
+    return "Not set";
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return dayFormatter.format(date);
+}
+
+export function formatBudgetWindowLabel(start: string, end: string) {
+  if (!start && !end) {
+    return "No active token window";
+  }
+
+  if (!start) {
+    return `Ends ${formatAIUsageDateLabel(end)}`;
+  }
+
+  if (!end) {
+    return `Started ${formatAIUsageDateLabel(start)}`;
+  }
+
+  return `${formatAIUsageDateLabel(start)} to ${formatAIUsageDateLabel(end)}`;
+}

--- a/admin/src/components/ai-usage/overview-section.tsx
+++ b/admin/src/components/ai-usage/overview-section.tsx
@@ -1,0 +1,78 @@
+import { AdminSurface } from "@/components/admin-surface";
+import { formatBudgetWindowLabel } from "@/components/ai-usage/format";
+import type { AIUsageView } from "@/components/ai-usage/types";
+import { formatCompactNumber, formatUSD } from "@/lib/ai-usage.mjs";
+
+function SummaryMetric({
+  label,
+  value,
+  note,
+  tone = "text-slate-500 dark:text-slate-400",
+}: {
+  label: string;
+  value: string;
+  note: string;
+  tone?: string;
+}) {
+  return (
+    <div className="rounded-2xl border border-slate-200/70 bg-white/80 px-4 py-3 dark:border-white/10 dark:bg-slate-950/40">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+        {label}
+      </p>
+      <p className="mt-2 text-3xl font-semibold tracking-tight text-slate-950 dark:text-slate-50">
+        {value}
+      </p>
+      <p className={`mt-1 text-sm ${tone}`}>{note}</p>
+    </div>
+  );
+}
+
+export function AIUsageOverviewSection({
+  view,
+}: {
+  view: AIUsageView;
+}) {
+  return (
+    <AdminSurface
+      className="border-transparent bg-transparent shadow-none"
+      contentClassName="space-y-4 px-0 pb-0 pt-1"
+    >
+      <div className="space-y-1">
+        <h1 className="text-[2rem] font-semibold tracking-tight text-slate-950 dark:text-slate-50">
+          AI usage
+        </h1>
+        <p className="max-w-3xl text-sm text-slate-600 dark:text-slate-300">
+          Token volume, budget status, and provider mix for the current school workspace.
+        </p>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+        <SummaryMetric
+          label="Tokens"
+          value={formatCompactNumber(view.totalTokens)}
+          note={view.topProvider ? `${view.topProvider.provider} top source` : "No provider activity yet"}
+        />
+        <SummaryMetric
+          label="Messages"
+          value={formatCompactNumber(view.total_messages)}
+          note="Current aggregate window"
+        />
+        <SummaryMetric
+          label="Budget"
+          value={view.budgetStatus.label}
+          note={formatBudgetWindowLabel(view.budget_period_start, view.budget_period_end)}
+          tone={view.budgetStatus.tone}
+        />
+        <SummaryMetric
+          label="Per learner"
+          value={view.per_student_average_tokens !== null ? formatCompactNumber(view.per_student_average_tokens) : "--"}
+          note={
+            view.per_student_average_cost_usd !== null
+              ? formatUSD(view.per_student_average_cost_usd)
+              : "Token average"
+          }
+        />
+      </div>
+    </AdminSurface>
+  );
+}

--- a/admin/src/components/ai-usage/provider-breakdown-section.tsx
+++ b/admin/src/components/ai-usage/provider-breakdown-section.tsx
@@ -1,0 +1,82 @@
+import { AdminInsetPanel } from "@/components/admin-inset-panel";
+import { AdminSurface, AdminSurfaceHeader } from "@/components/admin-surface";
+import { StatePanel } from "@/components/state-panel";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { formatCompactNumber, formatUSD } from "@/lib/ai-usage.mjs";
+import type { AIUsageView } from "@/components/ai-usage/types";
+
+function ProviderBreakdownTable({
+  view,
+}: {
+  view: AIUsageView;
+}) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Provider</TableHead>
+          <TableHead>Model</TableHead>
+          <TableHead className="text-right">Messages</TableHead>
+          <TableHead className="text-right">Tokens</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {view.providers.map((provider) => (
+          <TableRow key={`${provider.provider}-${provider.model}`}>
+            <TableCell className="font-medium">{provider.provider}</TableCell>
+            <TableCell className="text-muted-foreground">
+              {provider.model || "Default model"}
+            </TableCell>
+            <TableCell className="text-right">{formatCompactNumber(provider.messages)}</TableCell>
+            <TableCell className="text-right">{formatCompactNumber(provider.total_tokens)}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+export function AIUsageProviderBreakdownSection({
+  view,
+}: {
+  view: AIUsageView;
+}) {
+  return (
+    <AdminSurface>
+      <div className="space-y-5">
+        <AdminSurfaceHeader
+          title="Provider breakdown"
+          description="Provider and model mix for the recorded AI traffic in this workspace."
+        />
+
+        {view.providers.length > 0 ? (
+          <ProviderBreakdownTable view={view} />
+        ) : (
+          <StatePanel
+            tone="empty"
+            title="No provider traffic recorded"
+            description="Provider rows will populate after the first successful AI requests for this tenant."
+          />
+        )}
+
+        <div className="grid gap-4 md:grid-cols-3">
+          <AdminInsetPanel title="Monthly cost">
+            <p className="text-lg font-semibold text-slate-950 dark:text-slate-50">
+              {formatUSD(view.monthlyCost)}
+            </p>
+          </AdminInsetPanel>
+          <AdminInsetPanel title="Budget cap (USD)">
+            <p className="text-lg font-semibold text-slate-950 dark:text-slate-50">
+              {view.budgetLimit !== null ? formatUSD(view.budgetLimit) : "Not set"}
+            </p>
+          </AdminInsetPanel>
+          <AdminInsetPanel title="Top provider">
+            <p className="text-lg font-semibold text-slate-950 dark:text-slate-50">
+              {view.topProvider?.provider ?? "None yet"}
+            </p>
+          </AdminInsetPanel>
+        </div>
+      </div>
+    </AdminSurface>
+  );
+}

--- a/admin/src/components/ai-usage/types.ts
+++ b/admin/src/components/ai-usage/types.ts
@@ -1,0 +1,39 @@
+export type AIUsageBudgetStatus = Readonly<{
+  label: string;
+  tone: string;
+}>;
+
+export type AIUsageDailyPoint = Readonly<{
+  date: string;
+  messages: number;
+  tokens: number;
+  cost_usd: number | null;
+}>;
+
+export type AIUsageProvider = Readonly<{
+  provider: string;
+  model: string;
+  messages: number;
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+}>;
+
+export type AIUsageView = Readonly<{
+  totalTokens: number;
+  total_messages: number;
+  topProvider: AIUsageProvider | null;
+  budgetStatus: AIUsageBudgetStatus;
+  budget_period_start: string;
+  budget_period_end: string;
+  per_student_average_tokens: number | null;
+  per_student_average_cost_usd: number | null;
+  budgetTokenLimit: number | null;
+  budgetTokenRemaining: number | null;
+  daily_usage: readonly AIUsageDailyPoint[];
+  hasDailyTrend: boolean;
+  dailyTrendPeak: number;
+  providers: readonly AIUsageProvider[];
+  monthlyCost: number | null;
+  budgetLimit: number | null;
+}>;

--- a/admin/src/lib/navigation.mjs
+++ b/admin/src/lib/navigation.mjs
@@ -14,6 +14,13 @@ export const primaryNavigation = [
     roles: ["teacher", "admin", "platform_admin"],
   },
   {
+    title: "Onboarding",
+    href: "/setup/onboard",
+    description: "Set curriculum, the first class, and the initial bot setup.",
+    group: "Administration",
+    roles: ["admin", "platform_admin"],
+  },
+  {
     title: "Users",
     href: "/settings/users",
     description: "Manage teacher, parent, and admin access plus invite status.",

--- a/admin/src/lib/navigation.mjs
+++ b/admin/src/lib/navigation.mjs
@@ -14,13 +14,6 @@ export const primaryNavigation = [
     roles: ["teacher", "admin", "platform_admin"],
   },
   {
-    title: "Onboarding",
-    href: "/setup/onboard",
-    description: "Set curriculum, first class, and a minimal bot preset for a school workspace.",
-    group: "Administration",
-    roles: ["admin", "platform_admin"],
-  },
-  {
     title: "Users",
     href: "/settings/users",
     description: "Manage teacher, parent, and admin access plus invite status.",
@@ -152,6 +145,14 @@ export function getCurrentSection(pathname) {
     };
   }
 
+  if (pathname.startsWith("/dashboard/ai-usage")) {
+    return {
+      eyebrow: "Administration",
+      title: "AI usage",
+      description: "Track token consumption, provider mix, and tenant budget windows for the current workspace.",
+    };
+  }
+
   const match = primaryNavigation.find((item) => isRouteActive(pathname, item.href));
   if (match) {
     return {
@@ -189,6 +190,13 @@ export function getBreadcrumbs(pathname, user) {
     return [
       { label: "Dashboard", href: "/dashboard" },
       { label: "Classes", href: "/dashboard/classes" },
+    ];
+  }
+
+  if (pathname.startsWith("/dashboard/ai-usage")) {
+    return [
+      { label: "Dashboard", href: "/dashboard" },
+      { label: "AI usage", href: "/dashboard/ai-usage" },
     ];
   }
 

--- a/admin/src/lib/navigation.test.mjs
+++ b/admin/src/lib/navigation.test.mjs
@@ -121,14 +121,14 @@ test("getNavigationForUser keeps elevated navigation for teachers", () => {
 test("getNavigationForUser adds administration links for admins", () => {
   assert.deepEqual(
     getNavigationForUser({ role: "admin", user_id: "admin-1" }).map((item) => item.href),
-    ["/dashboard", "/dashboard/classes", "/settings/users", "/export", "/settings/whatsapp"],
+    ["/dashboard", "/dashboard/classes", "/setup/onboard", "/settings/users", "/export", "/settings/whatsapp"],
   );
 });
 
 test("getNavigationForUser exposes onboarding to platform admins", () => {
   assert.deepEqual(
     getNavigationForUser({ role: "platform_admin", user_id: "platform-admin-1" }).map((item) => item.href),
-    ["/dashboard", "/dashboard/classes", "/settings/users", "/export", "/settings/whatsapp"],
+    ["/dashboard", "/dashboard/classes", "/setup/onboard", "/settings/users", "/export", "/settings/whatsapp"],
   );
 });
 

--- a/admin/src/lib/navigation.test.mjs
+++ b/admin/src/lib/navigation.test.mjs
@@ -60,6 +60,14 @@ test("getCurrentSection returns class management metadata for dashboard classes 
   });
 });
 
+test("getCurrentSection returns AI usage metadata for dashboard ai usage routes", () => {
+  assert.deepEqual(getCurrentSection("/dashboard/ai-usage"), {
+    eyebrow: "Administration",
+    title: "AI usage",
+    description: "Track token consumption, provider mix, and tenant budget windows for the current workspace.",
+  });
+});
+
 test("getCurrentSection returns user management metadata for settings routes", () => {
   assert.deepEqual(getCurrentSection("/settings/users"), {
     eyebrow: "Administration",
@@ -113,14 +121,14 @@ test("getNavigationForUser keeps elevated navigation for teachers", () => {
 test("getNavigationForUser adds administration links for admins", () => {
   assert.deepEqual(
     getNavigationForUser({ role: "admin", user_id: "admin-1" }).map((item) => item.href),
-    ["/dashboard", "/dashboard/classes", "/setup/onboard", "/settings/users", "/export", "/settings/whatsapp"],
+    ["/dashboard", "/dashboard/classes", "/settings/users", "/export", "/settings/whatsapp"],
   );
 });
 
 test("getNavigationForUser exposes onboarding to platform admins", () => {
   assert.deepEqual(
     getNavigationForUser({ role: "platform_admin", user_id: "platform-admin-1" }).map((item) => item.href),
-    ["/dashboard", "/dashboard/classes", "/setup/onboard", "/settings/users", "/export", "/settings/whatsapp"],
+    ["/dashboard", "/dashboard/classes", "/settings/users", "/export", "/settings/whatsapp"],
   );
 });
 
@@ -141,6 +149,13 @@ test("getBreadcrumbs returns class management hierarchy", () => {
   assert.deepEqual(getBreadcrumbs("/dashboard/classes"), [
     { label: "Dashboard", href: "/dashboard" },
     { label: "Classes", href: "/dashboard/classes" },
+  ]);
+});
+
+test("getBreadcrumbs returns AI usage hierarchy", () => {
+  assert.deepEqual(getBreadcrumbs("/dashboard/ai-usage"), [
+    { label: "Dashboard", href: "/dashboard" },
+    { label: "AI usage", href: "/dashboard/ai-usage" },
   ]);
 });
 

--- a/docs/embeddable-chat.md
+++ b/docs/embeddable-chat.md
@@ -1,0 +1,125 @@
+---
+title: "Embeddable Chat Surface"
+summary: "Future-plan note for a tawk.to-style embeddable chat, grounded in what pai-bot already has and what is still missing."
+read_when:
+  - You are discussing an embeddable chat widget for external users, like tawk.to or Intercom.
+  - You need to separate existing chat transport primitives from a real hosted chat widget product.
+  - You are planning iframe chat, website chat embed, or third-party site integration.
+---
+
+# Embeddable Chat Surface
+
+Status:
+
+- future plan
+- not a shipped product surface today
+
+This doc answers a narrower question than "embeddable software":
+
+> does `pai-bot` already have an embeddable chat surface that external websites can use, like `tawk.to`?
+
+Short answer today:
+
+- not yet as a shipped product surface
+- but the backend primitives are partly there
+
+## What exists today
+
+### 1. WebSocket chat transport
+
+There is a working WebSocket channel in the backend:
+
+- `internal/chat/websocket.go`
+- wired in `cmd/server/main.go`
+- exercised by `cmd/terminal-chat/main.go`
+
+What this gives us:
+
+- realtime message send / receive
+- typing events
+- a browser-friendly transport path
+
+What it does **not** give us by itself:
+
+- an embeddable widget
+- a hosted chat launcher bubble
+- an external-site snippet
+- tenant-safe visitor session bootstrap
+
+### 2. Multi-channel runtime
+
+The tutoring runtime already supports multiple channels:
+
+- Telegram
+- WhatsApp
+- WebSocket
+
+That matters because an embedded website chat can be introduced as another surface on the same runtime instead of a separate tutoring backend.
+
+### 3. Public unauthenticated entry
+
+There is already a public route:
+
+- `admin/src/app/join/[slug]/page.tsx`
+- backed by `GET /api/join/{slug}`
+
+That proves public entry is acceptable in the product shape.
+
+But this route is not a chat widget.
+It only exposes class metadata and the join surface scaffold.
+
+## What is missing for a real tawk.to-style embed
+
+Right now the repo does **not** have:
+
+- a JS embed snippet
+- a hosted widget shell
+- an iframe-ready chat app
+- a launcher bubble UI
+- anonymous or visitor identity issuance for external users
+- per-site tenant routing for embeds
+- allowed-origin / host validation for external websites
+- widget events like open, close, unread, ready, or resize
+- conversation persistence rules for external visitors
+- theme / size / placement configuration for host websites
+
+So the truthful statement is:
+
+> `pai-bot` has a realtime transport that could power an embeddable chat, but it does not yet ship a tawk.to-style embedded chat product.
+
+## Future-plan next slice
+
+If the goal is "external users can drop in a small chat widget on their website", the smallest sensible slice is:
+
+1. Hosted widget app
+   - one minimal web chat UI
+   - separate from admin panel
+2. Embed loader
+   - one `<script>` snippet that mounts an iframe
+3. Visitor session bootstrap
+   - issue a tenant-scoped visitor/session token
+4. WebSocket reuse
+   - use existing `websocket` channel instead of inventing another realtime stack
+5. Host controls
+   - allowed origins
+   - widget title
+   - theme
+   - position
+
+## Best current product wording
+
+Use this wording unless the embed is actually built:
+
+> `pai-bot` does not yet have a shipped embeddable chat widget for external websites. It does already have the WebSocket transport and multi-channel runtime needed to build one.
+
+## Proposed first implementation shape
+
+If we build it, the clean first version is:
+
+- `widget.pandai.org/embed.js`
+- host page loads one script
+- script mounts an iframe
+- iframe app talks to backend over existing WebSocket channel
+- backend maps widget session to tenant / school context
+
+That is much closer to `tawk.to` than trying to expose admin pages or the current join route directly.


### PR DESCRIPTION
## Summary
- restore `/dashboard/ai-usage` as a server-first admin page
- add compact AI usage overview, token budget, daily trend, and provider breakdown sections
- remove the Onboarding item from sidebar navigation while keeping direct route support

## Testing
- cd admin && npm run test:unit
- cd admin && npm run lint -- 'src/app/(app)/dashboard/ai-usage/page.tsx' 'src/components/ai-usage/*.tsx' 'src/components/ai-usage/*.ts' 'src/lib/navigation.mjs' 'src/lib/navigation.test.mjs'