### PR TITLE
test: focus admin auth e2e coverage

### DIFF
--- a/admin/e2e/authenticated.spec.ts
+++ b/admin/e2e/authenticated.spec.ts
@@ -22,9 +22,54 @@ async function loginAsAdmin(page: Page) {
 
   const sessionResponse = await page.request.get("/api/auth/session");
   expect(sessionResponse.ok()).toBeTruthy();
+
+  const session = await sessionResponse.json();
+  expect(session.user).toMatchObject({
+    email: adminEmail,
+  });
+  expect(["admin", "platform_admin"]).toContain(session.user.role);
+}
+
+async function completeOnboarding(page: Page) {
+  const current = await page.request.get("/api/admin/onboarding");
+  expect(current.ok()).toBeTruthy();
+
+  const view = await current.json();
+  if (view.onboarding) {
+    return;
+  }
+
+  const response = await page.request.post("/api/admin/onboarding", {
+    data: {
+      school_name: view.tenant_name ?? "CI Test School",
+      curriculum: {
+        syllabus_id: "kssm-algebra",
+        label: "KSSM Algebra",
+      },
+      first_class: {
+        name: "CI Test Class",
+        slug: "ci-test-class",
+      },
+      bot_setup: {
+        preset: "guided-practice",
+      },
+    },
+  });
+
+  if (!response.ok()) {
+    const body = await response.text();
+    throw new Error(`Failed to complete onboarding. Status ${response.status()}. Body: ${body}`);
+  }
+}
+
+async function loginAsConfiguredAdmin(page: Page) {
+  await loginAsAdmin(page);
+  await completeOnboarding(page);
 }
 
 test.describe("admin authenticated routes @backend", () => {
+  test.describe.configure({ mode: "serial" });
+
   test.skip(
     !hasAuthSetup,
     "Set E2E_AUTH_ENABLED=true, E2E_ADMIN_EMAIL, and E2E_ADMIN_PASSWORD to run authenticated E2E tests.",
@@ -36,51 +81,37 @@ test.describe("admin authenticated routes @backend", () => {
     await expect(page).toHaveURL(/\/setup\/onboard$/);
   });
 
-  test("renders /dashboard", async ({ page }) => {
-    await loginAsAdmin(page);
-    await page.goto("/dashboard");
-    await expect(page).toHaveURL(/\/dashboard$/);
+  test("renders configured admin route surfaces", async ({ page }) => {
+    await loginAsConfiguredAdmin(page);
+
+    const routes = [
+      { path: "/dashboard", url: /\/dashboard$/, heading: "Dashboard" },
+      { path: "/dashboard/ai-usage", url: /\/dashboard\/ai-usage$/, heading: "AI usage" },
+      { path: "/dashboard/classes", url: /\/dashboard\/classes$/, heading: "Class management" },
+      { path: "/settings/users", url: /\/settings\/users$/, heading: "User and invite management" },
+      { path: "/export", url: /\/export$/, heading: "Data export" },
+    ];
+
+    for (const route of routes) {
+      await test.step(route.path, async () => {
+        await page.goto(route.path);
+        await expect(page).toHaveURL(route.url);
+        await expect(page.getByRole("heading", { name: route.heading })).toBeVisible();
+      });
+    }
   });
 
-  test("renders /dashboard/ai-usage", async ({ page }) => {
-    await loginAsAdmin(page);
-    await page.goto("/dashboard/ai-usage");
-    await expect(page).toHaveURL(/\/dashboard\/ai-usage$/);
-  });
-
-  test("redirects /dashboard/metrics to /dashboard/ai-usage", async ({ page }) => {
-    await loginAsAdmin(page);
+  test("redirects legacy dashboard metrics route to AI usage", async ({ page }) => {
+    await loginAsConfiguredAdmin(page);
     await page.goto("/dashboard/metrics");
     await expect(page).toHaveURL(/\/dashboard\/ai-usage$/);
+    await expect(page.getByRole("heading", { name: "AI usage" })).toBeVisible();
   });
 
-  test("renders /dashboard/classes", async ({ page }) => {
-    await loginAsAdmin(page);
-    await page.goto("/dashboard/classes");
-    await expect(page).toHaveURL(/\/dashboard\/classes$/);
-  });
-
-  test("renders /students/:id route shell", async ({ page }) => {
-    await loginAsAdmin(page);
-    await page.goto("/students/test-student-id");
-    await expect(page).toHaveURL(/\/students\/test-student-id$/);
-  });
-
-  test("renders /parents/:id route shell", async ({ page }) => {
-    await loginAsAdmin(page);
-    await page.goto("/parents/test-parent-id");
-    await expect(page).toHaveURL(/\/parents\/test-parent-id$/);
-  });
-
-  test("renders /settings/users for admin-level roles", async ({ page }) => {
-    await loginAsAdmin(page);
-    await page.goto("/settings/users");
-    await expect(page).toHaveURL(/\/settings\/users$/);
-  });
-
-  test("renders /export for admin-level roles", async ({ page }) => {
-    await loginAsAdmin(page);
-    await page.goto("/export");
-    await expect(page).toHaveURL(/\/export$/);
+  test("redirects configured admins away from /login to dashboard", async ({ page }) => {
+    await loginAsConfiguredAdmin(page);
+    await page.goto("/login");
+    await expect(page).toHaveURL(/\/dashboard$/);
+    await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
- replace URL-only admin auth E2E route shell checks with fewer critical behavior checks
- assert admin login session identity and onboarding/login redirect semantics
- keep legacy metrics redirect covered with a semantic AI usage page assertion

## Verification
- pnpm test
- pnpm lint (passes with existing whatsapp-setup-panel img warning)
- E2E_BACKEND_ENABLED=true E2E_AUTH_ENABLED=true E2E_ADMIN_EMAIL=admin@example.com E2E_ADMIN_PASSWORD=demo-password pnpm exec playwright test authenticated.spec.ts --list