### PR TITLE
fix: bot forgets topic after /learn on vague follow-ups

### DIFF
--- a/internal/agent/context_resolver.go
+++ b/internal/agent/context_resolver.go
@@ -11,6 +11,37 @@ import (
 	"github.com/p-n-ai/pai-bot/internal/retrieval"
 )
 
+// vagueContinuationTokens are short affirmations or prompts that don't introduce
+// a new subject and should keep the conversation's active topic in context.
+var vagueContinuationTokens = map[string]struct{}{
+	"ok": {}, "okay": {}, "okey": {}, "yes": {}, "yeah": {}, "yup": {}, "yep": {},
+	"ya": {}, "baik": {}, "boleh": {}, "setuju": {}, "sure": {}, "done": {}, "siap": {},
+	"continue": {}, "teruskan": {}, "lanjut": {}, "go": {}, "proceed": {}, "more": {},
+	"thanks": {}, "thank": {}, "terima": {}, "kasih": {}, "tq": {},
+}
+
+// isVagueContinuation reports whether the given message is a short
+// acknowledgment or generic follow-up that should not displace the
+// conversation's active topic. It returns true when the message either
+// has no content-bearing tokens or every token is a known generic
+// follow-up / acknowledgment token.
+func isVagueContinuation(text string) bool {
+	tokens := tokenizeRetrievalText(text)
+	if len(tokens) == 0 {
+		return true
+	}
+	for _, token := range tokens {
+		if _, ok := genericFollowUpTokens[token]; ok {
+			continue
+		}
+		if _, ok := vagueContinuationTokens[token]; ok {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
 // ContextResolver resolves curriculum context for a user message.
 // It returns a matched topic and optional teaching notes.
 // Returning nil topic and empty notes means "no curriculum match".

--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -306,27 +306,26 @@ func (e *Engine) ProcessMessage(ctx context.Context, msg chat.InboundMessage) (s
 	e.maybeCompact(ctx, conv)
 
 	matchedTopic, teachingNotes := e.resolveCurriculumContext(msg.UserID, conv.TopicID, msg.Text)
-	if matchedTopic != nil && matchedTopic.ID != "" && matchedTopic.ID != conv.TopicID {
-		if err := e.store.UpdateConversationTopicID(conv.ID, matchedTopic.ID); err != nil {
-			slog.Warn("failed to persist matched topic", "conversation_id", conv.ID, "topic_id", matchedTopic.ID, "error", err)
-		} else {
-			conv.TopicID = matchedTopic.ID
-		}
-	}
-	// Fallback: if lexical retrieval did not match but the conversation already
-	// has an active topic (set via /learn or a prior match) and the user's
-	// message is a vague acknowledgment or generic follow-up, reuse the stored
-	// topic so the bot does not "forget" the current topic on replies like
-	// "ok" or "what's next". We intentionally skip this when the message has
-	// content-bearing terms, so an explicit off-topic request still falls
-	// through to a clean topic-less prompt.
-	if matchedTopic == nil && conv.TopicID != "" && e.curriculumLoader != nil && isVagueContinuation(msg.Text) {
+
+	// Guard: if the message is a vague continuation ("ok", "whats next", etc.)
+	// and the conversation already has a stored topic, always prefer the stored
+	// topic — even if the retriever matched a different topic (e.g. "next"
+	// matching "Patterns and Sequences" via assessment items).
+	vague := isVagueContinuation(msg.Text)
+	if vague && conv.TopicID != "" && e.curriculumLoader != nil {
 		if stored, ok := e.curriculumLoader.GetTopic(conv.TopicID); ok {
 			topicCopy := stored
 			matchedTopic = &topicCopy
 			if notes, ok := e.curriculumLoader.GetTeachingNotes(conv.TopicID); ok {
 				teachingNotes = notes
 			}
+		}
+	} else if matchedTopic != nil && matchedTopic.ID != "" && matchedTopic.ID != conv.TopicID {
+		// Non-vague message matched a different topic — update the conversation.
+		if err := e.store.UpdateConversationTopicID(conv.ID, matchedTopic.ID); err != nil {
+			slog.Warn("failed to persist matched topic", "conversation_id", conv.ID, "topic_id", matchedTopic.ID, "error", err)
+		} else {
+			conv.TopicID = matchedTopic.ID
 		}
 	}
 	replyCount := countTutoringReplies(conv.Messages) + 1

--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -313,6 +313,22 @@ func (e *Engine) ProcessMessage(ctx context.Context, msg chat.InboundMessage) (s
 			conv.TopicID = matchedTopic.ID
 		}
 	}
+	// Fallback: if lexical retrieval did not match but the conversation already
+	// has an active topic (set via /learn or a prior match) and the user's
+	// message is a vague acknowledgment or generic follow-up, reuse the stored
+	// topic so the bot does not "forget" the current topic on replies like
+	// "ok" or "what's next". We intentionally skip this when the message has
+	// content-bearing terms, so an explicit off-topic request still falls
+	// through to a clean topic-less prompt.
+	if matchedTopic == nil && conv.TopicID != "" && e.curriculumLoader != nil && isVagueContinuation(msg.Text) {
+		if stored, ok := e.curriculumLoader.GetTopic(conv.TopicID); ok {
+			topicCopy := stored
+			matchedTopic = &topicCopy
+			if notes, ok := e.curriculumLoader.GetTeachingNotes(conv.TopicID); ok {
+				teachingNotes = notes
+			}
+		}
+	}
 	replyCount := countTutoringReplies(conv.Messages) + 1
 	promptRequested := shouldRequestRatingAfterReply(replyCount, e.ratingPromptEvery)
 

--- a/internal/agent/engine_test.go
+++ b/internal/agent/engine_test.go
@@ -1207,6 +1207,59 @@ func TestEngine_ProcessMessage_PersistsMatchedTopicForFollowUps(t *testing.T) {
 	}
 }
 
+// Regression: after a topic is set on the conversation (via /learn or a prior
+// lexical match), subsequent vague messages like "ok" or "what's next" should
+// not cause the bot to forget the topic. The stored topic must still be
+// injected into the system prompt as TOPIC CONTEXT.
+func TestEngine_ProcessMessage_InjectsStoredTopicContextForVagueFollowUp(t *testing.T) {
+	mockAI := ai.NewMockProvider("ok")
+	store := agent.NewMemoryStore()
+	loader := createTestCurriculumLoader(t)
+
+	engine := agent.NewEngine(agent.EngineConfig{
+		AIRouter:         mockRouter(mockAI),
+		Store:            store,
+		CurriculumLoader: loader,
+	})
+
+	_, err := engine.ProcessMessage(context.Background(), chat.InboundMessage{
+		Channel: "telegram",
+		UserID:  "vague-user",
+		Text:    "/learn linear equations",
+	})
+	if err != nil {
+		t.Fatalf("ProcessMessage(/learn) error = %v", err)
+	}
+
+	conv, ok := store.GetActiveConversation("vague-user")
+	if !ok {
+		t.Fatal("expected active conversation after /learn")
+	}
+	if conv.TopicID != "F1-02" {
+		t.Fatalf("conv.TopicID after /learn = %q, want F1-02", conv.TopicID)
+	}
+
+	_, err = engine.ProcessMessage(context.Background(), chat.InboundMessage{
+		Channel: "telegram",
+		UserID:  "vague-user",
+		Text:    "ok",
+	})
+	if err != nil {
+		t.Fatalf("ProcessMessage(ok) error = %v", err)
+	}
+
+	systemPrompt := mockAI.LastRequest.Messages[0].Content
+	if !contains(systemPrompt, "TOPIC CONTEXT") {
+		t.Fatalf("expected TOPIC CONTEXT in system prompt after vague reply, got: %s", systemPrompt)
+	}
+	if !contains(systemPrompt, "F1-02") {
+		t.Fatalf("expected stored topic ID F1-02 in system prompt, got: %s", systemPrompt)
+	}
+	if !contains(systemPrompt, "Treat the equation like a balance") {
+		t.Fatalf("expected stored teaching notes in system prompt, got: %s", systemPrompt)
+	}
+}
+
 func TestEngine_ClearClearsHistory(t *testing.T) {
 	mockAI := ai.NewMockProvider("Response")
 

--- a/internal/agent/learn.go
+++ b/internal/agent/learn.go
@@ -5,14 +5,18 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"log/slog"
 	"strings"
 
+	"github.com/p-n-ai/pai-bot/internal/ai"
 	"github.com/p-n-ai/pai-bot/internal/chat"
+	"github.com/p-n-ai/pai-bot/internal/curriculum"
 	"github.com/p-n-ai/pai-bot/internal/i18n"
 )
 
-func (e *Engine) handleLearnCommand(_ context.Context, msg chat.InboundMessage, args []string) (string, error) {
+func (e *Engine) handleLearnCommand(ctx context.Context, msg chat.InboundMessage, args []string) (string, error) {
 	locale := e.messageLocale(msg, nil)
 
 	if len(args) == 0 {
@@ -31,8 +35,16 @@ func (e *Engine) handleLearnCommand(_ context.Context, msg chat.InboundMessage, 
 
 	raw := strings.Join(args, " ")
 
-	// Resolve topic from text.
+	// Resolve topic from text via lexical retrieval.
 	topic, _ := e.resolveCurriculumContext(msg.UserID, "", raw)
+
+	// Fallback: if lexical retrieval missed (e.g. typos), ask AI to fuzzy-match.
+	if topic == nil && e.curriculumLoader != nil && e.aiRouter != nil {
+		if matched := e.aiMatchTopic(ctx, raw); matched != nil {
+			topic = matched
+		}
+	}
+
 	if topic == nil {
 		return i18n.S(locale, i18n.MsgLearnTopicNotFound, raw), nil
 	}
@@ -72,5 +84,92 @@ func (e *Engine) handleLearnCommand(_ context.Context, msg chat.InboundMessage, 
 		},
 	})
 
-	return i18n.S(locale, i18n.MsgLearnTopicSet, topic.Name), nil
+	// Store the /learn exchange in conversation history so subsequent AI
+	// calls see that a topic was just set and a learning session started.
+	response := i18n.S(locale, i18n.MsgLearnTopicSet, topic.Name)
+	if _, err := e.store.AddMessage(conv.ID, StoredMessage{
+		Role:    "user",
+		Content: msg.Text,
+	}); err != nil {
+		slog.Error("failed to store /learn user message", "error", err)
+	}
+	if _, err := e.store.AddMessage(conv.ID, StoredMessage{
+		Role:    "assistant",
+		Content: response,
+	}); err != nil {
+		slog.Error("failed to store /learn response", "error", err)
+	}
+
+	return response, nil
+}
+
+// aiMatchTopic uses a cheap AI model to fuzzy-match user input (possibly with
+// typos) against the list of available topic IDs and names.
+func (e *Engine) aiMatchTopic(ctx context.Context, userInput string) *curriculum.Topic {
+	topics := e.curriculumLoader.AllTopics()
+	if len(topics) == 0 {
+		return nil
+	}
+
+	// Build a compact topic list for the prompt.
+	var topicList strings.Builder
+	for _, t := range topics {
+		fmt.Fprintf(&topicList, "- %s: %s\n", t.ID, t.Name)
+	}
+
+	type matchResult struct {
+		TopicID string `json:"topic_id"`
+	}
+
+	prompt := fmt.Sprintf(`The user typed: %q
+
+Available topics:
+%s
+Match the user's input to the most likely topic from the list above.
+The user may have typos or use abbreviations. Pick the best match.
+If nothing is remotely close, return an empty topic_id.
+
+Return JSON: {"topic_id": "<ID>"}`, userInput, topicList.String())
+
+	schema, _ := json.Marshal(map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"topic_id": map[string]any{"type": "string"},
+		},
+		"required":             []string{"topic_id"},
+		"additionalProperties": false,
+	})
+
+	var result matchResult
+	_, err := e.aiRouter.CompleteJSON(ctx, ai.CompletionRequest{
+		Messages:  []ai.Message{{Role: "user", Content: prompt}},
+		Task:      ai.TaskGrading, // cheap model
+		MaxTokens: 64,
+		StructuredOutput: &ai.StructuredOutputSpec{
+			Name:       "topic_match",
+			JSONSchema: schema,
+			Strict:     true,
+		},
+	}, &result)
+	if err != nil {
+		slog.Warn("AI topic match failed", "error", err, "input", userInput)
+		return nil
+	}
+
+	if result.TopicID == "" {
+		return nil
+	}
+
+	matched, ok := e.curriculumLoader.GetTopic(result.TopicID)
+	if !ok {
+		slog.Warn("AI returned unknown topic ID", "topic_id", result.TopicID, "input", userInput)
+		return nil
+	}
+
+	slog.Info("AI fuzzy-matched topic",
+		"input", userInput,
+		"matched_id", matched.ID,
+		"matched_name", matched.Name,
+	)
+	return &matched
 }

--- a/internal/ai/provider_openai.go
+++ b/internal/ai/provider_openai.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 )
 
 const (
@@ -83,11 +84,12 @@ func NewDeepSeekProvider(apiKey string, opts ...OpenAIOption) *OpenAIProvider {
 
 // openaiRequest is the request body for the OpenAI chat completions API.
 type openaiRequest struct {
-	Model          string                `json:"model"`
-	Messages       []openaiMessage       `json:"messages"`
-	ResponseFormat *openaiResponseFormat `json:"response_format,omitempty"`
-	MaxTokens      int                   `json:"max_tokens,omitempty"`
-	Temperature    *float64              `json:"temperature,omitempty"`
+	Model               string                `json:"model"`
+	Messages            []openaiMessage       `json:"messages"`
+	ResponseFormat      *openaiResponseFormat `json:"response_format,omitempty"`
+	MaxTokens           int                   `json:"max_tokens,omitempty"`
+	MaxCompletionTokens int                   `json:"max_completion_tokens,omitempty"`
+	Temperature         *float64              `json:"temperature,omitempty"`
 }
 
 type openaiMessage struct {
@@ -141,7 +143,13 @@ func (p *OpenAIProvider) Complete(ctx context.Context, req CompletionRequest) (C
 		Messages: buildOpenAIMessages(req.Messages),
 	}
 	if req.MaxTokens > 0 {
-		oaiReq.MaxTokens = req.MaxTokens
+		// Newer OpenAI models (o1+, gpt-5+) reject max_tokens and require
+		// max_completion_tokens instead.
+		if needsMaxCompletionTokens(model) {
+			oaiReq.MaxCompletionTokens = req.MaxTokens
+		} else {
+			oaiReq.MaxTokens = req.MaxTokens
+		}
 	}
 	if req.Temperature > 0 {
 		temp := req.Temperature
@@ -224,6 +232,21 @@ func applyOpenAIStructuredOutput(providerName string, oaiReq *openaiRequest, spe
 		},
 	}
 	return nil
+}
+
+// needsMaxCompletionTokens returns true for model families that reject the
+// legacy max_tokens parameter and require max_completion_tokens instead.
+func needsMaxCompletionTokens(model string) bool {
+	switch {
+	case strings.HasPrefix(model, "o1"),
+		strings.HasPrefix(model, "o3"),
+		strings.HasPrefix(model, "o4"),
+		strings.HasPrefix(model, "gpt-4.1"),
+		strings.HasPrefix(model, "gpt-5"):
+		return true
+	default:
+		return false
+	}
 }
 
 func buildOpenAIMessages(messages []Message) []openaiMessage {


### PR DESCRIPTION
## Summary
- **AI fuzzy-match for `/learn`**: when lexical retrieval misses due to typos (e.g. "pechan algrebra" → "pecahan algebra"), falls back to a cheap AI model to match against the full topic list
- **Store `/learn` exchange in conversation history**: the bot's "Topic set…" response was invisible to subsequent AI calls, so the model didn't know a learning session had just started — now both the command and response are stored as messages
- **Prefer stored topic for vague messages**: for follow-ups like "ok" or "whats next", always use the conversation's stored TopicID instead of letting the retriever spuriously match a different topic (e.g. "next" matching "Patterns and Sequences")
- **OpenAI `max_completion_tokens`**: fix gpt-5.4+ models rejecting the legacy `max_tokens` parameter

## Test plan
- [x] Unit test: `TestEngine_ProcessMessage_InjectsStoredTopicContextForVagueFollowUp`
- [x] Existing tests: `DoesNotReuseActiveTopicForExplicitOffTopicFollowUp` still passes (off-topic requests don't reuse stored topic)
- [x] `go test ./...` all green
- [x] Live Telegram test: `/learn pemfaktoran dan pechan algrebra` → fuzzy matched correctly, "whats next" stays on Factorisation topic

🤖 Generated with [Claude Code](https://claude.com/claude-code)