### PR TITLE
fix: start early /healthz listener to prevent deploy rollbacks

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -52,6 +52,19 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Start an early health endpoint so Docker/K8s health checks pass while
+	// the rest of the application initialises (curriculum seeding, retrieval
+	// indexing, Telegram sync, etc. can take >60 s on small instances).
+	earlyHealth := &http.Server{
+		Addr:    fmt.Sprintf(":%d", cfg.Server.Port),
+		Handler: http.HandlerFunc(handleHealthz),
+	}
+	go func() {
+		if err := earlyHealth.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			slog.Error("early health server error", "error", err)
+		}
+	}()
+
 	// Initialize AI router with configured providers.
 	router := setupAIRouter(cfg)
 	if !router.HasProvider() {
@@ -245,12 +258,6 @@ func main() {
 		}
 	}
 
-	err = gw.StartAll(ctx, handleInbound)
-	if err != nil {
-		slog.Error("failed to start channels", "error", err)
-		os.Exit(1)
-	}
-
 	authService := auth.NewPostgresService(
 		db.Pool,
 		defaultSessionTTL,
@@ -332,6 +339,12 @@ func main() {
 	}
 	topMux.Handle("/", apiHandler)
 
+	// Shut down the early health-only listener before binding the full server
+	// on the same port.
+	if err := earlyHealth.Close(); err != nil {
+		slog.Warn("early health server close", "error", err)
+	}
+
 	addr := fmt.Sprintf(":%d", cfg.Server.Port)
 	srv := &http.Server{
 		Addr:         addr,
@@ -343,11 +356,19 @@ func main() {
 
 	go func() {
 		slog.Info("server starting", "addr", srv.Addr)
-		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			slog.Error("server error", "error", err)
 			os.Exit(1)
 		}
 	}()
+
+	// Start chat channels after the HTTP server is listening so /healthz is
+	// available immediately.  Telegram's syncCommands (60 s timeout) would
+	// otherwise block the health check window.
+	if err := gw.StartAll(ctx, handleInbound); err != nil {
+		slog.Error("failed to start channels", "error", err)
+		os.Exit(1)
+	}
 
 	slog.Info("P&AI Bot is running")
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -17,6 +17,7 @@ import (
 	"os/signal"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -52,16 +53,27 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Start an early health endpoint so Docker/K8s health checks pass while
-	// the rest of the application initialises (curriculum seeding, retrieval
-	// indexing, Telegram sync, etc. can take >60 s on small instances).
-	earlyHealth := &http.Server{
-		Addr:    fmt.Sprintf(":%d", cfg.Server.Port),
-		Handler: http.HandlerFunc(handleHealthz),
+	// Start the HTTP server immediately with only /healthz so Docker/K8s
+	// health checks pass while the rest of the application initialises
+	// (curriculum seeding, retrieval indexing, Telegram sync can take >60 s
+	// on small instances).  The handler is atomically swapped to the full
+	// mux once initialisation completes.
+	var handler atomic.Value
+	handler.Store(http.HandlerFunc(handleHealthz))
+	srv := &http.Server{
+		Addr: fmt.Sprintf(":%d", cfg.Server.Port),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			handler.Load().(http.Handler).ServeHTTP(w, r)
+		}),
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 30 * time.Second,
+		IdleTimeout:  60 * time.Second,
 	}
 	go func() {
-		if err := earlyHealth.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			slog.Error("early health server error", "error", err)
+		slog.Info("server starting", "addr", srv.Addr)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			slog.Error("server error", "error", err)
+			os.Exit(1)
 		}
 	}()
 
@@ -339,32 +351,11 @@ func main() {
 	}
 	topMux.Handle("/", apiHandler)
 
-	// Shut down the early health-only listener before binding the full server
-	// on the same port.
-	if err := earlyHealth.Close(); err != nil {
-		slog.Warn("early health server close", "error", err)
-	}
+	// Atomically swap to the full handler — no port gap, no reconnect.
+	handler.Store(topMux)
+	slog.Info("full handler active")
 
-	addr := fmt.Sprintf(":%d", cfg.Server.Port)
-	srv := &http.Server{
-		Addr:         addr,
-		Handler:      topMux,
-		ReadTimeout:  10 * time.Second,
-		WriteTimeout: 30 * time.Second,
-		IdleTimeout:  60 * time.Second,
-	}
-
-	go func() {
-		slog.Info("server starting", "addr", srv.Addr)
-		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			slog.Error("server error", "error", err)
-			os.Exit(1)
-		}
-	}()
-
-	// Start chat channels after the HTTP server is listening so /healthz is
-	// available immediately.  Telegram's syncCommands (60 s timeout) would
-	// otherwise block the health check window.
+	// Start chat channels now that the full HTTP handler is live.
 	if err := gw.StartAll(ctx, handleInbound); err != nil {
 		slog.Error("failed to start channels", "error", err)
 		os.Exit(1)

--- a/internal/retrieval/curriculum_seed.go
+++ b/internal/retrieval/curriculum_seed.go
@@ -37,14 +37,15 @@ func SeedCurriculum(service *Service, loader *curriculum.Loader) error {
 		return fmt.Errorf("upsert curriculum source: %w", err)
 	}
 
+	// Collect all documents first, then bulk-upsert so the BM25 index is
+	// rebuilt once instead of after every insert (O(N) vs O(N²)).
+	var docs []UpsertDocumentInput
+
 	for _, topic := range loader.AllTopics() {
 		subject, _ := loader.GetSubject(topic.SubjectID)
 		syllabus, _ := loader.GetSyllabus(topic.SyllabusID)
 		form := inferTopicForm(topic, subject)
 
-		// Step 2: create or update the collection that scopes this topic's
-		// material. Right now we use subject-level collections so search can be
-		// narrowed without hard-coding curriculum logic into the service.
 		collectionID := topic.SubjectID
 		if collectionID == "" {
 			collectionID = topic.SyllabusID
@@ -82,10 +83,7 @@ func SeedCurriculum(service *Service, loader *curriculum.Loader) error {
 			"form":        form,
 		}
 
-		// Step 3: store normalized curriculum documents.
-		// We keep topic cards, teaching-note sections, and assessment items as
-		// separate searchable records so BM25 can rank the most relevant chunk.
-		if _, err := service.UpsertDocument(UpsertDocumentInput{
+		docs = append(docs, UpsertDocumentInput{
 			ID:           "topic:" + topic.ID,
 			CollectionID: collectionID,
 			Kind:         "topic_card",
@@ -96,13 +94,11 @@ func SeedCurriculum(service *Service, loader *curriculum.Loader) error {
 			SourceType:   "curriculum",
 			Metadata:     withKind(baseMetadata, "topic_card"),
 			Source:       "curriculum",
-		}); err != nil {
-			return fmt.Errorf("upsert topic document %s: %w", topic.ID, err)
-		}
+		})
 
 		if notes, ok := loader.GetTeachingNotes(topic.ID); ok && strings.TrimSpace(notes) != "" {
 			for i, section := range splitTeachingNoteSections(notes) {
-				if _, err := service.UpsertDocument(UpsertDocumentInput{
+				docs = append(docs, UpsertDocumentInput{
 					ID:           "note:" + topic.ID + ":" + strconv.Itoa(i),
 					CollectionID: collectionID,
 					Kind:         "teaching_note",
@@ -113,15 +109,13 @@ func SeedCurriculum(service *Service, loader *curriculum.Loader) error {
 					SourceType:   "curriculum",
 					Metadata:     withKind(baseMetadata, "teaching_note"),
 					Source:       "curriculum",
-				}); err != nil {
-					return fmt.Errorf("upsert note document %s: %w", topic.ID, err)
-				}
+				})
 			}
 		}
 
 		if assessment, ok := loader.GetAssessment(topic.ID); ok {
 			for i, question := range assessment.Questions {
-				if _, err := service.UpsertDocument(UpsertDocumentInput{
+				docs = append(docs, UpsertDocumentInput{
 					ID:           "assessment:" + topic.ID + ":" + strconv.Itoa(i),
 					CollectionID: collectionID,
 					Kind:         "assessment_item",
@@ -132,11 +126,13 @@ func SeedCurriculum(service *Service, loader *curriculum.Loader) error {
 					SourceType:   "curriculum",
 					Metadata:     withKind(baseMetadata, "assessment_item"),
 					Source:       "curriculum",
-				}); err != nil {
-					return fmt.Errorf("upsert assessment document %s: %w", topic.ID, err)
-				}
+				})
 			}
 		}
+	}
+
+	if _, err := service.BulkUpsertDocuments(docs); err != nil {
+		return fmt.Errorf("bulk upsert curriculum documents: %w", err)
 	}
 
 	return nil

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -352,9 +352,32 @@ func (s *Service) UpsertDocument(req UpsertDocumentInput) (Document, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Step 2 in the generic model: once the caller knows the source and
-	// collection, it writes a normalized document here. The service owns the
-	// indexing details and rebuilds the BM25 state after each mutation.
+	doc, err := s.upsertDocumentLocked(req)
+	if err != nil {
+		return Document{}, err
+	}
+	s.rebuildIndexLocked()
+	return doc, nil
+}
+
+// BulkUpsertDocuments inserts many documents and rebuilds the index once at
+// the end instead of after every insert.  This turns O(N²) seeding into O(N).
+func (s *Service) BulkUpsertDocuments(reqs []UpsertDocumentInput) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for i, req := range reqs {
+		if _, err := s.upsertDocumentLocked(req); err != nil {
+			return i, err
+		}
+	}
+	s.rebuildIndexLocked()
+	return len(reqs), nil
+}
+
+// upsertDocumentLocked writes a single document without rebuilding the index.
+// Caller must hold s.mu.
+func (s *Service) upsertDocumentLocked(req UpsertDocumentInput) (Document, error) {
 	if strings.TrimSpace(req.Kind) == "" || strings.TrimSpace(req.Title) == "" {
 		return Document{}, fmt.Errorf("%w: document kind and title are required", ErrInvalidArgument)
 	}
@@ -389,7 +412,6 @@ func (s *Service) UpsertDocument(req UpsertDocumentInput) (Document, error) {
 		document.Active = true
 	}
 	s.documents[id] = document
-	s.rebuildIndexLocked()
 	return cloneDocument(document), nil
 }
 


### PR DESCRIPTION
## Summary
- App initialization (curriculum seeding, retrieval indexing, Telegram `syncCommands`) takes ~90s on t3.small, exceeding the deploy script's 60s health check window → rollback every deploy
- Start a minimal `/healthz` HTTP server immediately after config validation (~1s into startup), replacing it with the full server once all initialization completes
- Move `gw.StartAll()` after the full HTTP server starts so Telegram's 60s API timeout doesn't block health checks

## Root cause
Traced via SSH (EC2 Instance Connect) to the live server. Logs showed a 89-second gap between `curriculum ready` and `prerequisite graph built` — the app was healthy but the deploy script had already rolled back.

## Test plan
- [x] `go build ./cmd/server/` passes
- [x] `go test ./cmd/server/ -short` passes
- [ ] Deploy pipeline should now pass health checks within seconds instead of timing out

🤖 Generated with [Claude Code](https://claude.com/claude-code)