### PR TITLE
fix(terraform): add lifecycle guard to prevent instance destruction

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -117,7 +117,7 @@ resource "aws_instance" "app" {
   root_block_device {
     volume_size = var.volume_size_gb
     volume_type = "gp3"
-    encrypted   = true
+    encrypted   = false # existing instance was launched unencrypted
   }
 
   metadata_options {
@@ -128,6 +128,12 @@ resource "aws_instance" "app" {
   user_data = templatefile("${path.module}/user-data.sh", {
     app_dir = var.app_dir
   })
+
+  # Prevent Terraform from destroying/recreating the instance when AMI
+  # or user-data changes. These only apply at launch time anyway.
+  lifecycle {
+    ignore_changes = [ami, user_data]
+  }
 
   tags = {
     Name    = "${var.project}-server"


### PR DESCRIPTION
## Summary
- Add `lifecycle { ignore_changes = [ami, user_data] }` to the EC2 instance to prevent Terraform from destroying the running server when a new Ubuntu AMI is published or user-data changes
- Fix `encrypted` flag to `false` to match the existing instance (was `true` in config but `false` on the live instance, which would also force replacement)

## Context
After losing the Terraform state file, we recovered via `terraform import`. Without these guards, `terraform plan` wanted to destroy and recreate the instance due to AMI drift and the encrypted mismatch. Both fields only apply at launch time anyway.

## Test plan
- [x] `terraform plan` shows 0 to destroy after import
- [x] `terraform apply` succeeded — instance untouched, new key pair created

🤖 Generated with [Claude Code](https://claude.com/claude-code)