### PR TITLE
chore(curriculum): update OSS curriculum pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,7 +668,7 @@ See [docs/ops/setup.md](docs/ops/setup.md) for development environment setup.
 
 | Repository | Description |
 |-----------|-------------|
-| [p-n-ai/oss](https://github.com/p-n-ai/oss) | Open School Syllabus — structured curriculum data for any learning platform |
+| [p-n-ai/oss](https://github.com/p-n-ai/oss) | Open School Syllabus — structured curriculum data for any learning platform. See [docs/curriculum-oss.md](docs/curriculum-oss.md) for how pai-bot consumes it. |
 | [p-n-ai/oss-bot](https://github.com/p-n-ai/oss-bot) | GitHub bot + CLI tools for contributing to Open School Syllabus |
 
 ---

--- a/docs/curriculum-oss.md
+++ b/docs/curriculum-oss.md
@@ -1,0 +1,163 @@
+---
+summary: How Open School Syllabus (OSS) feeds pai-bot curriculum, quiz, retrieval, progress, and admin surfaces.
+read_when:
+  - You are changing curriculum loading, topic matching, quiz assessment flow, retrieval seeding, or OSS submodule wiring.
+  - You need to explain what belongs in p-n-ai/oss versus this repo.
+---
+
+# OSS Curriculum Relationship
+
+## Purpose
+
+Open School Syllabus (OSS) is the curriculum source. This repo is the product runtime.
+
+In practice:
+
+- `p-n-ai/oss` owns structured syllabus content: syllabi, subjects, topics, teaching notes, prerequisites, and assessments.
+- `pai-bot` owns how students, teachers, and admins experience that content through chat, quizzes, progress tracking, retrieval, and the admin panel.
+
+Keep curriculum facts in OSS. Keep product behavior in this repo.
+
+## Current Wiring
+
+OSS is registered as a Git submodule at `oss/`:
+
+```text
+.gitmodules -> path = oss, url = https://github.com/p-n-ai/oss.git
+```
+
+The default curriculum path is `./oss`, configurable through:
+
+```bash
+LEARN_CURRICULUM_PATH=/path/to/oss
+```
+
+Current checkout note: if `git submodule status` shows a leading `-`, the submodule is not initialized and `oss/` may be empty. Initialize it before running curriculum-backed flows:
+
+```bash
+git submodule update --init oss
+```
+
+To move this repo to the latest OSS commit from the configured remote branch:
+
+```bash
+git submodule update --remote oss
+```
+
+That updates the checked-out submodule content; commit the changed submodule pointer in this repo when the product should pin that OSS revision.
+
+## Loader Contract
+
+`internal/curriculum/loader.go` walks the configured curriculum directory at startup and loads supported files into memory:
+
+| OSS file pattern | pai-bot use |
+| --- | --- |
+| `syllabus.yaml` / `syllabus.yml` | Top-level syllabus metadata |
+| `subject.yaml` / `subject.yml` | Subject metadata and topic list |
+| `*.yaml` / `*.yml` | Topic cards, except known non-topic files |
+| `*.teaching.md` | Teaching notes paired with a same-name topic YAML file |
+| `*.assessments.yaml` / `*.assessments.yml` | Quiz assessment questions for one topic |
+
+Loaded data maps into `internal/curriculum/types.go`:
+
+- `Syllabus`
+- `Subject`
+- `Topic`
+- `Assessment`
+- `AssessmentQuestion`
+
+The server currently treats curriculum load failure as non-fatal: it logs a warning and keeps the app alive. That lets non-curriculum routes work, but curriculum context, quiz assessment lookup, and curriculum retrieval will be degraded or unavailable.
+
+## Runtime Flow
+
+At boot, `cmd/server/main.go` creates `curriculum.NewLoader(cfg.CurriculumPath)`.
+
+If the loader succeeds, this repo uses OSS content in four main places:
+
+1. Chat teaching context
+
+   `internal/agent` resolves a user message to a curriculum topic, fetches teaching notes, and injects topic context into the tutor response path.
+
+2. Quiz mode
+
+   `internal/agent/quiz_router.go` starts and runs quizzes from `*.assessments.yaml` questions. Current quiz grading is deterministic for OSS-backed answers.
+
+3. Retrieval seed
+
+   `internal/retrieval/curriculum_seed.go` turns loaded curriculum into retrieval records:
+
+   - source: `source:curriculum`
+   - collections: `curriculum:<subject-or-syllabus-id>`
+   - documents: `topic:<topic-id>`, `note:<topic-id>:<section>`, `assessment:<topic-id>:<index>`
+
+   This is why curriculum is now one retrieval source type, not the whole retrieval architecture.
+
+4. Progress and motivation
+
+   Progress, goals, topic unlocks, challenges, and mastery records use OSS identifiers such as `syllabus_id` and `topic_id` to stay tied to curriculum content.
+
+## Boundary
+
+Change OSS when the work is about curriculum truth:
+
+- official syllabus references
+- topic names and learning objectives
+- prerequisite relationships
+- teaching notes
+- assessment questions, rubrics, hints, and distractors
+- content provenance or quality level
+
+Change this repo when the work is about product behavior:
+
+- how topics are matched from student messages
+- how prompts use teaching notes
+- quiz routing, grading behavior, XP, streaks, or state handling
+- retrieval indexing/search behavior
+- admin APIs and UI around curriculum
+- database schema for progress, goals, or challenges
+
+If a product behavior depends on a new curriculum field, update OSS first or in the same branch/PR chain, then update `internal/curriculum/types.go`, loader tests, and the consuming feature here.
+
+## Current Versus Planned
+
+Current:
+
+- OSS is wired as a submodule at `oss/`.
+- `LEARN_CURRICULUM_PATH` controls where pai-bot loads curriculum from.
+- The loader reads YAML topics, subjects, syllabi, teaching notes, and assessment files from the filesystem.
+- Chat context, quiz mode, retrieval seeding, progress, goals, topic unlocks, and challenges can use loaded OSS identifiers/content.
+- The submodule may be uninitialized in a fresh checkout; initialize it explicitly.
+
+Planned or incomplete:
+
+- Hot reload is described in older architecture docs but is not implemented in the current loader.
+- Dragonfly-backed curriculum cache is described in older architecture docs but the current loader is in-memory.
+- "Add curriculum in OSS and pai-bot automatically picks it up" is only true after the deployed repo updates its `oss` submodule pointer or points `LEARN_CURRICULUM_PATH` at the new content.
+- Dynamic AI question generation from sparse OSS assessments is planned; current quiz mode primarily uses OSS-backed assessment YAML.
+
+## Safe Change Checklist
+
+Before changing curriculum integration:
+
+1. Check current repo state:
+
+   ```bash
+   git status --short --branch
+   git submodule status
+   ```
+
+2. Initialize OSS if needed:
+
+   ```bash
+   git submodule update --init oss
+   ```
+
+3. Inspect the relevant OSS files and this repo's loader/types before editing contracts.
+
+4. Add or update tests for loader, topic matching, quiz assessment behavior, or retrieval seeding.
+
+5. Run the repo gate before handoff:
+
+   ```bash
+   just test-all
+   ```

--- a/docs/technical-plan.md
+++ b/docs/technical-plan.md
@@ -680,11 +680,13 @@ make docker                          # Docker image
 
 P&AI Bot consumes curriculum data from the [Open School Syllabus (OSS)](https://github.com/p-n-ai/oss) repository. The integration works as follows:
 
-1. **Git submodule** — OSS is included as a Git submodule at `curriculum/`
-2. **Loader** — `internal/curriculum/loader.go` reads YAML files at startup and caches parsed curriculum in memory + Dragonfly
-3. **Hot reload** — A filesystem watcher detects changes to curriculum files and reloads without restart
-4. **Go types** — `internal/curriculum/types.go` defines Go structs that mirror the OSS JSON Schema (Syllabus, Subject, Topic, Assessment, TeachingNotes)
-5. **No code changes needed** — Adding a new curriculum to OSS automatically makes it available in P&AI
+1. **Git submodule** — OSS is included as a Git submodule at `oss/`
+2. **Loader** — `internal/curriculum/loader.go` reads YAML files at startup and caches parsed curriculum in memory
+3. **Go types** — `internal/curriculum/types.go` defines Go structs for loaded syllabi, subjects, topics, teaching notes, and assessments
+4. **Retrieval seed** — `internal/retrieval/curriculum_seed.go` turns curriculum into retrieval source, collection, and document records
+5. **Pinned updates** — Adding or changing curriculum in OSS becomes available after the deployed repo updates its `oss` submodule pointer or points `LEARN_CURRICULUM_PATH` at the new content
+
+See [curriculum-oss.md](curriculum-oss.md) for the current boundary between OSS content and pai-bot runtime behavior.
 
 ---
 


### PR DESCRIPTION
## Summary

Updates pai-bot to pin the latest OSS curriculum snapshot and documents how OSS content flows into the runtime. No product code behavior change is intended.

## Status

Green: the submodule pointer is updated to current `p-n-ai/oss@main`, and the curriculum relationship is documented. Review needed before merge so `main` pins the new OSS revision.

## Why it matters

- pai-bot only gets updated curriculum content when the parent repo commits the `oss` gitlink pointer.
- The previous docs mixed current behavior with planned behavior, which made the OSS integration look more automatic than it is.
- The new doc gives future contributors the boundary between OSS curriculum truth and pai-bot runtime behavior.

## What changed

- Fast-forwarded `oss` from `54a09ce` to `539e61e`.
- Added `docs/curriculum-oss.md` covering setup, loader contract, runtime usage, and current/planned behavior.
- Updated README and technical plan references so they match the actual `oss/` submodule path and current loader behavior.

## Review focus

- Is it acceptable for pai-bot `main` to pin OSS commit `539e61e`?
- Is the OSS versus pai-bot ownership boundary clear?
- Does the technical-plan correction accurately remove stale hot-reload/cache claims?

## Validation

- `git -C oss fetch origin main`
- Confirmed `oss` HEAD, `origin/main`, and `FETCH_HEAD` all match `539e61e`.
- `docs-list`

## Risks / Rollout

- Low runtime risk: no pai-bot code paths changed.
- Main effect after merge is that fresh checkouts and deploys pin the newer OSS curriculum snapshot.
