### PR TITLE
refine admin landing page

### DIFF
--- a/admin/e2e/smoke.spec.ts
+++ b/admin/e2e/smoke.spec.ts
@@ -10,9 +10,14 @@ test.describe("admin public entry flows", () => {
     await expect(page.getByRole("button", { name: "Sign in" })).toBeVisible();
   });
 
-  test("redirects root path to login and preserves next query parameter", async ({ page }) => {
+  test("keeps the landing page visible and preserves next on the sign-in CTA", async ({ page }) => {
     await page.goto("/?next=/dashboard");
-    await expect(page).toHaveURL(/\/login\?next=%2Fdashboard$/);
+    await expect(page).toHaveURL(/\/\?next=\/dashboard$/);
+    await expect(page.getByRole("heading", { name: "Learn math in chat." })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Sign in" }).first()).toHaveAttribute(
+      "href",
+      "/login?next=%2Fdashboard",
+    );
   });
 
   test("shows mapped auth error message on login when auth_error is present", async ({ page }) => {

--- a/admin/public/landing/student-abstract-scene.svg
+++ b/admin/public/landing/student-abstract-scene.svg
@@ -1,0 +1,25 @@
+<svg width="1600" height="1066" viewBox="0 0 1600 1066" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1600" height="1066" rx="72" fill="#F6F2EC"/>
+  <rect x="68" y="68" width="1464" height="930" rx="52" fill="#FBF8F4" stroke="#E6DED2" stroke-width="4"/>
+  <circle cx="348" cy="300" r="170" fill="#F1E8DB"/>
+  <circle cx="348" cy="300" r="118" fill="#E35B10" fill-opacity="0.14"/>
+  <circle cx="348" cy="300" r="58" fill="#111111"/>
+  <rect x="636" y="166" width="430" height="126" rx="34" fill="#111111"/>
+  <rect x="1122" y="198" width="214" height="62" rx="31" fill="#F1E8DB"/>
+  <rect x="1122" y="198" width="214" height="62" rx="31" stroke="#E6DED2" stroke-width="4"/>
+  <rect x="300" y="498" width="980" height="350" rx="42" fill="#FFFFFF" stroke="#E6DED2" stroke-width="4"/>
+  <rect x="368" y="566" width="462" height="102" rx="30" fill="#F6F2EC"/>
+  <rect x="770" y="700" width="396" height="98" rx="30" fill="#E35B10"/>
+  <rect x="876" y="566" width="292" height="102" rx="30" fill="#111111"/>
+  <path d="M444 619H738" stroke="#D6CCBE" stroke-width="14" stroke-linecap="round"/>
+  <path d="M798 753H1057" stroke="#F5C3AA" stroke-width="14" stroke-linecap="round"/>
+  <path d="M928 619H1100" stroke="#303030" stroke-width="14" stroke-linecap="round"/>
+  <path d="M446 736C540 660 624 640 744 640" stroke="#E35B10" stroke-width="10" stroke-linecap="round"/>
+  <path d="M742 642C864 642 930 694 1016 749" stroke="#111111" stroke-width="10" stroke-linecap="round"/>
+  <circle cx="444" cy="736" r="16" fill="#E35B10"/>
+  <circle cx="1016" cy="749" r="16" fill="#111111"/>
+  <rect x="1240" y="560" width="146" height="146" rx="36" fill="#F1E8DB"/>
+  <path d="M1286 634L1326 594L1360 628" stroke="#E35B10" stroke-width="14" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M1278 760H1358" stroke="#D6CCBE" stroke-width="12" stroke-linecap="round"/>
+  <path d="M300 920H1290" stroke="#E6DED2" stroke-width="4"/>
+</svg>

--- a/admin/public/landing/teacher-abstract-scene.svg
+++ b/admin/public/landing/teacher-abstract-scene.svg
@@ -1,0 +1,33 @@
+<svg width="1600" height="1066" viewBox="0 0 1600 1066" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1600" height="1066" rx="72" fill="#F6F2EC"/>
+  <rect x="68" y="68" width="1464" height="930" rx="52" fill="#FBF8F4" stroke="#E6DED2" stroke-width="4"/>
+  <rect x="176" y="164" width="1248" height="182" rx="42" fill="#FFFFFF" stroke="#E6DED2" stroke-width="4"/>
+  <rect x="232" y="226" width="302" height="58" rx="29" fill="#111111"/>
+  <rect x="576" y="226" width="230" height="58" rx="29" fill="#F1E8DB"/>
+  <rect x="576" y="226" width="230" height="58" rx="29" stroke="#E6DED2" stroke-width="4"/>
+  <rect x="1246" y="214" width="122" height="82" rx="28" fill="#E35B10"/>
+  <rect x="176" y="404" width="770" height="470" rx="42" fill="#FFFFFF" stroke="#E6DED2" stroke-width="4"/>
+  <rect x="1002" y="404" width="422" height="208" rx="42" fill="#FFFFFF" stroke="#E6DED2" stroke-width="4"/>
+  <rect x="1002" y="666" width="422" height="208" rx="42" fill="#FFFFFF" stroke="#E6DED2" stroke-width="4"/>
+  <rect x="240" y="470" width="642" height="86" rx="28" fill="#F6F2EC"/>
+  <rect x="240" y="588" width="642" height="86" rx="28" fill="#F6F2EC"/>
+  <rect x="240" y="706" width="642" height="86" rx="28" fill="#F6F2EC"/>
+  <path d="M286 512H464" stroke="#111111" stroke-width="12" stroke-linecap="round"/>
+  <path d="M286 630H516" stroke="#111111" stroke-width="12" stroke-linecap="round"/>
+  <path d="M286 748H500" stroke="#111111" stroke-width="12" stroke-linecap="round"/>
+  <path d="M286 538H446" stroke="#B2A693" stroke-width="10" stroke-linecap="round"/>
+  <path d="M286 656H468" stroke="#B2A693" stroke-width="10" stroke-linecap="round"/>
+  <path d="M286 774H452" stroke="#B2A693" stroke-width="10" stroke-linecap="round"/>
+  <rect x="744" y="488" width="92" height="50" rx="25" fill="#FADFD2"/>
+  <rect x="744" y="606" width="92" height="50" rx="25" fill="#F1E8DB"/>
+  <rect x="744" y="724" width="92" height="50" rx="25" fill="#FADFD2"/>
+  <path d="M1058 474H1204" stroke="#111111" stroke-width="12" stroke-linecap="round"/>
+  <path d="M1058 524H1368" stroke="#E6DED2" stroke-width="16" stroke-linecap="round"/>
+  <path d="M1058 524H1148" stroke="#E35B10" stroke-width="16" stroke-linecap="round"/>
+  <path d="M1058 742H1368" stroke="#E6DED2" stroke-width="16" stroke-linecap="round"/>
+  <path d="M1058 742H1286" stroke="#111111" stroke-width="16" stroke-linecap="round"/>
+  <path d="M1058 790H1368" stroke="#E6DED2" stroke-width="16" stroke-linecap="round"/>
+  <path d="M1058 790H1118" stroke="#B2A693" stroke-width="16" stroke-linecap="round"/>
+  <path d="M1058 838H1368" stroke="#E6DED2" stroke-width="16" stroke-linecap="round"/>
+  <path d="M1058 838H1332" stroke="#E35B10" stroke-width="16" stroke-linecap="round"/>
+</svg>

--- a/admin/src/app/page.test.tsx
+++ b/admin/src/app/page.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+import RootPage from "./page";
+
+const { getServerAuthSessionMock, getServerPostAuthPathMock } = vi.hoisted(() => ({
+  getServerAuthSessionMock: vi.fn(),
+  getServerPostAuthPathMock: vi.fn(),
+}));
+
+vi.mock("@/lib/server-api", () => ({
+  getServerAuthSession: getServerAuthSessionMock,
+  getServerPostAuthPath: getServerPostAuthPathMock,
+}));
+
+describe("RootPage", () => {
+  beforeEach(() => {
+    getServerAuthSessionMock.mockReset();
+    getServerPostAuthPathMock.mockReset();
+  });
+
+  it("renders the landing page with login CTA for signed-out visitors", async () => {
+    getServerAuthSessionMock.mockResolvedValue(null);
+
+    render(await RootPage({ searchParams: Promise.resolve({}) }));
+
+    expect(screen.getByRole("heading", { name: /learn math in chat\./i })).toBeInTheDocument();
+    expect(screen.getAllByRole("link", { name: "Sign in" })[0]).toHaveAttribute("href", "/login");
+    expect(getServerPostAuthPathMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps the landing page visible and points signed-in users to their workspace", async () => {
+    getServerAuthSessionMock.mockResolvedValue({
+      user: {
+        user_id: "teacher-1",
+        tenant_id: "tenant-1",
+        role: "teacher",
+        name: "Teacher",
+        email: "teacher@example.com",
+      },
+    });
+    getServerPostAuthPathMock.mockResolvedValue("/dashboard");
+
+    render(await RootPage({ searchParams: Promise.resolve({ next: "/dashboard/classes" }) }));
+
+    expect(screen.getAllByRole("link", { name: "Open workspace" })[0]).toHaveAttribute("href", "/dashboard");
+    expect(screen.queryByRole("link", { name: "Sign in" })).not.toBeInTheDocument();
+    expect(getServerPostAuthPathMock).toHaveBeenCalledWith(
+      expect.objectContaining({ role: "teacher" }),
+      "/dashboard/classes",
+    );
+  });
+});

--- a/admin/src/app/page.test.tsx
+++ b/admin/src/app/page.test.tsx
@@ -28,6 +28,18 @@ describe("RootPage", () => {
     expect(getServerPostAuthPathMock).not.toHaveBeenCalled();
   });
 
+  it("preserves next for signed-out visitors", async () => {
+    getServerAuthSessionMock.mockResolvedValue(null);
+
+    render(await RootPage({ searchParams: Promise.resolve({ next: "/dashboard/classes" }) }));
+
+    expect(screen.getAllByRole("link", { name: "Sign in" })[0]).toHaveAttribute(
+      "href",
+      "/login?next=%2Fdashboard%2Fclasses",
+    );
+    expect(getServerPostAuthPathMock).not.toHaveBeenCalled();
+  });
+
   it("keeps the landing page visible and points signed-in users to their workspace", async () => {
     getServerAuthSessionMock.mockResolvedValue({
       user: {

--- a/admin/src/app/page.tsx
+++ b/admin/src/app/page.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from "next";
-import { redirect } from "next/navigation";
+import { RootLandingPage } from "@/components/landing/root-landing-page";
 import { getServerAuthSession, getServerPostAuthPath } from "@/lib/server-api";
 import { hasAdminUIAccess } from "@/lib/rbac.mjs";
 
 export const dynamic = "force-dynamic";
 export const metadata: Metadata = {
-  title: "P&AI Admin",
-  description: "Teacher and parent dashboard for P&AI Bot.",
+  title: "P&AI Bot | WhatsApp and Telegram learning support",
+  description: "Students chat with the bot in WhatsApp and Telegram while teachers see weak topics and follow-up needs.",
 };
 
 type RootPageProps = {
@@ -17,14 +17,23 @@ export default async function RootPage({ searchParams }: RootPageProps) {
   const { next } = await searchParams;
   const session = await getServerAuthSession();
   const currentUser = session?.user ?? null;
-
-  if (currentUser && hasAdminUIAccess(currentUser)) {
-    redirect(await getServerPostAuthPath(currentUser, next ?? null));
-  }
-
   const loginURL = new URL("/login", "http://localhost");
+
   if (next) {
     loginURL.searchParams.set("next", next);
   }
-  redirect(`${loginURL.pathname}${loginURL.search}`);
+
+  const loginHref = `${loginURL.pathname}${loginURL.search}`;
+  const hasWorkspaceAccess = Boolean(currentUser && hasAdminUIAccess(currentUser));
+  const primaryHref = hasWorkspaceAccess
+    ? await getServerPostAuthPath(currentUser!, next ?? null)
+    : loginHref;
+
+  return (
+    <RootLandingPage
+      primaryHref={primaryHref}
+      primaryLabel={hasWorkspaceAccess ? "Open workspace" : "Sign in"}
+      signedInLabel={hasWorkspaceAccess ? "Signed in" : null}
+    />
+  );
 }

--- a/admin/src/components/landing/landing-audience-showcase.test.tsx
+++ b/admin/src/components/landing/landing-audience-showcase.test.tsx
@@ -1,0 +1,29 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { LandingAudienceShowcase } from "./landing-audience-showcase";
+
+describe("LandingAudienceShowcase", () => {
+  it("switches between student and teacher landing views", async () => {
+    render(
+      <LandingAudienceShowcase
+        primaryHref="/login"
+        primaryActionLabel="Sign in"
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", {
+        name: /learn math in chat\./i,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /stay with the problem\./i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: /teachers/i }));
+
+    expect(
+      await screen.findByRole("heading", {
+        name: /see the next follow-up\./i,
+      }),
+    ).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: /follow-up, in order\./i })).toBeInTheDocument();
+  });
+});

--- a/admin/src/components/landing/landing-audience-showcase.tsx
+++ b/admin/src/components/landing/landing-audience-showcase.tsx
@@ -1,0 +1,521 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { ArrowRight } from "lucide-react";
+import { Card } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+const landingButtonClassName =
+  "inline-flex shrink-0 items-center justify-center whitespace-nowrap transition-all outline-none focus-visible:ring-3 focus-visible:ring-ring/30";
+
+const landingPrimaryButtonClassName =
+  "h-12 rounded-full bg-primary px-6 text-sm font-semibold text-primary-foreground shadow-[0_12px_30px_color-mix(in_oklch,var(--primary)_18%,transparent)] hover:bg-primary/90 active:translate-y-px";
+
+type AudienceKey = "student" | "teacher";
+type Tone = "destructive" | "secondary" | "primary";
+
+type ChatTurn = {
+  speaker: "Student" | "Bot";
+  body: string;
+};
+
+type Stat = {
+  label: string;
+  value: string;
+};
+
+type Intervention = {
+  name: string;
+  topic: string;
+  score: string;
+  tone: Tone;
+};
+
+type TopicScore = {
+  name: string;
+  value: number;
+  tone: Tone;
+};
+
+type AudienceFrame = {
+  tabLabel: string;
+  heroTitle: string;
+  heroBody: string;
+  imageSrc: string;
+  imageAlt: string;
+  panelTitle: string;
+};
+
+type StudentAudienceView = AudienceFrame & {
+  summaryStats: Stat[];
+  chatLabel: string;
+  chatTurns: ChatTurn[];
+};
+
+type TeacherAudienceView = AudienceFrame & {
+  summaryStats: Stat[];
+  interventions: Intervention[];
+  topicScores: TopicScore[];
+};
+
+const audienceViews = {
+  student: {
+    tabLabel: "Students",
+    heroTitle: "Learn math in chat.",
+    heroBody: "Ask. See the steps. Ask again.",
+    imageSrc: "/landing/student-abstract-scene.svg",
+    imageAlt: "Abstract chat learning visual with message blocks and step-by-step flow.",
+    panelTitle: "Stay with the problem.",
+    summaryStats: [
+      { label: "Channel", value: "WhatsApp / Telegram" },
+      { label: "Style", value: "Step by step" },
+      { label: "Flow", value: "Same thread" },
+    ],
+    chatLabel: "Functions",
+    chatTurns: [
+      { speaker: "Student", body: "How do I solve 3x + 5 = 20?" },
+      { speaker: "Bot", body: "Subtract 5 first. What is 20 - 5?" },
+      { speaker: "Student", body: "15" },
+      { speaker: "Bot", body: "Good. Now divide by 3. So x = 5." },
+    ],
+  },
+  teacher: {
+    tabLabel: "Teachers",
+    heroTitle: "See the next follow-up.",
+    heroBody: "Weak chats. Weak topics. Clear follow-up.",
+    imageSrc: "/landing/teacher-abstract-scene.svg",
+    imageAlt: "Abstract school dashboard visual with queues, score bars, and follow-up signals.",
+    panelTitle: "Follow-up, in order.",
+    summaryStats: [
+      { label: "Needs help", value: "3 students" },
+      { label: "Weakest topic", value: "Functions" },
+      { label: "Coverage", value: "12 / 12 filled" },
+    ],
+    interventions: [
+      { name: "Alya Sofea", topic: "WhatsApp • Functions", score: "30%", tone: "destructive" },
+      { name: "Hakim Firdaus", topic: "Telegram • Inequalities", score: "21%", tone: "secondary" },
+      { name: "Mei Lin", topic: "WhatsApp • Linear equations", score: "92%", tone: "primary" },
+    ],
+    topicScores: [
+      { name: "Functions", value: 30, tone: "destructive" },
+      { name: "Inequalities", value: 21, tone: "secondary" },
+      { name: "Linear equations", value: 92, tone: "primary" },
+    ],
+  },
+} satisfies {
+  student: StudentAudienceView;
+  teacher: TeacherAudienceView;
+};
+
+type AudienceView = StudentAudienceView | TeacherAudienceView;
+
+function LandingSurface({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <Card
+      className={cn(
+        "overflow-hidden rounded-[32px] border border-border/80 bg-card shadow-[0_16px_44px_color-mix(in_oklch,var(--foreground)_6%,transparent)] ring-1 ring-foreground/5 backdrop-blur",
+        className,
+      )}
+    >
+      {children}
+    </Card>
+  );
+}
+
+function AudienceSwitch({
+  activeAudience,
+  onChange,
+}: {
+  activeAudience: AudienceKey;
+  onChange: (value: AudienceKey) => void;
+}) {
+  return (
+    <div className="flex justify-center">
+      <div
+        className="inline-flex rounded-full border border-foreground/10 bg-foreground/[0.05] p-1 shadow-[0_16px_36px_color-mix(in_oklch,var(--foreground)_6%,transparent)] backdrop-blur"
+        role="tablist"
+        aria-label="Landing audience"
+      >
+        {(Object.entries(audienceViews) as [AudienceKey, AudienceView][]).map(([key, audience]) => {
+          const isActive = key === activeAudience;
+
+          return (
+            <button
+              key={key}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              aria-controls={`${key}-panel`}
+              onClick={() => onChange(key)}
+              className={cn(
+                "relative min-w-[7.25rem] rounded-full px-4 py-2 text-sm font-medium transition focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:outline-none",
+                isActive ? "text-background" : "text-foreground/58 hover:text-foreground",
+              )}
+            >
+              {isActive ? (
+                <motion.span
+                  layoutId="landing-audience-pill"
+                  className="absolute inset-0 rounded-full bg-foreground shadow-[0_8px_22px_color-mix(in_oklch,var(--foreground)_18%,transparent)]"
+                  transition={{ type: "spring", stiffness: 320, damping: 30 }}
+                />
+              ) : null}
+              <span className="relative z-10">{audience.tabLabel}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function AudienceImage({ src, alt }: { src: string; alt: string }) {
+  return (
+    <div className="space-y-4">
+      <div className="overflow-hidden rounded-[28px] border border-border/80 bg-background/80">
+        <motion.div layout transition={{ type: "spring", stiffness: 220, damping: 26 }}>
+          <Image src={src} alt={alt} width={1152} height={768} className="h-auto w-full object-cover" />
+        </motion.div>
+      </div>
+    </div>
+  );
+}
+
+function SummaryList({ items }: { items: Stat[] }) {
+  return (
+    <div className="grid gap-3 md:grid-cols-3">
+      {items.map((item, index) => (
+        <motion.div
+          key={item.label}
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.06 * index, duration: 0.24 }}
+          className="rounded-[22px] border border-border/80 bg-background/72 px-4 py-4"
+        >
+          <p className="text-[11px] font-semibold tracking-[0.16em] uppercase text-muted-foreground">{item.label}</p>
+          <p className="mt-2 text-lg font-semibold tracking-[-0.03em] text-foreground">{item.value}</p>
+        </motion.div>
+      ))}
+    </div>
+  );
+}
+
+function LiveThreadBadge() {
+  return (
+    <div className="inline-flex items-center gap-2 rounded-full border border-border/70 bg-background/70 px-3 py-1 text-xs font-medium text-muted-foreground">
+      <motion.span
+        aria-hidden="true"
+        className="size-2 rounded-full bg-primary"
+        animate={{ opacity: [0.35, 1, 0.35], scale: [0.92, 1.18, 0.92] }}
+        transition={{ duration: 1.6, repeat: Infinity, ease: "easeInOut" }}
+      />
+      Live thread
+    </div>
+  );
+}
+
+function TypingDots() {
+  return (
+    <div className="flex items-center gap-1.5">
+      {[0, 1, 2].map((dot) => (
+        <motion.span
+          key={dot}
+          className="size-1.5 rounded-full bg-current/50"
+          animate={{ opacity: [0.3, 1, 0.3], y: [0, -1.5, 0] }}
+          transition={{ duration: 1.1, delay: dot * 0.12, repeat: Infinity, ease: "easeInOut" }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ChatBubble({
+  turn,
+  index,
+  isLast,
+}: {
+  turn: ChatTurn;
+  index: number;
+  isLast: boolean;
+}) {
+  const isStudent = turn.speaker === "Student";
+
+  return (
+    <motion.div
+      key={`${turn.speaker}-${index}`}
+      initial={{ opacity: 0, y: 18, x: isStudent ? 16 : -16, scale: 0.98 }}
+      animate={{ opacity: 1, y: 0, x: 0, scale: 1 }}
+      transition={{ delay: 0.08 * index, duration: 0.34, ease: [0.22, 1, 0.36, 1] }}
+      className={cn(
+        "max-w-[88%] rounded-[20px] px-4 py-3 text-sm leading-6 shadow-[0_10px_26px_color-mix(in_oklch,var(--foreground)_4%,transparent)]",
+        isStudent
+          ? "ml-auto bg-primary text-primary-foreground"
+          : "bg-card text-foreground ring-1 ring-border/70",
+      )}
+    >
+      <p className="text-[11px] font-semibold tracking-[0.16em] uppercase opacity-70">{turn.speaker}</p>
+      <p className="mt-1">{turn.body}</p>
+      {!isStudent && isLast ? <div className="mt-3 text-muted-foreground"><TypingDots /></div> : null}
+    </motion.div>
+  );
+}
+
+function ChatTranscript({ turns, label }: { turns: ChatTurn[]; label: string }) {
+  return (
+    <div className="relative overflow-hidden rounded-[26px] border border-border/80 bg-background/72 p-4">
+      <motion.div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-y-0 left-0 w-24 bg-[linear-gradient(90deg,color-mix(in_oklch,var(--primary)_7%,transparent),transparent)]"
+        animate={{ x: ["-18%", "132%"] }}
+        transition={{ duration: 1.8, ease: "easeInOut", repeat: Infinity, repeatDelay: 2.8 }}
+      />
+
+      <div className="relative flex items-center justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold text-foreground">Example student chat</p>
+          <p className="text-sm text-muted-foreground">{label}</p>
+        </div>
+        <LiveThreadBadge />
+      </div>
+
+      <div className="relative mt-4 flex flex-col gap-3">
+        {turns.map((turn, index) => (
+          <ChatBubble
+            key={`${turn.speaker}-${index}`}
+            turn={turn}
+            index={index}
+            isLast={index === turns.length - 1}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function InterventionRow({ item }: { item: Intervention }) {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-[20px] border border-border/70 bg-background/90 px-4 py-3">
+      <div>
+        <p className="font-medium text-foreground">{item.name}</p>
+        <p className="text-sm text-muted-foreground">{item.topic}</p>
+      </div>
+      <div
+        className={cn(
+          "rounded-full px-3 py-1 text-sm font-semibold",
+          item.tone === "destructive" && "bg-destructive/12 text-destructive",
+          item.tone === "secondary" && "bg-secondary text-secondary-foreground",
+          item.tone === "primary" && "bg-primary/12 text-primary",
+        )}
+      >
+        {item.score}
+      </div>
+    </div>
+  );
+}
+
+function TopicScoreList({ items }: { items: TopicScore[] }) {
+  return (
+    <div className="rounded-[26px] border border-border/80 bg-background/72 p-5">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-sm font-semibold text-foreground">Topic scores</p>
+        <div className="rounded-full border border-border/70 bg-background/70 px-3 py-1 text-xs font-medium text-muted-foreground">
+          12 / 12 filled
+        </div>
+      </div>
+
+      <div className="mt-4 flex flex-col gap-3">
+        {items.map((item) => (
+          <div key={item.name} className="flex flex-col gap-2">
+            <div className="flex items-center justify-between gap-3 text-sm">
+              <span className="font-medium text-foreground">{item.name}</span>
+              <span className="text-muted-foreground">{item.value}%</span>
+            </div>
+            <div className="h-2 rounded-full bg-muted">
+              <motion.div
+                initial={{ width: 0 }}
+                animate={{ width: `${item.value}%` }}
+                transition={{ duration: 0.45, ease: "easeOut" }}
+                className={cn(
+                  "h-2 rounded-full",
+                  item.tone === "destructive" && "bg-destructive",
+                  item.tone === "secondary" && "bg-foreground/45",
+                  item.tone === "primary" && "bg-primary",
+                )}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TeacherInterventionList({
+  items,
+  primaryHref,
+}: {
+  items: Intervention[];
+  primaryHref: string;
+}) {
+  return (
+    <div className="rounded-[26px] border border-border/80 bg-background/72 p-4">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold text-foreground">Chats to follow up with</p>
+        </div>
+        <Link href={primaryHref} className="inline-flex items-center gap-2 text-sm font-semibold text-primary hover:text-primary/80">
+          Open workspace
+          <ArrowRight className="h-4 w-4" />
+        </Link>
+      </div>
+
+      <div className="mt-4 flex flex-col gap-3">
+        {items.map((item) => (
+          <InterventionRow key={item.name} item={item} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function AudiencePanelFrame({
+  panelId,
+  audience,
+  primaryHref,
+  primaryActionLabel,
+  children,
+}: {
+  panelId: string;
+  audience: AudienceFrame;
+  primaryHref: string;
+  primaryActionLabel: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <motion.section
+      key={panelId}
+      id={panelId}
+      initial={{ opacity: 0, y: 14 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -10 }}
+      transition={{ duration: 0.28, ease: [0.22, 1, 0.36, 1] }}
+      className="space-y-8"
+    >
+      <div className="mt-7 flex flex-col gap-3">
+        <h1 className="text-5xl leading-[0.9] font-semibold tracking-[-0.07em] text-balance sm:text-6xl lg:text-[5.6rem]">
+          {audience.heroTitle}
+        </h1>
+        <p className="mx-auto max-w-md text-lg leading-8 text-muted-foreground">{audience.heroBody}</p>
+      </div>
+
+      <div className="mt-7 flex items-center justify-center">
+        <Link href={primaryHref} className={cn(landingButtonClassName, landingPrimaryButtonClassName)}>
+          {primaryActionLabel}
+        </Link>
+      </div>
+
+      <section className="pb-8">
+        <LandingSurface className="rounded-[36px] border-border/80 bg-card p-6 shadow-[0_14px_36px_color-mix(in_oklch,var(--foreground)_5%,transparent)]">
+          <div className="grid gap-6 lg:grid-cols-[minmax(0,0.98fr)_minmax(0,1.02fr)]">
+            <AudienceImage src={audience.imageSrc} alt={audience.imageAlt} />
+
+            <div className="space-y-4 text-left">
+              <div className="max-w-xl">
+                <h2 className="text-[2.15rem] leading-tight font-semibold tracking-[-0.06em]">{audience.panelTitle}</h2>
+              </div>
+
+              {children}
+            </div>
+          </div>
+        </LandingSurface>
+      </section>
+    </motion.section>
+  );
+}
+
+function StudentAudiencePanel({
+  audience,
+  primaryHref,
+  primaryActionLabel,
+}: {
+  audience: StudentAudienceView;
+  primaryHref: string;
+  primaryActionLabel: string;
+}) {
+  return (
+    <AudiencePanelFrame
+      panelId="student-panel"
+      audience={audience}
+      primaryHref={primaryHref}
+      primaryActionLabel={primaryActionLabel}
+    >
+      <ChatTranscript turns={audience.chatTurns} label={audience.chatLabel} />
+      <SummaryList items={audience.summaryStats} />
+    </AudiencePanelFrame>
+  );
+}
+
+function TeacherAudiencePanel({
+  audience,
+  primaryHref,
+  primaryActionLabel,
+}: {
+  audience: TeacherAudienceView;
+  primaryHref: string;
+  primaryActionLabel: string;
+}) {
+  return (
+    <AudiencePanelFrame
+      panelId="teacher-panel"
+      audience={audience}
+      primaryHref={primaryHref}
+      primaryActionLabel={primaryActionLabel}
+    >
+      <TeacherInterventionList items={audience.interventions} primaryHref={primaryHref} />
+      <SummaryList items={audience.summaryStats} />
+      <TopicScoreList items={audience.topicScores} />
+    </AudiencePanelFrame>
+  );
+}
+
+export function LandingAudienceShowcase({
+  primaryHref,
+  primaryActionLabel,
+}: {
+  primaryHref: string;
+  primaryActionLabel: string;
+}) {
+  const [activeAudience, setActiveAudience] = useState<AudienceKey>("student");
+
+  return (
+    <div className="space-y-8">
+      <AudienceSwitch activeAudience={activeAudience} onChange={setActiveAudience} />
+
+      <AnimatePresence mode="wait" initial={false}>
+        {activeAudience === "student" ? (
+          <StudentAudiencePanel
+            key="student"
+            audience={audienceViews.student}
+            primaryHref={primaryHref}
+            primaryActionLabel={primaryActionLabel}
+          />
+        ) : (
+          <TeacherAudiencePanel
+            key="teacher"
+            audience={audienceViews.teacher}
+            primaryHref={primaryHref}
+            primaryActionLabel={primaryActionLabel}
+          />
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/admin/src/components/landing/root-landing-page.tsx
+++ b/admin/src/components/landing/root-landing-page.tsx
@@ -1,0 +1,72 @@
+import Link from "next/link";
+import { Bot } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { LandingAudienceShowcase } from "@/components/landing/landing-audience-showcase";
+
+const landingButtonClassName =
+  "inline-flex shrink-0 items-center justify-center whitespace-nowrap transition-all outline-none focus-visible:ring-3 focus-visible:ring-ring/30";
+
+const landingHeaderPrimaryButtonClassName =
+  "h-9 rounded-full bg-primary px-5 text-sm font-semibold text-primary-foreground shadow-[0_10px_24px_color-mix(in_oklch,var(--primary)_16%,transparent)] hover:bg-primary/90 active:translate-y-px";
+
+export function RootLandingPage({
+  primaryHref,
+  primaryLabel,
+  signedInLabel,
+}: {
+  primaryHref: string;
+  primaryLabel: string;
+  signedInLabel: string | null;
+}) {
+  const primaryActionLabel = signedInLabel ? "Open workspace" : primaryLabel;
+
+  return (
+    <main className="relative min-h-[100dvh] overflow-hidden bg-background text-foreground">
+      <div className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[28rem] bg-[linear-gradient(180deg,color-mix(in_oklch,var(--primary)_12%,transparent)_0%,transparent_72%)]" />
+      <div className="pointer-events-none absolute left-[8%] top-20 -z-10 size-72 rounded-full bg-primary/8 blur-3xl" />
+      <div className="pointer-events-none absolute right-[10%] top-40 -z-10 size-80 rounded-full bg-secondary blur-3xl opacity-45" />
+
+      <div className="mx-auto flex min-h-[100dvh] max-w-7xl flex-col px-6 py-0 sm:px-8 lg:px-10">
+        <header className="mt-5 flex items-center justify-between gap-6 rounded-full border border-border/80 bg-background/92 px-5 py-3 shadow-[0_10px_28px_color-mix(in_oklch,var(--foreground)_5%,transparent)] backdrop-blur">
+          <div className="flex items-center gap-3">
+            <div className="flex size-11 items-center justify-center rounded-2xl bg-primary text-primary-foreground">
+              <Bot className="size-5" />
+            </div>
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.28em] text-primary">P&amp;AI Bot</p>
+              <p className="text-sm font-medium text-muted-foreground">Math chatbot for WhatsApp, Telegram, and schools</p>
+            </div>
+          </div>
+          <Link
+            href={primaryHref}
+            className={cn(landingButtonClassName, landingHeaderPrimaryButtonClassName)}
+          >
+            {primaryActionLabel}
+          </Link>
+        </header>
+
+        <section className="py-14 lg:py-18">
+          <div className="mx-auto max-w-5xl text-center">
+            <LandingAudienceShowcase
+              primaryHref={primaryHref}
+              primaryActionLabel={primaryActionLabel}
+              signedInLabel={signedInLabel}
+            />
+          </div>
+        </section>
+
+        <footer className="mt-auto border-t border-border/80 py-8">
+          <div className="flex flex-col gap-5 text-sm text-muted-foreground md:flex-row md:items-center md:justify-between">
+            <div className="flex flex-col gap-1">
+              <p className="font-medium text-foreground">P&amp;AI Bot</p>
+              <p>Math chatbot for WhatsApp, Telegram, and schools.</p>
+            </div>
+            <Link href={primaryHref} className="transition hover:text-foreground">
+              {primaryActionLabel}
+            </Link>
+          </div>
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/admin/src/components/landing/root-landing-page.tsx
+++ b/admin/src/components/landing/root-landing-page.tsx
@@ -50,7 +50,6 @@ export function RootLandingPage({
             <LandingAudienceShowcase
               primaryHref={primaryHref}
               primaryActionLabel={primaryActionLabel}
-              signedInLabel={signedInLabel}
             />
           </div>
         </section>

--- a/docs/admin-panel-uiux.md
+++ b/docs/admin-panel-uiux.md
@@ -162,9 +162,23 @@ The admin shell provides a persistent sidebar (desktop) or collapsible menu (mob
 
 ---
 
+## Landing Page
+
+**Route:** `/`
+**Access:** All roles
+**Status:** Implemented
+
+The root route is now a real landing page instead of a redirect shim. It should explain the product in product language, show a concrete intervention-oriented snapshot, and keep login as an explicit next step rather than embedding the auth form directly into the landing experience.
+
+**Interactions:**
+- Signed-out users land on `/` and move to `/login` through CTA buttons
+- Signed-in users can still view `/`, but the main CTA routes them into their role-safe workspace
+- Keep the hero outcome-oriented: early intervention, mastery drift, family follow-up, rollout visibility
+- Use a clear visual difference between landing and auth so `/login` feels like a deliberate entry point, not a slightly different hero state
+
 ## Login Page
 
-**Routes:** `/`, `/login`
+**Route:** `/login`
 **Access:** All roles (unauthenticated)
 **Status:** Implemented
 
@@ -200,7 +214,7 @@ Current shell note:
 └───────────────────────────────────────────────────┘
 ```
 
-The root route `/` is now redirect-only. It sends signed-in users to their role-safe default route and sends signed-out users to `/login`. `/login` remains the direct auth URL and renders the login layout.
+`/login` remains the direct auth URL and renders the login layout. It should stay focused on authentication only.
 
 **Interactions:**
 - On success → redirect to the role-appropriate workspace

--- a/docs/admin-panel.md
+++ b/docs/admin-panel.md
@@ -9,7 +9,7 @@ read_when:
 
 # Admin / Management Panel — Feature Specification
 
-> **Status:** Partially implemented. Current shipped scope includes the public gate (`/`), direct login (`/login`), teacher dashboard (`/dashboard`), class dashboard, student detail, parent summary, and onboarding. AI usage and token-budget administration remain out of the current slice even though backend budget APIs still exist. Remaining sections below stay planned until implemented.
+> **Status:** Partially implemented. Current shipped scope includes the public landing page (`/`), direct login (`/login`), teacher dashboard (`/dashboard`), class dashboard, student detail, parent summary, and onboarding. AI usage and token-budget administration remain out of the current slice even though backend budget APIs still exist. Remaining sections below stay planned until implemented.
 >
 > **Stack:** Next.js 16 (App Router) · TypeScript · shadcn/ui · Tailwind CSS 4 · TanStack Query v5 · Recharts/Tremor
 
@@ -42,7 +42,7 @@ This document describes all planned features for the P&AI Bot admin panel, organ
 | `platform_admin` | Multi-tenant management + all admin features | Web (admin panel) |
 
 ---
-The root route `/` now resolves immediately to the role-safe workspace when a session exists, otherwise it redirects to `/login`.
+The root route `/` now stays public as a landing page. Its primary CTA routes signed-in users to their role-safe workspace and routes signed-out users to `/login`.
 
 ## Authentication & Authorization
 
@@ -53,7 +53,7 @@ Detailed runtime reference:
 ### Flow
 
 1. **Enter** — User lands on `/` or `/login`
-   Root `/` redirects to `/login` when no session exists
+   Root `/` stays public and sends users onward only through its CTA
 2. **Login** — Email + password, or `Continue with Google` for linked Google identities and exact single-account verified-email matches. Google workspace/domain restriction is code-level auth policy, not env; current admin wiring limits Google login to `pandai.org`.
 3. **Resolve tenant when needed** — If the same email belongs to more than one school, the backend returns `tenant_required` and the UI asks the user to choose the school before retrying sign-in. Google callback flows do not silently pick a tenant when the email maps to multiple schools.
 4. **Link sign-in methods** — Authenticated admins can link Google from the signed-in workspace shell. Same-email auto-linking is limited to exact one-account matches; different-email Google accounts require an explicit authenticated link flow.


### PR DESCRIPTION
## Summary
This PR brings back the admin landing page on `/` as a real public entry surface instead of the previous redirect-only behavior. It separates product discovery from authentication, keeps `/login` focused on sign-in, and gives signed-in users a direct path back into their workspace without forcing the root route to behave like a hidden redirect.

## Problem
The root route had been acting as a transport layer rather than a product surface. Signed-out users were immediately pushed into `/login`, which meant there was no public page explaining what the admin product is, who it is for, or how the WhatsApp / Telegram learning workflow should be understood before authentication.

For users, that created two problems. First, the product had no proper landing experience at its natural entry point. Second, login and landing were visually and conceptually collapsed into one flow, so `/login` did not feel like a deliberate authentication screen; it felt like the only way to learn what the product does.

## Root Cause
The root route implementation in `admin/src/app/page.tsx` was still built around redirect logic. That design made sense when `/` was treated as a gate, but it prevented the admin app from having a public-facing entry surface. The supporting docs also still described `/` as redirect-only, so the route contract and product intent were aligned around the old behavior.

## Fix
This PR changes `/` from a redirect shim into a landing page while preserving role-safe workspace entry.

The implementation introduces a dedicated landing composition under `admin/src/components/landing/`. The page now:
- keeps `/` public
- routes signed-out users to `/login` through explicit CTAs
- routes signed-in users to their role-safe workspace through the primary CTA
- keeps `/login` as the auth-only route

The landing itself is structured around two explicit audience variants, `Students` and `Teachers`, instead of one mode-heavy component. It uses a shared frame with audience-specific content so the student and teacher stories remain distinct as the page evolves. The visual proof section was also moved to abstract SVG imagery instead of literal photo scenes, which keeps the page more product-shaped and less illustrative.

Within the student slice, the chat proof surface now has lightweight motion to make the interaction feel active without becoming noisy. The summary block beneath it was simplified from dense rows into lighter stat tiles so the information scans faster.

The follow-up fix commit included here also removes a stale prop mismatch between the landing wrapper and the audience showcase, and adds coverage for preserving the signed-out `next` query string on the login CTA.

## Docs
The admin panel docs were updated to reflect the new route contract:
- `/` is now a public landing page
- `/login` remains the direct authentication route
- the root CTA behavior differs depending on whether a valid admin session exists

## Validation
I verified the landing slice with:
- `npm run lint -- src/components/landing/root-landing-page.tsx src/components/landing/landing-audience-showcase.tsx src/components/landing/landing-audience-showcase.test.tsx src/app/page.tsx src/app/page.test.tsx`
- `npx vitest run src/app/page.test.tsx src/components/landing/landing-audience-showcase.test.tsx --config vitest.config.mjs --configLoader native --pool threads --maxWorkers 1`

I also checked the page live in Helium during iteration to confirm the audience switch, proof surfaces, copy density, and CTA behavior matched the intended split between landing and login.