### PR TITLE
feat(config): add product feature flag overrides

### DIFF
--- a/cmd/conversation-harness/main.go
+++ b/cmd/conversation-harness/main.go
@@ -206,11 +206,11 @@ func buildEngine(memory bool, mockResponse string, progressSideEffects bool) (*a
 		Store:                state.Store,
 		EventLogger:          state.EventLogger,
 		CurriculumLoader:     loader,
-		DisableMultiLanguage: cfg.Features.DisableMultiLanguage,
-		RatingPromptEvery:    cfg.Features.RatingPromptEvery,
+		DisableMultiLanguage: cfg.Runtime.DisableMultiLanguage,
+		RatingPromptEvery:    cfg.Runtime.RatingPromptEvery,
 		Goals:                goalStore,
 		Challenges:           challengeStore,
-		DevMode:              cfg.Features.DevMode,
+		DevMode:              cfg.Runtime.DevMode,
 	}
 	if progressSideEffects {
 		engineCfg.Tracker = state.Tracker

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -81,7 +81,7 @@ func main() {
 	// Initialize AI router with configured providers.
 	router := setupAIRouter(cfg)
 	if !router.HasProvider() {
-		if cfg.Features.DevMode {
+		if cfg.Runtime.DevMode {
 			slog.Warn("no AI providers configured; continuing in dev mode without AI-backed chat responses")
 		} else {
 			slog.Error("no AI providers configured")
@@ -146,8 +146,8 @@ func main() {
 		EventLogger:          eventLogger,
 		CurriculumLoader:     loader,
 		RetrievalService:     retrievalService,
-		DisableMultiLanguage: cfg.Features.DisableMultiLanguage,
-		RatingPromptEvery:    cfg.Features.RatingPromptEvery,
+		DisableMultiLanguage: cfg.Runtime.DisableMultiLanguage,
+		RatingPromptEvery:    cfg.Runtime.RatingPromptEvery,
 		Tracker:              tracker,
 		Streaks:              streakTracker,
 		XP:                   xpTracker,
@@ -155,7 +155,7 @@ func main() {
 		Challenges:           challengeStore,
 		Groups:               groupStore,
 		TenantID:             store.TenantID(),
-		DevMode:              cfg.Features.DevMode,
+		DevMode:              cfg.Runtime.DevMode,
 	})
 
 	gw := chat.NewGateway()
@@ -165,7 +165,7 @@ func main() {
 			slog.Error("failed to create Telegram channel", "error", err)
 			os.Exit(1)
 		}
-		tg.SetDevMode(cfg.Features.DevMode)
+		tg.SetDevMode(cfg.Runtime.DevMode)
 		gw.Register("telegram", tg)
 	} else {
 		slog.Warn("telegram channel disabled; LEARN_TELEGRAM_BOT_TOKEN is not set")
@@ -207,7 +207,7 @@ func main() {
 	// requires origin checking and subprotocol JWT auth.
 	embedTokenManager := auth.NewTokenManager(cfg.Auth.JWTSecret, time.Hour)
 	var wsChannel *chat.WSChannel
-	if cfg.Features.DevMode {
+	if cfg.Runtime.DevMode {
 		wsChannel = chat.NewWSChannel()
 	} else {
 		wsChannel = chat.NewEmbedWSChannel(embedConfigStore, embedTokenManager)
@@ -223,7 +223,7 @@ func main() {
 		agent.SchedulerConfig{
 			CheckInterval:               agent.DefaultSchedulerConfig().CheckInterval,
 			MaxNudgesPerDay:             agent.DefaultSchedulerConfig().MaxNudgesPerDay,
-			AIPersonalizedNudgesEnabled: cfg.Features.AIPersonalizedNudgesEnabled,
+			AIPersonalizedNudgesEnabled: cfg.Runtime.AIPersonalizedNudgesEnabled,
 		},
 		tracker,
 		streakTracker,

--- a/cmd/terminal-chat/main.go
+++ b/cmd/terminal-chat/main.go
@@ -134,11 +134,11 @@ func main() {
 		Store:                state.Store,
 		EventLogger:          state.EventLogger,
 		CurriculumLoader:     loader,
-		DisableMultiLanguage: cfg.Features.DisableMultiLanguage,
-		RatingPromptEvery:    cfg.Features.RatingPromptEvery,
+		DisableMultiLanguage: cfg.Runtime.DisableMultiLanguage,
+		RatingPromptEvery:    cfg.Runtime.RatingPromptEvery,
 		Goals:                goalStore,
 		Challenges:           challengeStore,
-		DevMode:              cfg.Features.DevMode,
+		DevMode:              cfg.Runtime.DevMode,
 	}
 	if progressSideEffects {
 		engineCfg.Tracker = state.Tracker

--- a/cmd/terminal-nudge/main.go
+++ b/cmd/terminal-nudge/main.go
@@ -90,7 +90,7 @@ func main() {
 		agent.SchedulerConfig{
 			CheckInterval:               agent.DefaultSchedulerConfig().CheckInterval,
 			MaxNudgesPerDay:             agent.DefaultSchedulerConfig().MaxNudgesPerDay,
-			AIPersonalizedNudgesEnabled: cfg.Features.AIPersonalizedNudgesEnabled,
+			AIPersonalizedNudgesEnabled: cfg.Runtime.AIPersonalizedNudgesEnabled,
 		},
 		state.Tracker,
 		nil,

--- a/docs/implementation-guide.md
+++ b/docs/implementation-guide.md
@@ -1728,7 +1728,7 @@ analytics-example:
 ```bash
 # P&AI Bot Configuration
 # Copy to .env and fill in your values
-# All variables use the LEARN_ prefix
+# Core runtime variables use LEARN_; auth and product flags use PAI_.
 
 # --- Server ---
 LEARN_SERVER_PORT=8080
@@ -1758,6 +1758,10 @@ PAI_AUTH_SECRET=change-me-in-production
 
 # --- Tenancy ---
 LEARN_TENANT_MODE=single
+
+# --- Product Feature Flags ---
+# Example: PAI_FEATURES=some_feature=true
+PAI_FEATURES=
 
 # --- WhatsApp (Optional) ---
 LEARN_WHATSAPP_ENABLED=false
@@ -5070,6 +5074,7 @@ echo ""
 | `PAI_AUTH_SECRET` | 16 | No | `change-me-in-production` |
 | `LEARN_TENANT_MODE` | 23 | No | `single` |
 | `LEARN_WHATSAPP_ENABLED` | 24 | No | `false` |
+| `PAI_FEATURES` | 0 | No | — |
 | `LEARN_LOG_LEVEL` | 0 | No | `info` |
 
 *At least one AI provider must be configured.

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -77,6 +77,7 @@ read_when:
 | `LEARN_TENANT_MODE` | `single` | Must be `single` or `multi`. |
 | `LEARN_LOG_LEVEL` | `info` | Log level. |
 | `LEARN_LOG_FORMAT` | `json` | Log format. |
+| `PAI_FEATURES` | empty | Comma-separated learner-facing product feature overrides. Example placeholder: `some_feature=true,other_feature=false`. `flag` enables; `flag=true` enables; `flag=false` disables. Unknown names, invalid values, or duplicate feature names fail config load. |
 | `LEARN_DEV_MODE` | `false` | Relaxes provider/token requirements for local dev. |
 | `LEARN_DISABLE_MULTI_LANGUAGE` | `false` | Disables multilingual behavior. |
 | `LEARN_RATING_PROMPT_EVERY_REPLIES` | `5` | Rating prompt cadence. |
@@ -91,3 +92,4 @@ read_when:
 - `LEARN_AI_DEFAULT_PROVIDER`, when set, must be a known provider.
 - `LEARN_TENANT_MODE` must be `single` or `multi`.
 - Partial email configuration requires `LEARN_EMAIL_SMTP_ADDR` and `LEARN_EMAIL_FROM_ADDRESS`.
+- `PAI_FEATURES`, when set, must contain only known product feature flag names and boolean override values. Each feature may appear at most once.

--- a/docs/runtime/feature-flags.md
+++ b/docs/runtime/feature-flags.md
@@ -1,0 +1,97 @@
+---
+title: "Feature Flags"
+summary: "Feature flag model for learner-facing product experiments, including PAI_FEATURES syntax, goals, and non-goals."
+read_when:
+  - You are adding or consuming a learner-facing product feature flag.
+  - You are changing PAI_FEATURES parsing or internal/platform/featureflags.
+  - You are deciding whether a deploy-time switch is a feature flag or runtime toggle.
+---
+
+# Feature Flags
+
+## Context
+
+Feature flags in pai-bot are deploy-time controls for learner-facing product experiments. They are separate from runtime toggles such as dev mode, provider enablement, channel enablement, and local development shortcuts.
+
+`PAI_FEATURES` is the single deploy-time override surface for product feature flags. It accepts comma-separated overrides:
+
+```env
+PAI_FEATURES=some_feature
+PAI_FEATURES=some_feature=true
+PAI_FEATURES=some_feature=false
+```
+
+These example names are placeholders until the registry contains real product flags. `some_feature` is shorthand for `some_feature=true`. Unknown feature names, invalid boolean values, and duplicate overrides for the same feature fail config load.
+
+The current infrastructure slice intentionally has an empty registry. That means `PAI_FEATURES=` passes, while any non-empty feature name fails until a real product behavior adds a known flag. No agent engine behavior consumes feature flags yet.
+
+## Dev Mode
+
+`LEARN_DEV_MODE` and `PAI_FEATURES` control different things.
+
+`LEARN_DEV_MODE=true` is an operational runtime mode. It lets the process run with development shortcuts, such as relaxed startup requirements or development-only auth behavior.
+
+`PAI_FEATURES=some_feature=true` is a product behavior decision. It enables a learner-facing experiment.
+
+Keep them separate so developers can run any combination:
+
+```env
+LEARN_DEV_MODE=true
+PAI_FEATURES=
+```
+
+Run locally with dev shortcuts, but no product experiment active.
+
+```env
+LEARN_DEV_MODE=false
+PAI_FEATURES=some_feature=true
+```
+
+Run with `LEARN_DEV_MODE=false` and a specific experiment active.
+
+When developing a feature flag locally, use both only when both meanings are needed:
+
+```env
+LEARN_DEV_MODE=true
+PAI_FEATURES=some_feature=true
+```
+
+## Goals
+
+- Keep product experiment flags separate from runtime toggles.
+- Provide one deploy-time feature override surface through `PAI_FEATURES`.
+- Hard-fail unknown feature names and invalid override values.
+- Keep source state minimal: registry defaults plus deploy-time overrides.
+- Derive the effective product feature set from defaults and overrides.
+- Allow future feature status such as `in_development` and `stable` without mixing status with enabled state.
+
+## Non-Goals
+
+- Do not use feature flags for dev mode, provider enablement, channel enablement, or operational runtime switches.
+- Do not wire feature flags into the agent engine before a learner-facing behavior needs them.
+- Do not add rollout percentages, variants, tenant overrides, or per-feature config structs in this slice.
+- Do not add hook-specific flags before the hook behavior slice exists.
+
+## Adding a Feature Flag
+
+Add a feature flag only with the product behavior that consumes it. Do not add names to the registry as placeholders.
+
+1. Name the flag after the learner-facing outcome, not the internal mechanism.
+2. Add the flag to `internal/platform/featureflags` with its status and default.
+3. Add or update config tests for `PAI_FEATURES` parsing when the new flag changes expected behavior.
+4. Wire the effective feature set into the smallest runtime module that owns the learner-facing decision.
+5. Check the flag at the decision point, not in `cmd/server` unless startup itself is the behavior.
+6. Add behavior tests with the flag off and on.
+7. Update this doc and `docs/ops/config.md` when syntax, defaults, or validation rules change.
+
+Examples of good placement:
+
+- A quiz-start experiment belongs near quiz-start routing.
+- A tutor-response experiment belongs near the agent turn or prompt assembly decision.
+- A channel-specific learner experience belongs in that channel runtime.
+
+Examples of poor placement:
+
+- Do not branch in `cmd/server` for product behavior that belongs in the agent.
+- Do not put feature-flag checks inside `internal/platform/featureflags`; that package only parses and answers enabled state.
+- Do not use feature flags as a substitute for runtime config validation.

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -27,13 +27,13 @@ type Config struct {
 	Auth           AuthConfig
 	Tenant         TenantConfig
 	Log            LogConfig
-	Features       FeatureConfig
+	Runtime        RuntimeConfig
 	FeatureFlags   featureflags.Features
 	CurriculumPath string
 }
 
-// FeatureConfig holds legacy env knobs. New product experiments use FeatureFlags.
-type FeatureConfig struct {
+// RuntimeConfig holds runtime knobs. New product experiments use FeatureFlags.
+type RuntimeConfig struct {
 	DisableMultiLanguage        bool
 	RatingPromptEvery           int
 	AIPersonalizedNudgesEnabled bool
@@ -274,7 +274,7 @@ func Load() (*Config, error) {
 			Level:  envStr("LEARN_LOG_LEVEL", "info"),
 			Format: envStr("LEARN_LOG_FORMAT", "json"),
 		},
-		Features: FeatureConfig{
+		Runtime: RuntimeConfig{
 			DevMode:                     envBool("LEARN_DEV_MODE", false),
 			DisableMultiLanguage:        envBool("LEARN_DISABLE_MULTI_LANGUAGE", false),
 			RatingPromptEvery:           envInt("LEARN_RATING_PROMPT_EVERY_REPLIES", 5),
@@ -289,11 +289,11 @@ func Load() (*Config, error) {
 
 // Validate checks that required configuration is present.
 func (c *Config) Validate() error {
-	if c.Telegram.BotToken == "" && !c.Features.DevMode {
+	if c.Telegram.BotToken == "" && !c.Runtime.DevMode {
 		return fmt.Errorf("LEARN_TELEGRAM_BOT_TOKEN is required")
 	}
 
-	if !c.HasAIProvider() && !c.Features.DevMode {
+	if !c.HasAIProvider() && !c.Runtime.DevMode {
 		return fmt.Errorf("at least one AI provider must be configured")
 	}
 	if c.AI.DefaultProvider != "" && !isKnownAIProvider(c.AI.DefaultProvider) {

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/p-n-ai/pai-bot/internal/platform/featureflags"
 )
 
 // Config holds all application configuration.
@@ -26,10 +28,11 @@ type Config struct {
 	Tenant         TenantConfig
 	Log            LogConfig
 	Features       FeatureConfig
+	FeatureFlags   featureflags.Features
 	CurriculumPath string
 }
 
-// FeatureConfig holds toggle-able product features.
+// FeatureConfig holds legacy env knobs. New product experiments use FeatureFlags.
 type FeatureConfig struct {
 	DisableMultiLanguage        bool
 	RatingPromptEvery           int
@@ -176,6 +179,13 @@ type LogConfig struct {
 
 // Load reads configuration from environment variables.
 func Load() (*Config, error) {
+	// Unlike the one-env-to-one-field values below, PAI_FEATURES is a compact
+	// list of overrides that needs validation before it can be stored.
+	parsedFeatureFlags, err := featureflags.Parse(envStr("PAI_FEATURES", ""))
+	if err != nil {
+		return nil, err
+	}
+
 	cfg := &Config{
 		Server: ServerConfig{
 			Port: envInt("LEARN_SERVER_PORT", 8080),
@@ -270,6 +280,7 @@ func Load() (*Config, error) {
 			RatingPromptEvery:           envInt("LEARN_RATING_PROMPT_EVERY_REPLIES", 5),
 			AIPersonalizedNudgesEnabled: envBoolWithFallback("LEARN_AI_PERSONALIZED_NUDGES_ENABLED", "LEARN_AI_NUDGES_ENABLED", true),
 		},
+		FeatureFlags:   parsedFeatureFlags,
 		CurriculumPath: envStr("LEARN_CURRICULUM_PATH", "./oss"),
 	}
 

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -54,12 +54,22 @@ func clearEnv(t *testing.T) {
 		"LEARN_LOG_FORMAT",
 		"LEARN_CURRICULUM_PATH",
 		"LEARN_DEV_MODE",
+		"PAI_FEATURES",
 		"LEARN_AI_PERSONALIZED_NUDGES_ENABLED",
 		"LEARN_AI_NUDGES_ENABLED",
 		"LEARN_AI_MOCK_RESPONSE",
 	}
 	for _, v := range envVars {
 		_ = os.Unsetenv(v)
+	}
+}
+
+func TestLoad_FeatureFlagsRejectUnknown(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("PAI_FEATURES", "unknown_feature")
+
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() should reject unknown PAI_FEATURES entry")
 	}
 }
 
@@ -106,6 +116,9 @@ func TestLoad_Defaults(t *testing.T) {
 	}
 	if !cfg.Features.AIPersonalizedNudgesEnabled {
 		t.Error("Features.AIPersonalizedNudgesEnabled should default to true")
+	}
+	if cfg.FeatureFlags.Enabled("unknown_feature") {
+		t.Fatal("unknown feature should not be enabled")
 	}
 }
 

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -114,8 +114,8 @@ func TestLoad_Defaults(t *testing.T) {
 	if cfg.CurriculumPath != "./oss" {
 		t.Errorf("CurriculumPath = %q, want ./oss", cfg.CurriculumPath)
 	}
-	if !cfg.Features.AIPersonalizedNudgesEnabled {
-		t.Error("Features.AIPersonalizedNudgesEnabled should default to true")
+	if !cfg.Runtime.AIPersonalizedNudgesEnabled {
+		t.Error("Runtime.AIPersonalizedNudgesEnabled should default to true")
 	}
 	if cfg.FeatureFlags.Enabled("unknown_feature") {
 		t.Fatal("unknown feature should not be enabled")
@@ -232,8 +232,8 @@ func TestLoad_FromEnv(t *testing.T) {
 	if cfg.CurriculumPath != "/tmp/oss" {
 		t.Errorf("CurriculumPath = %q, want /tmp/oss", cfg.CurriculumPath)
 	}
-	if cfg.Features.AIPersonalizedNudgesEnabled {
-		t.Error("Features.AIPersonalizedNudgesEnabled should be false when configured")
+	if cfg.Runtime.AIPersonalizedNudgesEnabled {
+		t.Error("Runtime.AIPersonalizedNudgesEnabled should be false when configured")
 	}
 }
 
@@ -246,7 +246,7 @@ func TestLoad_AIPersonalizedNudges_FallbackToDeprecatedEnv(t *testing.T) {
 		t.Fatalf("Load() error = %v", err)
 	}
 
-	if cfg.Features.AIPersonalizedNudgesEnabled {
+	if cfg.Runtime.AIPersonalizedNudgesEnabled {
 		t.Error("deprecated LEARN_AI_NUDGES_ENABLED should still disable AI personalized nudges")
 	}
 }

--- a/internal/platform/featureflags/featureflags.go
+++ b/internal/platform/featureflags/featureflags.go
@@ -1,0 +1,109 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package featureflags owns learner-facing product experiment gates.
+package featureflags
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Feature names a learner-facing product experiment.
+type Feature string
+
+// Status describes feature maturity, not whether the feature is enabled.
+type Status string
+
+const (
+	InDevelopment Status = "in_development"
+	Stable        Status = "stable"
+)
+
+// Spec describes a known feature flag.
+type Spec struct {
+	Feature        Feature
+	Status         Status
+	DefaultEnabled bool
+}
+
+// Features is the effective product feature set for this process.
+type Features struct {
+	enabled map[Feature]struct{}
+}
+
+var registry = map[Feature]Spec{}
+
+// Parse builds an effective feature set from comma-separated overrides.
+func Parse(value string) (Features, error) {
+	features := withDefaults()
+	seen := map[Feature]struct{}{}
+
+	for _, part := range strings.Split(value, ",") {
+		name, enabled, err := parseOverride(part)
+		if err != nil {
+			return Features{}, err
+		}
+		if name == "" {
+			continue
+		}
+		feature := Feature(name)
+		if _, ok := registry[feature]; !ok {
+			return Features{}, fmt.Errorf("unknown feature flag %q", name)
+		}
+		if _, ok := seen[feature]; ok {
+			return Features{}, fmt.Errorf("duplicate feature flag override %q", name)
+		}
+		seen[feature] = struct{}{}
+		features.set(feature, enabled)
+	}
+
+	return features, nil
+}
+
+func withDefaults() Features {
+	features := Features{enabled: map[Feature]struct{}{}}
+	for feature, spec := range registry {
+		if spec.DefaultEnabled {
+			features.enabled[feature] = struct{}{}
+		}
+	}
+	return features
+}
+
+func parseOverride(value string) (string, bool, error) {
+	raw := strings.TrimSpace(value)
+	if raw == "" {
+		return "", false, nil
+	}
+
+	name, rawEnabled, ok := strings.Cut(raw, "=")
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", false, fmt.Errorf("feature flag name is required")
+	}
+	if !ok {
+		return name, true, nil
+	}
+
+	enabled, err := strconv.ParseBool(strings.TrimSpace(rawEnabled))
+	if err != nil {
+		return "", false, fmt.Errorf("invalid value for feature flag %q: %q", name, rawEnabled)
+	}
+	return name, enabled, nil
+}
+
+func (f Features) set(feature Feature, enabled bool) {
+	if enabled {
+		f.enabled[feature] = struct{}{}
+		return
+	}
+	delete(f.enabled, feature)
+}
+
+// Enabled reports whether feature is active.
+func (f Features) Enabled(feature Feature) bool {
+	_, ok := f.enabled[feature]
+	return ok
+}

--- a/internal/platform/featureflags/featureflags_test.go
+++ b/internal/platform/featureflags/featureflags_test.go
@@ -1,0 +1,28 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package featureflags
+
+import "testing"
+
+func TestParseEmptyFeatureSet(t *testing.T) {
+	features, err := Parse(" , ")
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if features.Enabled(Feature("missing")) {
+		t.Fatal("missing feature should not be enabled")
+	}
+}
+
+func TestParseUnknownFeature(t *testing.T) {
+	if _, err := Parse("unknown_feature"); err == nil {
+		t.Fatal("Parse() should reject unknown feature flag")
+	}
+}
+
+func TestParseInvalidBool(t *testing.T) {
+	if _, err := Parse("unknown_feature=maybe"); err == nil {
+		t.Fatal("Parse() should reject invalid bool override")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a minimal product feature flag surface for pai-bot via `PAI_FEATURES`.

This PR keeps product experiments separate from existing runtime/development knobs by:
- adding `internal/platform/featureflags`
- parsing `PAI_FEATURES` during config load
- hard-failing unknown flags, invalid values, and duplicate overrides
- renaming existing `Config.Features` to `Config.Runtime` so dev/runtime toggles do not get mixed with product feature flags
- documenting the model in `docs/runtime/feature-flags.md`, `docs/ops/config.md`, and `docs/implementation-guide.md`

## Scope

This is infrastructure only. The feature flag registry is intentionally empty, so `PAI_FEATURES=` passes and any non-empty feature name currently fails until a real product behavior adds a known flag.

No tutor/runtime behavior is gated by feature flags in this PR.

## Verification

- `gofmt -d ...`
- `go test ./...`
- `go vet ./...`
- `git diff --check`
