### PR TITLE
feat: add feature-flagged turn hooks

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,230 @@
+# P&AI Bot
+
+This context names the tutoring runtime concepts used by P&AI Bot. It keeps agent, learner, and operator language precise when shaping runtime behavior.
+
+## Language
+
+**Tutor Turn**:
+One learner-facing message cycle that reaches the tutor model path.
+_Avoid_: request, chat call
+
+**Turn Hook**:
+An internal runtime extension point that observes or shapes a **Tutor Turn** without becoming a user-installed extension system.
+_Avoid_: React hook, Git hook, Codex hook, plugin
+
+**Hook Outcome**:
+The limited result a **Turn Hook** may return: continue the turn, block the turn, or inject trace-safe context.
+_Avoid_: arbitrary prompt rewrite, dynamic extension result
+
+**Behavior-Preserving Turn Hook**:
+A **Turn Hook** that moves existing tutor-runtime behavior behind the hook seam without changing learner-facing behavior.
+_Avoid_: new policy hook, feature hook
+
+**Turn Hook Rollout Flag**:
+A `PAI_FEATURES=turn_hooks` flag that controls whether **Turn Hooks** run at all while the hook seam is being delivered.
+_Avoid_: per-hook flag, public hook setting
+
+**Rate Conversation Turn Hook**:
+A **Behavior-Preserving Turn Hook** that adds the existing conversation-rating prompt when the **Tutor Turn** is already due for rating.
+Use code slug `rate_convo_hook`.
+_Avoid_: rating_prompt_context, rate_convo_hooks
+
+**Turn Hook Catalog**:
+The internal list of **Turn Hooks** that run when the **Turn Hook Rollout Flag** is enabled.
+_Avoid_: plugin registry, dynamic hook config
+
+**Hook Call Notice**:
+A development-only Terminal Chat console line that prints a **Turn Hook** name and **Hook Outcome**.
+_Avoid_: hook artifact, hook dump, model-visible hook trace
+
+## Relationships
+
+- A **Tutor Turn** may pass through zero or more **Turn Hooks**.
+- A **Turn Hook** belongs to the internal tutoring runtime, not to external users or tenant configuration.
+- A **Turn Hook** returns exactly one **Hook Outcome**.
+- A **Behavior-Preserving Turn Hook** should keep the same learner-visible response path unless the existing behavior already blocked the turn.
+- The **Turn Hook Rollout Flag** controls the hook seam, not individual hooks.
+- The **Rate Conversation Turn Hook** does not decide when rating is due; it only turns that existing decision into hook-shaped context.
+- The **Turn Hook Catalog** controls which hooks run and in what order.
+- The first **Turn Hook Catalog** should contain only the **Rate Conversation Turn Hook**.
+- A **Hook Call Notice** may be printed by Terminal Chat only when developer mode is enabled and the **Turn Hook Rollout Flag** is enabled, but it must not be sent to the model, saved to chat history, or persisted.
+- When **Hook Call Notices** are enabled, every **Turn Hook** call prints one short notice, including `continue` outcomes.
+
+## Example dialogue
+
+> **Dev:** "Should this be a plugin?"
+> **Domain expert:** "No. For now it is a **Turn Hook** inside the **Tutor Turn** runtime, so we can keep tutor safety and trace rules local."
+
+> **Dev:** "How do I add a hook?"
+> **Domain expert:** "Add it to the **Turn Hook Catalog**. Do not add a per-hook flag."
+
+## Flagged ambiguities
+
+- "hooks" was used ambiguously across React hooks, Codex hooks, Git hooks, and agent harness hooks — resolved: in this work, "hooks" means **Turn Hooks**.
+
+## Local PRD: Feature-Flagged Turn Hook Seam
+
+### Problem Statement
+
+P&AI Bot needs a small internal **Turn Hook** seam for the **Tutor Turn** runtime, but without turning hooks into plugins, YAML config, user settings, or model-visible metadata. Current rating prompt behavior is mixed into context loading, making it hard to add/remove runtime shaping behavior cleanly.
+
+### Solution
+
+Ship **Turn Hooks** behind `PAI_FEATURES=turn_hooks`.
+
+First hook only: **Rate Conversation Turn Hook** with slug `rate_convo_hook`.
+
+It moves existing rating prompt injection behind the hook seam while preserving learner-visible behavior. When the flag is off, existing behavior remains. When the flag is on, the **Turn Hook Catalog** runs and `rate_convo_hook` injects the same trace-safe rating prompt context only when the existing runtime already says rating is due.
+
+### User Stories
+
+1. As a developer, I want **Turn Hooks** disabled by default, so that hook code can land safely.
+2. As a developer, I want one rollout flag, so that enabling/disabling the seam is simple.
+3. As a developer, I want hooks added through a **Turn Hook Catalog**, so that add/remove is one obvious place.
+4. As a developer, I want no per-hook flags, so that runtime behavior does not become config sprawl.
+5. As a tutor-runtime maintainer, I want `rate_convo_hook` to preserve existing behavior, so that learners see no regression.
+6. As a tutor-runtime maintainer, I want rating-due logic outside the hook, so that the hook only shapes context.
+7. As a prompt reviewer, I want hook-injected context to use existing context packet validation, so that trust rules still hold.
+8. As an operator, I want no hook data persisted, so that hook visibility does not create a privacy surface.
+9. As a CLI developer, I want short **Hook Call Notices** in Terminal Chat, so that I can see hooks ran during dev.
+10. As a CLI developer, I want every hook call noticed, including `continue`, so that silent no-op hooks are still observable.
+11. As a privacy reviewer, I want hook notices to include only name and outcome, so that learner text never leaks.
+12. As a future developer, I want `block`, `inject`, and `continue` outcomes available, so that later internal hooks have a stable shape.
+
+### Implementation Decisions
+
+- Add `turn_hooks` as a known feature flag, default off.
+- Treat this as an internal rollout exception to the current learner-facing feature flag wording.
+- Add a private **Tutor Turn** hook runner module.
+- Define **Hook Outcome** as `continue`, `block`, or `inject trace-safe context`.
+- Add a private **Turn Hook Catalog** with one initial entry: `rate_convo_hook`.
+- Move rating prompt packet creation out of base context loading into `rate_convo_hook`.
+- Keep rating-due calculation in the existing **Tutor Turn** flow.
+- Run hooks after base context is available and before prompt compilation.
+- Keep hook-injected packets under the same validation and trace contract as normal context packets.
+- Add Terminal Chat-only **Hook Call Notice** when dev mode and `turn_hooks` are enabled.
+- Do not send hook name/outcome to the model.
+- Do not persist hook notices to chat history, event telemetry, or request dumps.
+
+### Testing Decisions
+
+- Test feature flag parsing: known flag, default false, explicit true/false, unknown failure.
+- Test flag off path preserves existing rating prompt behavior.
+- Test flag on path runs `rate_convo_hook`.
+- Test `rate_convo_hook` injects rating prompt only when rating is already due.
+- Test non-rating turns continue without injection.
+- Test fake hooks for runner outcomes: `continue`, `inject`, `block`.
+- Test hook ordering through the catalog.
+- Test invalid injected context is rejected by existing packet validation.
+- Test Terminal Chat notices only appear with dev mode plus `turn_hooks`.
+- Test notices include every hook call and only hook name plus outcome.
+
+### Out of Scope
+
+- NSFW/content blocker hooks.
+- Public plugin system.
+- YAML/dynamic hook config.
+- Per-hook feature flags.
+- Admin UI/debug UI.
+- Persistent hook artifacts.
+- Model-visible hook metadata.
+- Provider request rewriting.
+- Multiple production hooks in first slice.
+
+### Further Notes
+
+This PRD's main architecture choice: make **Turn Hook** a deep internal module with a small interface. The leverage is clean add/remove behavior through the **Turn Hook Catalog**, while locality stays inside **Tutor Turn** runtime. The first shipment should prove the seam with boring existing behavior, not invent new policy.
+
+## Local Issue Breakdown: Turn Hook Tracer Bullets
+
+### 1. Add Turn Hook Rollout Flag
+
+**Type**: AFK
+
+**Blocked by**: None
+
+**User stories covered**: 1, 2
+
+**What to build**: `PAI_FEATURES=turn_hooks` is known, default off, documented as an internal rollout exception. No **Tutor Turn** behavior changes yet.
+
+**Acceptance criteria**:
+
+- [ ] `turn_hooks` is a known feature flag with default disabled behavior.
+- [ ] `PAI_FEATURES=turn_hooks` and explicit boolean overrides parse correctly.
+- [ ] Unknown feature names still fail config load.
+- [ ] Runtime docs explain why this internal rollout flag is allowed.
+
+### 2. Add Private Turn Hook Runner
+
+**Type**: AFK
+
+**Blocked by**: 1. Add Turn Hook Rollout Flag
+
+**User stories covered**: 3, 4, 12
+
+**What to build**: **Tutor Turn** can run an internal **Turn Hook Catalog** when the **Turn Hook Rollout Flag** is enabled. Runner supports `continue`, `inject`, and `block` with test-only hooks. No production hook yet.
+
+**Acceptance criteria**:
+
+- [ ] The **Turn Hook Catalog** is private and ordered.
+- [ ] The hook runner is skipped when `turn_hooks` is disabled.
+- [ ] Test hooks cover `continue`, `inject`, and `block` outcomes.
+- [ ] Hook-injected context still goes through existing packet validation.
+- [ ] No per-hook flag or dynamic config is introduced.
+
+### 3. Move Rating Prompt Into `rate_convo_hook`
+
+**Type**: AFK
+
+**Blocked by**: 2. Add Private Turn Hook Runner
+
+**User stories covered**: 5, 6, 7
+
+**What to build**: Existing rating prompt behavior becomes the first catalog hook. Flag off preserves old path. Flag on uses hook path. Prompt output stays equivalent.
+
+**Acceptance criteria**:
+
+- [ ] The first production **Turn Hook Catalog** contains only `rate_convo_hook`.
+- [ ] `rate_convo_hook` does not decide when rating is due.
+- [ ] When rating is due and `turn_hooks` is enabled, `rate_convo_hook` injects the existing rating prompt context.
+- [ ] When rating is not due, `rate_convo_hook` returns `continue`.
+- [ ] Behavior with the flag off remains equivalent to current learner-visible behavior.
+- [ ] Prompt-shape tests prove the rating instruction still appears in the expected place.
+
+### 4. Add Terminal Chat Hook Call Notices
+
+**Type**: AFK
+
+**Blocked by**: 3. Move Rating Prompt Into `rate_convo_hook`
+
+**User stories covered**: 8, 9, 10, 11
+
+**What to build**: Terminal Chat prints one short line per hook call only when `LEARN_DEV_MODE=true` and `PAI_FEATURES=turn_hooks`. The notice includes hook name and outcome only. It is not persisted.
+
+**Acceptance criteria**:
+
+- [ ] Terminal Chat prints a **Hook Call Notice** for every **Turn Hook** call when dev mode and `turn_hooks` are enabled.
+- [ ] Notices include only hook name and **Hook Outcome**.
+- [ ] `continue` outcomes are printed too.
+- [ ] Notices do not appear when dev mode is off.
+- [ ] Notices do not appear when `turn_hooks` is off.
+- [ ] Notices are not sent to the model, saved to chat history, or persisted in request dumps/events.
+
+### 5. Document Turn Hook Operating Contract
+
+**Type**: AFK
+
+**Blocked by**: 3. Move Rating Prompt Into `rate_convo_hook`
+
+**User stories covered**: 3, 4, 7, 8, 12
+
+**What to build**: Runtime docs explain **Turn Hook**, **Hook Outcome**, **Turn Hook Catalog**, **Turn Hook Rollout Flag**, privacy boundary, and how to add/remove hooks.
+
+**Acceptance criteria**:
+
+- [ ] Runtime docs use the exact domain terms from this context.
+- [ ] Docs explain that **Turn Hooks** are internal, not plugins.
+- [ ] Docs explain add/remove through **Turn Hook Catalog** only.
+- [ ] Docs explain why no per-hook flags exist.
+- [ ] Docs explain the **Hook Call Notice** privacy boundary.
+- [ ] Docs note the first catalog contains only `rate_convo_hook`.

--- a/cmd/conversation-harness/main.go
+++ b/cmd/conversation-harness/main.go
@@ -10,7 +10,9 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -77,6 +79,23 @@ type caseResult struct {
 	Failures []string `json:"failures,omitempty"`
 }
 
+type requestDumpRecord struct {
+	Sequence    int                  `json:"sequence"`
+	Provider    string               `json:"provider"`
+	Request     ai.CompletionRequest `json:"request"`
+	StartedAt   time.Time            `json:"started_at"`
+	CompletedAt time.Time            `json:"completed_at"`
+	Error       string               `json:"error,omitempty"`
+}
+
+type requestDumper struct {
+	mu      sync.Mutex
+	file    *os.File
+	encoder *json.Encoder
+	nextSeq int
+	err     error
+}
+
 func main() {
 	var fixturePath string
 	var caseID string
@@ -89,6 +108,8 @@ func main() {
 	var mockResponse string
 	var progressSideEffects bool
 	var verbose bool
+	var dumpRequestsPath string
+	var requestOnly bool
 
 	flag.StringVar(&fixturePath, "fixture", defaultFixturePath, "YAML conversation fixture")
 	flag.StringVar(&caseID, "case", "", "run one conversation id")
@@ -101,7 +122,13 @@ func main() {
 	flag.StringVar(&mockResponse, "mock-response", "", "use a deterministic mock AI response instead of configured providers")
 	flag.BoolVar(&progressSideEffects, "progress", false, "enable mastery/progress side effects during harness runs")
 	flag.BoolVar(&verbose, "verbose", false, "show diagnostic warnings from curriculum loading and background checks")
+	flag.StringVar(&dumpRequestsPath, "dump-requests", "", "write mock AI completion requests as JSONL to this path")
+	flag.BoolVar(&requestOnly, "request-only", false, "skip behavior scoring; useful with --dump-requests")
 	flag.Parse()
+	if err := validateRequestOnlyMode(requestOnly, dumpRequestsPath); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
 
 	logLevel := slog.LevelError
 	if verbose {
@@ -123,7 +150,25 @@ func main() {
 		os.Exit(1)
 	}
 
-	engine, cleanup, err := buildEngine(memory, mockResponse, progressSideEffects)
+	var dumper *requestDumper
+	if dumpRequestsPath != "" {
+		if mockResponse == "" {
+			mockResponse = "mock tutor response"
+		}
+		dumper, err = newRequestDumper(dumpRequestsPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "open request dump: %v\n", err)
+			os.Exit(1)
+		}
+		defer func() {
+			if err := dumper.Close(); err != nil {
+				fmt.Fprintf(os.Stderr, "close request dump: %v\n", err)
+				os.Exit(1)
+			}
+		}()
+	}
+
+	engine, cleanup, err := buildEngine(memory, mockResponse, progressSideEffects, traceFuncForDumper(dumper))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "build harness: %v\n", err)
 		os.Exit(1)
@@ -132,7 +177,7 @@ func main() {
 
 	results := make([]caseResult, 0, len(conversations))
 	for _, conv := range conversations {
-		result := runConversation(engine, conv, timeout, showResponses)
+		result := runConversation(engine, conv, timeout, showResponses, !requestOnly)
 		results = append(results, result)
 		if jsonl {
 			_ = json.NewEncoder(os.Stdout).Encode(result)
@@ -144,6 +189,76 @@ func main() {
 	if failedCount(results) > 0 {
 		os.Exit(1)
 	}
+}
+
+func newRequestDumper(path string) (*requestDumper, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, fmt.Errorf("path is required")
+	}
+	if dir := filepath.Dir(path); dir != "." && dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, err
+		}
+	}
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := file.Chmod(0o600); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return &requestDumper{
+		file:    file,
+		encoder: json.NewEncoder(file),
+	}, nil
+}
+
+func traceFuncForDumper(dumper *requestDumper) func(ai.CompletionTrace) {
+	if dumper == nil {
+		return nil
+	}
+	return dumper.Record
+}
+
+func (d *requestDumper) Record(trace ai.CompletionTrace) {
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.err != nil {
+		return
+	}
+	d.nextSeq++
+	d.err = d.encoder.Encode(requestDumpRecord{
+		Sequence:    d.nextSeq,
+		Provider:    trace.Provider,
+		Request:     trace.Request,
+		StartedAt:   trace.StartedAt,
+		CompletedAt: trace.CompletedAt,
+		Error:       trace.Error,
+	})
+}
+
+func (d *requestDumper) Close() error {
+	if d == nil {
+		return nil
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.err != nil {
+		_ = d.file.Close()
+		return d.err
+	}
+	return d.file.Close()
+}
+
+func validateRequestOnlyMode(requestOnly bool, dumpRequestsPath string) error {
+	if requestOnly && strings.TrimSpace(dumpRequestsPath) == "" {
+		return fmt.Errorf("--request-only requires --dump-requests")
+	}
+	return nil
 }
 
 func loadFixture(path string) (fixtureFile, error) {
@@ -161,7 +276,7 @@ func loadFixture(path string) (fixtureFile, error) {
 	return fixture, nil
 }
 
-func buildEngine(memory bool, mockResponse string, progressSideEffects bool) (*agent.Engine, func(), error) {
+func buildEngine(memory bool, mockResponse string, progressSideEffects bool, traceFunc func(ai.CompletionTrace)) (*agent.Engine, func(), error) {
 	cfg, err := config.Load()
 	if err != nil {
 		return nil, nil, fmt.Errorf("load config: %w", err)
@@ -177,6 +292,9 @@ func buildEngine(memory bool, mockResponse string, progressSideEffects bool) (*a
 		if !router.HasProvider() {
 			return nil, nil, fmt.Errorf("no AI providers configured")
 		}
+	}
+	if traceFunc != nil {
+		router.SetTraceFunc(traceFunc)
 	}
 
 	loader, err := curriculum.NewLoader(cfg.CurriculumPath)
@@ -211,6 +329,7 @@ func buildEngine(memory bool, mockResponse string, progressSideEffects bool) (*a
 		Goals:                goalStore,
 		Challenges:           challengeStore,
 		DevMode:              cfg.Runtime.DevMode,
+		FeatureFlags:         cfg.FeatureFlags,
 	}
 	if progressSideEffects {
 		engineCfg.Tracker = state.Tracker
@@ -238,7 +357,7 @@ func selectConversations(conversations []conversationSpec, caseID, tag string, m
 	return selected
 }
 
-func runConversation(engine *agent.Engine, conv conversationSpec, timeout time.Duration, showResponses bool) caseResult {
+func runConversation(engine *agent.Engine, conv conversationSpec, timeout time.Duration, showResponses bool, runChecks bool) caseResult {
 	userID := "harness-" + strings.ToLower(conv.ID) + "-" + fmt.Sprint(time.Now().UnixNano())
 	responses := make([]string, 0, len(conv.Turns))
 	failures := []string{}
@@ -259,9 +378,13 @@ func runConversation(engine *agent.Engine, conv conversationSpec, timeout time.D
 		if showResponses {
 			fmt.Printf("\n[%s turn %d]\nUser: %s\nAssistant: %s\n", conv.ID, i+1, turn.User, resp)
 		}
-		failures = append(failures, checkTurn(i+1, resp, conv.Checks)...)
+		if runChecks {
+			failures = append(failures, checkTurn(i+1, resp, conv.Checks)...)
+		}
 	}
-	failures = append(failures, checkConversation(conv.Checks, responses)...)
+	if runChecks {
+		failures = append(failures, checkConversation(conv.Checks, responses)...)
+	}
 
 	return caseResult{
 		ID:       conv.ID,

--- a/cmd/conversation-harness/main_test.go
+++ b/cmd/conversation-harness/main_test.go
@@ -4,12 +4,16 @@
 package main
 
 import (
+	"encoding/json"
+	"os"
 	"reflect"
 	"testing"
+
+	"github.com/p-n-ai/pai-bot/internal/ai"
 )
 
 func TestBuildEngineLeavesProgressOffByDefault(t *testing.T) {
-	engine, cleanup, err := buildEngine(true, "mock tutor response", false)
+	engine, cleanup, err := buildEngine(true, "mock tutor response", false, nil)
 	if err != nil {
 		t.Fatalf("buildEngine() error = %v", err)
 	}
@@ -21,7 +25,7 @@ func TestBuildEngineLeavesProgressOffByDefault(t *testing.T) {
 }
 
 func TestBuildEngineCanEnableProgress(t *testing.T) {
-	engine, cleanup, err := buildEngine(true, "mock tutor response", true)
+	engine, cleanup, err := buildEngine(true, "mock tutor response", true, nil)
 	if err != nil {
 		t.Fatalf("buildEngine() error = %v", err)
 	}
@@ -29,6 +33,83 @@ func TestBuildEngineCanEnableProgress(t *testing.T) {
 
 	if engineTrackerIsNil(engine) {
 		t.Fatal("conversation harness should enable mastery tracker when --progress is set")
+	}
+}
+
+func TestRequestDumperWritesCompletionRequestJSONL(t *testing.T) {
+	path := t.TempDir() + "/requests.jsonl"
+	dumper, err := newRequestDumper(path)
+	if err != nil {
+		t.Fatalf("newRequestDumper() error = %v", err)
+	}
+	dumper.Record(ai.CompletionTrace{
+		Provider: "mock",
+		Request: ai.CompletionRequest{
+			Messages:  []ai.Message{{Role: "user", Content: "hi"}},
+			Task:      ai.TaskTeaching,
+			MaxTokens: 1024,
+		},
+	})
+	if err := dumper.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	var record requestDumpRecord
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if err := json.Unmarshal(b, &record); err != nil {
+		t.Fatalf("dumped request is not JSON: %v\n%s", err, b)
+	}
+	if record.Sequence != 1 {
+		t.Fatalf("Sequence = %d, want 1", record.Sequence)
+	}
+	if record.Provider != "mock" {
+		t.Fatalf("Provider = %q, want mock", record.Provider)
+	}
+	if got := record.Request.Messages[0].Content; got != "hi" {
+		t.Fatalf("message content = %q, want hi", got)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("dump permissions = %v, want 0600", got)
+	}
+}
+
+func TestRequestDumperTightensExistingFilePermissions(t *testing.T) {
+	path := t.TempDir() + "/requests.jsonl"
+	if err := os.WriteFile(path, []byte("old\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	dumper, err := newRequestDumper(path)
+	if err != nil {
+		t.Fatalf("newRequestDumper() error = %v", err)
+	}
+	if err := dumper.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("dump permissions = %v, want 0600", got)
+	}
+}
+
+func TestValidateRequestOnlyModeRequiresDumpRequests(t *testing.T) {
+	if err := validateRequestOnlyMode(true, ""); err == nil {
+		t.Fatal("validateRequestOnlyMode() should reject request-only without dump path")
+	}
+	if err := validateRequestOnlyMode(true, "requests.jsonl"); err != nil {
+		t.Fatalf("validateRequestOnlyMode() error = %v", err)
+	}
+	if err := validateRequestOnlyMode(false, ""); err != nil {
+		t.Fatalf("validateRequestOnlyMode() error = %v", err)
 	}
 }
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -156,6 +156,7 @@ func main() {
 		Groups:               groupStore,
 		TenantID:             store.TenantID(),
 		DevMode:              cfg.Runtime.DevMode,
+		FeatureFlags:         cfg.FeatureFlags,
 	})
 
 	gw := chat.NewGateway()

--- a/cmd/terminal-chat/main.go
+++ b/cmd/terminal-chat/main.go
@@ -143,7 +143,7 @@ func main() {
 	}
 	if cfg.Runtime.DevMode {
 		engineCfg.TurnHookNotice = func(notice agent.TurnHookCallNotice) {
-			fmt.Fprintf(os.Stdout, "turn hook called: %s outcome=%s\n", notice.Name, notice.Outcome)
+			_, _ = fmt.Fprintf(os.Stdout, "turn hook called: %s outcome=%s\n", notice.Name, notice.Outcome)
 		}
 	}
 	if progressSideEffects {

--- a/cmd/terminal-chat/main.go
+++ b/cmd/terminal-chat/main.go
@@ -139,6 +139,12 @@ func main() {
 		Goals:                goalStore,
 		Challenges:           challengeStore,
 		DevMode:              cfg.Runtime.DevMode,
+		FeatureFlags:         cfg.FeatureFlags,
+	}
+	if cfg.Runtime.DevMode {
+		engineCfg.TurnHookNotice = func(notice agent.TurnHookCallNotice) {
+			fmt.Fprintf(os.Stdout, "turn hook called: %s outcome=%s\n", notice.Name, notice.Outcome)
+		}
 	}
 	if progressSideEffects {
 		engineCfg.Tracker = state.Tracker
@@ -319,7 +325,10 @@ func writeConversationHistory(path string, history *conversationHistory, turnLim
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, append(b, '\n'), 0o600)
+	if err := os.WriteFile(path, append(b, '\n'), 0o600); err != nil {
+		return err
+	}
+	return os.Chmod(path, 0o600)
 }
 
 func (h *conversationHistory) snapshot(turnLimit int) conversationHistorySnapshot {

--- a/cmd/terminal-chat/main_test.go
+++ b/cmd/terminal-chat/main_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestWriteConversationHistoryTightensExistingFilePermissions(t *testing.T) {
+	path := t.TempDir() + "/history.json"
+	if err := os.WriteFile(path, []byte("old\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	history := newConversationHistory("u1", "terminal")
+	history.Turns = append(history.Turns, conversationTurnJSON{
+		UserID:  "u1",
+		Channel: "terminal",
+		Role:    "student",
+		Text:    "hi",
+	})
+	if err := writeConversationHistory(path, history, 0); err != nil {
+		t.Fatalf("writeConversationHistory() error = %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("history permissions = %v, want 0600", got)
+	}
+}

--- a/docs/implementation-guide.md
+++ b/docs/implementation-guide.md
@@ -1759,8 +1759,8 @@ PAI_AUTH_SECRET=change-me-in-production
 # --- Tenancy ---
 LEARN_TENANT_MODE=single
 
-# --- Product Feature Flags ---
-# Example: PAI_FEATURES=some_feature=true
+# --- Feature Flags ---
+# Current known flag: PAI_FEATURES=turn_hooks
 PAI_FEATURES=
 
 # --- WhatsApp (Optional) ---
@@ -3683,7 +3683,14 @@ go run ./cmd/conversation-harness --case Q01 --show-responses
 
 # machine-readable output for comparison scripts
 go run ./cmd/conversation-harness --jsonl
+
+# inspect model request payloads without calling a real model
+go run ./cmd/conversation-harness --case Q01 --request-only --dump-requests /tmp/pai-bot-llm-requests.jsonl
 ```
+
+#### Turn Hook rollout
+
+The tutor runtime has an internal **Turn Hook** seam behind `PAI_FEATURES=turn_hooks`. The first **Turn Hook Catalog** contains only `rate_convo_hook`, which preserves existing rating-prompt behavior by injecting the same rating context only when the turn is already due for rating. Terminal Chat may print `turn hook called: rate_convo_hook outcome=<outcome>` only when both `LEARN_DEV_MODE=true` and `PAI_FEATURES=turn_hooks` are set. The notice is console-only and is not model context, chat history, request dump content, or event telemetry.
 
 #### Day 4 Exit Criteria
 
@@ -5074,7 +5081,7 @@ echo ""
 | `PAI_AUTH_SECRET` | 16 | No | `change-me-in-production` |
 | `LEARN_TENANT_MODE` | 23 | No | `single` |
 | `LEARN_WHATSAPP_ENABLED` | 24 | No | `false` |
-| `PAI_FEATURES` | 0 | No | — |
+| `PAI_FEATURES` | 0 | No | empty; known flag: `turn_hooks` |
 | `LEARN_LOG_LEVEL` | 0 | No | `info` |
 
 *At least one AI provider must be configured.

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -77,7 +77,7 @@ read_when:
 | `LEARN_TENANT_MODE` | `single` | Must be `single` or `multi`. |
 | `LEARN_LOG_LEVEL` | `info` | Log level. |
 | `LEARN_LOG_FORMAT` | `json` | Log format. |
-| `PAI_FEATURES` | empty | Comma-separated learner-facing product feature overrides. Example placeholder: `some_feature=true,other_feature=false`. `flag` enables; `flag=true` enables; `flag=false` disables. Unknown names, invalid values, or duplicate feature names fail config load. |
+| `PAI_FEATURES` | empty | Comma-separated feature overrides. Current known flag: `turn_hooks`. `flag` enables; `flag=true` enables; `flag=false` disables. Unknown names, invalid values, or duplicate feature names fail config load. |
 | `LEARN_DEV_MODE` | `false` | Relaxes provider/token requirements for local dev. |
 | `LEARN_DISABLE_MULTI_LANGUAGE` | `false` | Disables multilingual behavior. |
 | `LEARN_RATING_PROMPT_EVERY_REPLIES` | `5` | Rating prompt cadence. |
@@ -92,4 +92,4 @@ read_when:
 - `LEARN_AI_DEFAULT_PROVIDER`, when set, must be a known provider.
 - `LEARN_TENANT_MODE` must be `single` or `multi`.
 - Partial email configuration requires `LEARN_EMAIL_SMTP_ADDR` and `LEARN_EMAIL_FROM_ADDRESS`.
-- `PAI_FEATURES`, when set, must contain only known product feature flag names and boolean override values. Each feature may appear at most once.
+- `PAI_FEATURES`, when set, must contain only known feature flag names and boolean override values. Each feature may appear at most once.

--- a/docs/ops/local-tools.md
+++ b/docs/ops/local-tools.md
@@ -37,6 +37,14 @@ The default fixture is `internal/agent/testdata/ai_quality_conversations.yaml`. 
 
 The harness is quiet by default so pass/fail output stays readable. It also keeps mastery/progress side effects off by default so the rubric loop only scores tutor replies; pass `--progress` if you explicitly want mastery updates during a harness run. Use `--verbose` when you need curriculum-loader warnings or background-check diagnostics.
 
+To inspect model request payloads without calling a real model:
+
+```bash
+go run ./cmd/conversation-harness --case Q01 --request-only --dump-requests /tmp/pai-bot-llm-requests.jsonl
+```
+
+`--dump-requests` writes JSONL from the real turn harness and AI router trace, forcing a mock provider when no `--mock-response` is supplied. The dump includes model-facing messages and can contain raw learner text, so the file is local-only and written owner-only.
+
 For transport-only server checks without a real AI provider key, use the dev mock provider:
 
 ```bash

--- a/docs/runtime/agent-turn-api.md
+++ b/docs/runtime/agent-turn-api.md
@@ -154,6 +154,8 @@ Keep the loader direct. Do not add a second `TurnContext` representation unless 
 
 **Turn Hooks** are package-private runtime extension points for the normal **Tutor Turn** path. They are not React hooks, Git hooks, Codex hooks, plugins, YAML config, tenant settings, or user-installed extensions.
 
+Read [Turn Hooks](turn-hooks.md) for the full operating contract, add/remove workflow, privacy rules, and test checklist.
+
 The **Turn Hook Rollout Flag** is `PAI_FEATURES=turn_hooks`. When it is off, the hook runner does not run. When it is on, the private **Turn Hook Catalog** runs in order. The first catalog contains only `rate_convo_hook`.
 
 A **Turn Hook** returns exactly one **Hook Outcome**:

--- a/docs/runtime/agent-turn-api.md
+++ b/docs/runtime/agent-turn-api.md
@@ -29,6 +29,7 @@ The turn harness is package-private on purpose:
 - `agentTurn`
 - `contextPacket`
 - `loadContextPackets`
+- `runTurnHooks`
 - `buildPromptMessagesFromTurn`
 - `promptCompiler.compile`
 
@@ -47,6 +48,7 @@ Non-goals for the current surface:
 ProcessMessage
   -> agentTurn
   -> loadContextPackets
+  -> runTurnHooks (when PAI_FEATURES=turn_hooks)
   -> buildPromptMessagesFromTurn
   -> promptCompiler.compile
   -> aiRouter.Complete
@@ -143,9 +145,24 @@ Current sources:
 - XP
 - replied-to text
 - image instruction and attachment
-- rating prompt instruction
+
+When `PAI_FEATURES=turn_hooks` is disabled, existing rating prompt behavior is appended after base context loading. When `PAI_FEATURES=turn_hooks` is enabled, the **Rate Conversation Turn Hook** (`rate_convo_hook`) injects the same `rating.prompt` packet only when `agentTurn.RatingPromptRequested` is already true.
 
 Keep the loader direct. Do not add a second `TurnContext` representation unless multiple callers need the same intermediate shape.
+
+## Turn Hook contract
+
+**Turn Hooks** are package-private runtime extension points for the normal **Tutor Turn** path. They are not React hooks, Git hooks, Codex hooks, plugins, YAML config, tenant settings, or user-installed extensions.
+
+The **Turn Hook Rollout Flag** is `PAI_FEATURES=turn_hooks`. When it is off, the hook runner does not run. When it is on, the private **Turn Hook Catalog** runs in order. The first catalog contains only `rate_convo_hook`.
+
+A **Turn Hook** returns exactly one **Hook Outcome**:
+
+- `continue`: leave the **Tutor Turn** unchanged.
+- `inject`: append trace-safe `contextPacket` values and validate them through the existing packet validation rules.
+- `block`: stop the model call with a runtime-owned block response. No production hook uses this yet.
+
+Add or remove hooks by editing the **Turn Hook Catalog**. Do not add per-hook feature flags or dynamic hook configuration.
 
 ## Prompt compiler contract
 

--- a/docs/runtime/ai-turn-harness.md
+++ b/docs/runtime/ai-turn-harness.md
@@ -77,6 +77,8 @@ Mixed-trust records must be split. Example: goal target mastery is system-owned 
 
 **Turn Hooks** are internal runtime extension points that observe or shape a **Tutor Turn** without becoming plugins, YAML config, tenant settings, or user-installed extension points.
 
+For the operating contract, add/remove workflow, privacy rules, and test checklist, read [Turn Hooks](turn-hooks.md).
+
 The **Turn Hook Rollout Flag** is:
 
 ```env

--- a/docs/runtime/ai-turn-harness.md
+++ b/docs/runtime/ai-turn-harness.md
@@ -15,6 +15,7 @@ The AI turn harness makes one normal tutoring message explicit:
 ProcessMessage
   -> agentTurn
   -> loadContextPackets
+  -> runTurnHooks (when PAI_FEATURES=turn_hooks)
   -> buildPromptMessagesFromTurn
   -> promptCompiler.compile
   -> aiRouter.Complete
@@ -32,6 +33,7 @@ The current implementation lives in `internal/agent/`:
 | `turn.go` | Defines package-private `agentTurn`, `contextPacket`, trust/render/trace enums, prompt manifest, and model result metadata. |
 | `context_loader.go` | Reads current stores and creates trust-labeled packets for the turn. |
 | `context_packets.go` | Builds, defaults, validates, labels, and summarizes packets. |
+| `turn_hooks.go` | Defines the private Turn Hook runner, Hook Outcomes, Turn Hook Catalog, and `rate_convo_hook`. |
 | `prompt_builder.go` | Compiles packets and chat history into model-facing `[]ai.Message`. |
 | `engine.go` | Owns `ProcessMessage`, turn lifecycle, AI call, response persistence, and `agent_turn_completed`. |
 | `tutor_personality.go` | Encodes the active SOUL-style tutor personality block used by the prompt harness. |
@@ -66,9 +68,34 @@ Validation rejects any non-system-owned packet that tries to render as system co
 - streak and XP
 - replied-to text
 - image instruction and image attachment
-- rating prompt instruction
+
+When `PAI_FEATURES=turn_hooks` is off, existing rating prompt behavior is appended after base packet loading. When `PAI_FEATURES=turn_hooks` is on, `rate_convo_hook` injects the same `rating.prompt` packet only when the turn is already due for rating.
 
 Mixed-trust records must be split. Example: goal target mastery is system-owned metadata; goal summary is learner-provided text.
+
+## Turn Hooks
+
+**Turn Hooks** are internal runtime extension points that observe or shape a **Tutor Turn** without becoming plugins, YAML config, tenant settings, or user-installed extension points.
+
+The **Turn Hook Rollout Flag** is:
+
+```env
+PAI_FEATURES=turn_hooks
+```
+
+When the flag is disabled, the hook runner does not run. When the flag is enabled, the private **Turn Hook Catalog** runs in order. The first catalog contains only **Rate Conversation Turn Hook** (`rate_convo_hook`).
+
+Each **Turn Hook** returns one **Hook Outcome**:
+
+| Outcome | Meaning |
+|---|---|
+| `continue` | Leave the **Tutor Turn** unchanged. |
+| `inject` | Add trace-safe context packets, then validate them with the existing packet validation rules. |
+| `block` | Stop the model call with a runtime-owned block response. No production hook uses this yet. |
+
+`rate_convo_hook` is behavior-preserving. It does not decide when rating is due; it only turns the existing rating decision into hook-shaped context.
+
+Add or remove hooks through the **Turn Hook Catalog** only. Do not add per-hook feature flags, dynamic hook config, or public plugin behavior for this slice.
 
 ## Prompt Shape
 
@@ -106,6 +133,14 @@ Never add raw packet data, names, goal summaries, reply text, summaries, image d
 
 For local prompt debugging, `cmd/terminal-chat --dump-json <path>` can write an explicit file containing UI-visible turns plus model-facing `messages`. Add `--turn-limit 10` when the UI only needs the latest 10 visible turns/model calls. Keep that path opt-in and local-only; it is not part of `agent_turn_completed` or durable event telemetry.
 
+When `LEARN_DEV_MODE=true` and `PAI_FEATURES=turn_hooks`, Terminal Chat may print one **Hook Call Notice** per hook call:
+
+```text
+turn hook called: rate_convo_hook outcome=continue
+```
+
+The notice contains only hook name and **Hook Outcome**. It is not sent to the model, saved to chat history, included in `--dump-json`, emitted by `cmd/conversation-harness`, or persisted as an event.
+
 ## Future Work
 
 Keep future changes incremental:
@@ -137,3 +172,11 @@ The default fixture scores pilot-derived cases for:
 Add a failing conversation before changing prompt/runtime behavior. Keep checks broad enough to catch regressions without depending on one exact wording.
 
 The harness suppresses warning logs by default so the result transcript stays focused on pass/fail output. Add `--verbose` when diagnosing curriculum loading or async background checks.
+
+For local request inspection without calling a real model, dump the mock provider requests:
+
+```bash
+go run ./cmd/conversation-harness --case Q01 --request-only --dump-requests /tmp/pai-bot-llm-requests.jsonl
+```
+
+`--dump-requests` writes JSONL records from the real turn harness and router trace, but forces a mock provider when no `--mock-response` is supplied. The file contains model-facing `messages`, model/task/max-token request fields, and provider timing metadata. Treat the dump as local-only because it can include raw learner text and prompt context.

--- a/docs/runtime/feature-flags.md
+++ b/docs/runtime/feature-flags.md
@@ -30,6 +30,8 @@ The current registry contains one internal rollout flag:
 |---|---:|---|---|---|
 | `turn_hooks` | off | `in_development` | Tutor Turn runtime | Enables the internal **Turn Hook** runner and **Turn Hook Catalog**. The first catalog contains only `rate_convo_hook`. |
 
+Read [Turn Hooks](turn-hooks.md) before adding, removing, or reviewing hook behavior.
+
 ## Dev Mode
 
 `LEARN_DEV_MODE` and `PAI_FEATURES` control different things.

--- a/docs/runtime/feature-flags.md
+++ b/docs/runtime/feature-flags.md
@@ -1,8 +1,9 @@
 ---
 title: "Feature Flags"
-summary: "Feature flag model for learner-facing product experiments, including PAI_FEATURES syntax, goals, and non-goals."
+summary: "Feature flag model for learner-facing product experiments and internal rollout seams, including PAI_FEATURES syntax, goals, and non-goals."
 read_when:
   - You are adding or consuming a learner-facing product feature flag.
+  - You are adding or consuming an internal rollout feature flag.
   - You are changing PAI_FEATURES parsing or internal/platform/featureflags.
   - You are deciding whether a deploy-time switch is a feature flag or runtime toggle.
 ---
@@ -11,19 +12,23 @@ read_when:
 
 ## Context
 
-Feature flags in pai-bot are deploy-time controls for learner-facing product experiments. They are separate from runtime toggles such as dev mode, provider enablement, channel enablement, and local development shortcuts.
+Feature flags in pai-bot are deploy-time controls for learner-facing product experiments and narrowly scoped internal rollout seams. They are separate from runtime toggles such as dev mode, provider enablement, channel enablement, and local development shortcuts.
 
-`PAI_FEATURES` is the single deploy-time override surface for product feature flags. It accepts comma-separated overrides:
+`PAI_FEATURES` is the single deploy-time override surface for known feature flags. It accepts comma-separated overrides:
 
 ```env
-PAI_FEATURES=some_feature
-PAI_FEATURES=some_feature=true
-PAI_FEATURES=some_feature=false
+PAI_FEATURES=turn_hooks
+PAI_FEATURES=turn_hooks=true
+PAI_FEATURES=turn_hooks=false
 ```
 
-These example names are placeholders until the registry contains real product flags. `some_feature` is shorthand for `some_feature=true`. Unknown feature names, invalid boolean values, and duplicate overrides for the same feature fail config load.
+`turn_hooks` is shorthand for `turn_hooks=true`. Unknown feature names, invalid boolean values, and duplicate overrides for the same feature fail config load.
 
-The current infrastructure slice intentionally has an empty registry. That means `PAI_FEATURES=` passes, while any non-empty feature name fails until a real product behavior adds a known flag. No agent engine behavior consumes feature flags yet.
+The current registry contains one internal rollout flag:
+
+| Flag | Default | Status | Owner | Behavior |
+|---|---:|---|---|---|
+| `turn_hooks` | off | `in_development` | Tutor Turn runtime | Enables the internal **Turn Hook** runner and **Turn Hook Catalog**. The first catalog contains only `rate_convo_hook`. |
 
 ## Dev Mode
 
@@ -31,7 +36,7 @@ The current infrastructure slice intentionally has an empty registry. That means
 
 `LEARN_DEV_MODE=true` is an operational runtime mode. It lets the process run with development shortcuts, such as relaxed startup requirements or development-only auth behavior.
 
-`PAI_FEATURES=some_feature=true` is a product behavior decision. It enables a learner-facing experiment.
+`PAI_FEATURES=turn_hooks=true` is a deploy-time behavior decision. It enables the internal **Turn Hook** seam for the tutor model path.
 
 Keep them separate so developers can run any combination:
 
@@ -44,21 +49,23 @@ Run locally with dev shortcuts, but no product experiment active.
 
 ```env
 LEARN_DEV_MODE=false
-PAI_FEATURES=some_feature=true
+PAI_FEATURES=turn_hooks=true
 ```
 
-Run with `LEARN_DEV_MODE=false` and a specific experiment active.
+Run with `LEARN_DEV_MODE=false` and the **Turn Hook** seam active.
 
 When developing a feature flag locally, use both only when both meanings are needed:
 
 ```env
 LEARN_DEV_MODE=true
-PAI_FEATURES=some_feature=true
+PAI_FEATURES=turn_hooks=true
 ```
+
+With `LEARN_DEV_MODE=true` and `PAI_FEATURES=turn_hooks`, Terminal Chat may print **Hook Call Notices**. Those notices are local console output only; they are not model context, chat history, request dumps, or durable events.
 
 ## Goals
 
-- Keep product experiment flags separate from runtime toggles.
+- Keep product experiment and internal rollout flags separate from runtime toggles.
 - Provide one deploy-time feature override surface through `PAI_FEATURES`.
 - Hard-fail unknown feature names and invalid override values.
 - Keep source state minimal: registry defaults plus deploy-time overrides.
@@ -68,15 +75,15 @@ PAI_FEATURES=some_feature=true
 ## Non-Goals
 
 - Do not use feature flags for dev mode, provider enablement, channel enablement, or operational runtime switches.
-- Do not wire feature flags into the agent engine before a learner-facing behavior needs them.
+- Do not add feature flags without a behavior that consumes them.
 - Do not add rollout percentages, variants, tenant overrides, or per-feature config structs in this slice.
-- Do not add hook-specific flags before the hook behavior slice exists.
+- Do not add hook-specific flags. The **Turn Hook Rollout Flag** controls the seam; the **Turn Hook Catalog** controls which hooks run.
 
 ## Adding a Feature Flag
 
-Add a feature flag only with the product behavior that consumes it. Do not add names to the registry as placeholders.
+Add a feature flag only with the behavior that consumes it. Do not add names to the registry as placeholders.
 
-1. Name the flag after the learner-facing outcome, not the internal mechanism.
+1. Name learner-facing flags after the learner-facing outcome; name internal rollout flags after the internal seam they control.
 2. Add the flag to `internal/platform/featureflags` with its status and default.
 3. Add or update config tests for `PAI_FEATURES` parsing when the new flag changes expected behavior.
 4. Wire the effective feature set into the smallest runtime module that owns the learner-facing decision.
@@ -89,6 +96,7 @@ Examples of good placement:
 - A quiz-start experiment belongs near quiz-start routing.
 - A tutor-response experiment belongs near the agent turn or prompt assembly decision.
 - A channel-specific learner experience belongs in that channel runtime.
+- The `turn_hooks` internal rollout flag belongs in the **Tutor Turn** runtime because it controls whether **Turn Hooks** run.
 
 Examples of poor placement:
 

--- a/docs/runtime/feature-flags.md
+++ b/docs/runtime/feature-flags.md
@@ -28,7 +28,7 @@ The current registry contains one internal rollout flag:
 
 | Flag | Default | Status | Owner | Behavior |
 |---|---:|---|---|---|
-| `turn_hooks` | off | `in_development` | Tutor Turn runtime | Enables the internal **Turn Hook** runner and **Turn Hook Catalog**. The first catalog contains only `rate_convo_hook`. |
+| `turn_hooks` | off | `under_development` | Tutor Turn runtime | Enables the internal **Turn Hook** runner and **Turn Hook Catalog**. The first catalog contains only `rate_convo_hook`. |
 
 Read [Turn Hooks](turn-hooks.md) before adding, removing, or reviewing hook behavior.
 
@@ -72,7 +72,7 @@ With `LEARN_DEV_MODE=true` and `PAI_FEATURES=turn_hooks`, Terminal Chat may prin
 - Hard-fail unknown feature names and invalid override values.
 - Keep source state minimal: registry defaults plus deploy-time overrides.
 - Derive the effective product feature set from defaults and overrides.
-- Allow future feature status such as `in_development` and `stable` without mixing status with enabled state.
+- Allow future feature status such as `under_development` and `stable` without mixing status with enabled state.
 
 ## Non-Goals
 

--- a/docs/runtime/turn-hooks.md
+++ b/docs/runtime/turn-hooks.md
@@ -1,0 +1,139 @@
+---
+title: "Turn Hooks"
+summary: "Internal Tutor Turn hook contract, rollout flag, privacy boundary, and add/remove workflow."
+read_when:
+  - You are adding, removing, or reviewing an internal Tutor Turn hook.
+  - You are changing PAI_FEATURES=turn_hooks behavior.
+  - You need to verify hook notices, hook-injected context, or hook privacy rules.
+---
+
+# Turn Hooks
+
+Turn Hooks are private runtime extension points for the normal tutor model path.
+They let the agent runtime observe or shape a `Tutor Turn` after base context is loaded and before prompt compilation.
+
+They are not React hooks, Git hooks, Codex hooks, plugins, tenant settings, YAML config, or user-installed extensions.
+
+## Quick Start
+
+Enable the hook runner with the deploy-time rollout flag:
+
+```env
+PAI_FEATURES=turn_hooks
+```
+
+To see local hook calls in Terminal Chat, enable dev mode too:
+
+```env
+LEARN_DEV_MODE=true
+PAI_FEATURES=turn_hooks
+```
+
+Terminal Chat prints one short line per hook call:
+
+```text
+turn hook called: rate_convo_hook outcome=continue
+```
+
+That notice is console-only. It is not sent to the model, saved in chat history, written to Terminal Chat dumps, emitted by the conversation harness, or persisted as telemetry.
+
+## Runtime Position
+
+Hooks run only inside the generic tutor model flow:
+
+```text
+ProcessMessage
+  -> agentTurn
+  -> loadContextPackets
+  -> runTurnHooks
+  -> buildPromptMessagesFromTurn
+  -> promptCompiler.compile
+  -> aiRouter.Complete
+  -> agent_turn_completed
+```
+
+Early-return flows such as commands, onboarding, quiz routing, challenge runtime, and rating-only submissions do not run Turn Hooks unless they later enter the normal tutor model path.
+
+## Rollout Flag
+
+`PAI_FEATURES=turn_hooks` controls whether the hook runner executes at all.
+
+| Flag state | Runtime behavior |
+|---|---|
+| off | The hook runner is skipped. Existing rating prompt behavior is appended through the legacy path. |
+| on | The private Turn Hook Catalog runs in order. `rate_convo_hook` injects the same rating prompt packet when rating is already due. |
+
+Do not add per-hook feature flags. The rollout flag controls the hook seam. The Turn Hook Catalog controls which hooks run.
+
+## Current Catalog
+
+The first catalog contains only:
+
+| Hook | Slug | Outcome behavior |
+|---|---|---|
+| Rate Conversation Turn Hook | `rate_convo_hook` | Returns `inject` with `rating.prompt` when `agentTurn.RatingPromptRequested` is true; otherwise returns `continue`. |
+
+`rate_convo_hook` does not decide when rating is due. It only turns the existing rating decision into hook-shaped context.
+
+## Hook Outcomes
+
+Every hook returns exactly one outcome:
+
+| Outcome | Meaning | Required data |
+|---|---|---|
+| `continue` | Leave the turn unchanged. | No packets required. |
+| `inject` | Append context packets before prompt compilation. | At least one valid `contextPacket`. |
+| `block` | Stop before the model call with a runtime-owned response. | Optional block message. No production hook uses this yet. |
+
+Injected packets go through the same packet validation as base context. A non-system-owned packet cannot render as system content.
+
+## Privacy Rules
+
+Turn Hooks must keep the existing prompt boundary intact.
+
+- Do not log packet `Data`.
+- Do not add hook name, outcome, raw packet content, learner text, prompt messages, image data URLs, or summaries to `agent_turn_completed`.
+- Do not persist Hook Call Notices.
+- Do not send Hook Call Notices to the model.
+- Use `contextPacket` trust, render, and trace fields for any injected context.
+- Treat local dump files as private debug artifacts.
+
+## Add A Hook
+
+1. Add a package-private hook type in `internal/agent/turn_hooks.go` or a small sibling file under `internal/agent/`.
+2. Implement `Name() string` and `Run(context.Context, *agentTurn) (turnHookResult, error)`.
+3. Add the hook to `defaultTurnHookCatalog()` in the order it should run.
+4. Return `continue`, `inject`, or `block`.
+5. For `inject`, build trace-safe `contextPacket` values and rely on existing packet validation.
+6. Add focused tests in `internal/agent/turn_hooks_test.go`.
+7. Add an engine-level test when the hook changes prompt shape, model-call behavior, block behavior, or dev-mode notices.
+8. Update this doc when the catalog or operating contract changes.
+
+## Remove A Hook
+
+1. Remove it from `defaultTurnHookCatalog()`.
+2. Delete hook-specific code and tests.
+3. Preserve or restore the non-hook runtime path if learner behavior must remain unchanged.
+4. Update this doc and any feature-flag references.
+
+## Test Checklist
+
+Use focused package tests for normal changes:
+
+```bash
+go test ./internal/agent ./internal/platform/featureflags ./internal/platform/config
+```
+
+Use the full repo gate before publishing:
+
+```bash
+go test ./...
+```
+
+For request-shape inspection without calling a real model:
+
+```bash
+go run ./cmd/conversation-harness --case Q01 --request-only --dump-requests /tmp/pai-bot-llm-requests.jsonl
+```
+
+The request dump uses the real turn harness and router trace, but forces a mock provider when no `--mock-response` is supplied.

--- a/internal/agent/context_loader.go
+++ b/internal/agent/context_loader.go
@@ -163,16 +163,6 @@ func (e *Engine) loadContextPackets(_ context.Context, turn *agentTurn, msg chat
 	if turn.ImageDataURL != "" {
 		packets = appendImagePackets(packets, turn.ImageDataURL)
 	}
-	if turn.RatingPromptRequested {
-		packets = append(packets, newContextPacket(contextPacket{
-			ID:       "rating.prompt",
-			Kind:     contextKindControlInstruction,
-			Trust:    contextTrustSystemOwned,
-			Source:   "rating",
-			Data:     ratingPromptInstruction,
-			RenderAs: contextRenderSystemInstruction,
-		}))
-	}
 
 	return packets
 }

--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -17,6 +17,7 @@ import (
 	"github.com/p-n-ai/pai-bot/internal/chat"
 	"github.com/p-n-ai/pai-bot/internal/curriculum"
 	"github.com/p-n-ai/pai-bot/internal/i18n"
+	"github.com/p-n-ai/pai-bot/internal/platform/featureflags"
 	"github.com/p-n-ai/pai-bot/internal/progress"
 	"github.com/p-n-ai/pai-bot/internal/retrieval"
 )
@@ -66,6 +67,8 @@ type EngineConfig struct {
 	Groups                GroupStore
 	TenantID              string // tenant UUID for bot-side group operations
 	DevMode               bool
+	FeatureFlags          featureflags.Features
+	TurnHookNotice        func(TurnHookCallNotice)
 	Notifier              Notifier
 }
 
@@ -89,6 +92,9 @@ type Engine struct {
 	groups                GroupStore
 	tenantID              string
 	devMode               bool
+	featureFlags          featureflags.Features
+	turnHookNotice        func(TurnHookCallNotice)
+	turnHooks             []turnHook
 	notifier              Notifier
 	prereqGraph           *curriculum.PrereqGraph
 	unlocks               *pendingUnlocks
@@ -168,6 +174,9 @@ func NewEngine(cfg EngineConfig) *Engine {
 		groups:                groups,
 		tenantID:              cfg.TenantID,
 		devMode:               cfg.DevMode,
+		featureFlags:          cfg.FeatureFlags,
+		turnHookNotice:        cfg.TurnHookNotice,
+		turnHooks:             defaultTurnHookCatalog(),
 		notifier:              notifier,
 		prereqGraph:           prereqGraph,
 		unlocks:               newPendingUnlocks(),
@@ -355,6 +364,25 @@ func (e *Engine) ProcessMessage(ctx context.Context, msg chat.InboundMessage) (s
 	turn.Topic = matchedTopic
 	turn.TeachingNotes = teachingNotes
 	turn.Packets = e.loadContextPackets(ctx, turn, msg, conv, matchedTopic, teachingNotes)
+	if e.turnHooksEnabled() {
+		hookResult, err := e.runTurnHooks(ctx, turn)
+		if err != nil {
+			turn.Model.Error = err.Error()
+			e.logAgentTurnCompleted(turn, "failed")
+			slog.Error("turn hook failed", "error", err)
+			return i18n.S(e.messageLocale(msg, conv), i18n.MsgTechnicalIssue), nil
+		}
+		turn.Packets = hookResult.Packets
+		if hookResult.Blocked {
+			e.logAgentTurnCompleted(turn, "blocked")
+			if hookResult.BlockMessage != "" {
+				return hookResult.BlockMessage, nil
+			}
+			return i18n.S(e.messageLocale(msg, conv), i18n.MsgTechnicalIssue), nil
+		}
+	} else if turn.RatingPromptRequested {
+		turn.Packets = appendRatingPromptPacket(turn.Packets)
+	}
 	messages := e.buildPromptMessagesFromTurn(turn)
 
 	reqModel := ""

--- a/internal/agent/engine_turn_hooks_test.go
+++ b/internal/agent/engine_turn_hooks_test.go
@@ -1,0 +1,165 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package agent_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/p-n-ai/pai-bot/internal/agent"
+	"github.com/p-n-ai/pai-bot/internal/ai"
+	"github.com/p-n-ai/pai-bot/internal/chat"
+	"github.com/p-n-ai/pai-bot/internal/platform/featureflags"
+)
+
+func TestEngine_ProcessMessage_TurnHooksMoveRatingPromptBehindFlag(t *testing.T) {
+	features, err := featureflags.Parse("turn_hooks")
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	mockAI := ai.NewMockProvider("AI response")
+	tracker := &callTracker{provider: mockAI}
+	var notices []agent.TurnHookCallNotice
+	engine := agent.NewEngine(agent.EngineConfig{
+		AIRouter:          mockRouter(tracker),
+		Store:             agent.NewMemoryStore(),
+		RatingPromptEvery: 1,
+		FeatureFlags:      features,
+		DevMode:           true,
+		TurnHookNotice: func(notice agent.TurnHookCallNotice) {
+			notices = append(notices, notice)
+		},
+	})
+
+	resp, err := engine.ProcessMessage(context.Background(), chat.InboundMessage{
+		Channel: "telegram",
+		UserID:  "u-turn-hooks-rating",
+		Text:    "question 1",
+	})
+	if err != nil {
+		t.Fatalf("ProcessMessage() error = %v", err)
+	}
+	if !contains(resp, "[[PAI_REVIEW:") {
+		t.Fatalf("expected rating prompt on first tutoring reply, got: %q", resp)
+	}
+	requests := tracker.Requests()
+	if len(requests) != 1 {
+		t.Fatalf("AI request count = %d, want 1", len(requests))
+	}
+	if got := countMessagesContaining(requests[0].Messages, "system", "quick 1-5 rating"); got != 1 {
+		t.Fatalf("rating instruction count = %d, want 1", got)
+	}
+	if len(notices) != 1 {
+		t.Fatalf("notice count = %d, want 1", len(notices))
+	}
+	if notices[0].Name != "rate_convo_hook" || notices[0].Outcome != "inject" {
+		t.Fatalf("notice = %#v, want rate_convo_hook inject", notices[0])
+	}
+}
+
+func TestEngine_ProcessMessage_TurnHooksNoticeContinueOutcome(t *testing.T) {
+	features, err := featureflags.Parse("turn_hooks")
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	var notices []agent.TurnHookCallNotice
+	engine := agent.NewEngine(agent.EngineConfig{
+		AIRouter:          mockRouter(ai.NewMockProvider("AI response")),
+		Store:             agent.NewMemoryStore(),
+		RatingPromptEvery: 5,
+		FeatureFlags:      features,
+		DevMode:           true,
+		TurnHookNotice: func(notice agent.TurnHookCallNotice) {
+			notices = append(notices, notice)
+		},
+	})
+
+	resp, err := engine.ProcessMessage(context.Background(), chat.InboundMessage{
+		Channel: "telegram",
+		UserID:  "u-turn-hooks-continue",
+		Text:    "question 1",
+	})
+	if err != nil {
+		t.Fatalf("ProcessMessage() error = %v", err)
+	}
+	if contains(resp, "[[PAI_REVIEW:") {
+		t.Fatalf("did not expect rating prompt, got: %q", resp)
+	}
+	if len(notices) != 1 {
+		t.Fatalf("notice count = %d, want 1", len(notices))
+	}
+	if notices[0].Name != "rate_convo_hook" || notices[0].Outcome != "continue" {
+		t.Fatalf("notice = %#v, want rate_convo_hook continue", notices[0])
+	}
+}
+
+func TestEngine_ProcessMessage_TurnHookNoticeDisabledWithoutFeatureFlag(t *testing.T) {
+	var notices []agent.TurnHookCallNotice
+	engine := agent.NewEngine(agent.EngineConfig{
+		AIRouter:          mockRouter(ai.NewMockProvider("AI response")),
+		Store:             agent.NewMemoryStore(),
+		RatingPromptEvery: 1,
+		DevMode:           true,
+		TurnHookNotice: func(notice agent.TurnHookCallNotice) {
+			notices = append(notices, notice)
+		},
+	})
+
+	resp, err := engine.ProcessMessage(context.Background(), chat.InboundMessage{
+		Channel: "telegram",
+		UserID:  "u-turn-hooks-flag-off",
+		Text:    "question 1",
+	})
+	if err != nil {
+		t.Fatalf("ProcessMessage() error = %v", err)
+	}
+	if !contains(resp, "[[PAI_REVIEW:") {
+		t.Fatalf("expected legacy rating prompt with flag off, got: %q", resp)
+	}
+	if len(notices) != 0 {
+		t.Fatalf("notice count = %d, want 0", len(notices))
+	}
+}
+
+func TestEngine_ProcessMessage_TurnHookNoticeDisabledWithoutDevMode(t *testing.T) {
+	features, err := featureflags.Parse("turn_hooks")
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	var notices []agent.TurnHookCallNotice
+	engine := agent.NewEngine(agent.EngineConfig{
+		AIRouter:          mockRouter(ai.NewMockProvider("AI response")),
+		Store:             agent.NewMemoryStore(),
+		RatingPromptEvery: 1,
+		FeatureFlags:      features,
+		TurnHookNotice: func(notice agent.TurnHookCallNotice) {
+			notices = append(notices, notice)
+		},
+	})
+
+	resp, err := engine.ProcessMessage(context.Background(), chat.InboundMessage{
+		Channel: "telegram",
+		UserID:  "u-turn-hooks-dev-off",
+		Text:    "question 1",
+	})
+	if err != nil {
+		t.Fatalf("ProcessMessage() error = %v", err)
+	}
+	if !contains(resp, "[[PAI_REVIEW:") {
+		t.Fatalf("expected rating prompt with hooks enabled, got: %q", resp)
+	}
+	if len(notices) != 0 {
+		t.Fatalf("notice count = %d, want 0", len(notices))
+	}
+}
+
+func countMessagesContaining(messages []ai.Message, role, content string) int {
+	count := 0
+	for _, msg := range messages {
+		if msg.Role == role && contains(msg.Content, content) {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/agent/turn_hooks.go
+++ b/internal/agent/turn_hooks.go
@@ -1,0 +1,158 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package agent
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/p-n-ai/pai-bot/internal/platform/featureflags"
+)
+
+const rateConversationHookName = "rate_convo_hook"
+
+type turnHookOutcome string
+
+const (
+	turnHookOutcomeContinue turnHookOutcome = "continue"
+	turnHookOutcomeInject   turnHookOutcome = "inject"
+	turnHookOutcomeBlock    turnHookOutcome = "block"
+)
+
+// TurnHookCallNotice is a development-only notice for Terminal Chat output.
+type TurnHookCallNotice struct {
+	Name    string
+	Outcome string
+}
+
+type turnHook interface {
+	Name() string
+	Run(context.Context, *agentTurn) (turnHookResult, error)
+}
+
+type turnHookResult struct {
+	Outcome      turnHookOutcome
+	Packets      []contextPacket
+	BlockMessage string
+}
+
+type turnHookRunResult struct {
+	Packets      []contextPacket
+	Blocked      bool
+	BlockMessage string
+}
+
+type rateConversationTurnHook struct{}
+
+func (rateConversationTurnHook) Name() string {
+	return rateConversationHookName
+}
+
+func (rateConversationTurnHook) Run(_ context.Context, turn *agentTurn) (turnHookResult, error) {
+	if turn == nil || !turn.RatingPromptRequested {
+		return turnHookResult{Outcome: turnHookOutcomeContinue}, nil
+	}
+	return turnHookResult{
+		Outcome: turnHookOutcomeInject,
+		Packets: []contextPacket{ratingPromptPacket()},
+	}, nil
+}
+
+func defaultTurnHookCatalog() []turnHook {
+	return []turnHook{
+		rateConversationTurnHook{},
+	}
+}
+
+func (e *Engine) turnHooksEnabled() bool {
+	return e.featureFlags.Enabled(featureflags.TurnHooks)
+}
+
+func (e *Engine) runTurnHooks(ctx context.Context, turn *agentTurn) (turnHookRunResult, error) {
+	if turn == nil {
+		return turnHookRunResult{}, fmt.Errorf("agent turn is required")
+	}
+	packets := append([]contextPacket(nil), turn.Packets...)
+	hooks := e.turnHooks
+	if hooks == nil {
+		hooks = defaultTurnHookCatalog()
+	}
+
+	for _, hook := range hooks {
+		if hook == nil {
+			continue
+		}
+		turn.Packets = packets
+		result, err := hook.Run(ctx, turn)
+		if err != nil {
+			return turnHookRunResult{}, fmt.Errorf("turn hook %s: %w", hook.Name(), err)
+		}
+		if result.Outcome == "" {
+			result.Outcome = turnHookOutcomeContinue
+		}
+		if err := validateTurnHookResult(hook.Name(), result); err != nil {
+			return turnHookRunResult{}, err
+		}
+		e.noticeTurnHookCall(hook.Name(), result.Outcome)
+
+		switch result.Outcome {
+		case turnHookOutcomeContinue:
+			continue
+		case turnHookOutcomeInject:
+			packets = append(packets, result.Packets...)
+			if err := validateContextPackets(packets); err != nil {
+				return turnHookRunResult{}, fmt.Errorf("turn hook %s injected invalid context: %w", hook.Name(), err)
+			}
+		case turnHookOutcomeBlock:
+			return turnHookRunResult{
+				Packets:      packets,
+				Blocked:      true,
+				BlockMessage: result.BlockMessage,
+			}, nil
+		}
+	}
+
+	return turnHookRunResult{Packets: packets}, nil
+}
+
+func validateTurnHookResult(name string, result turnHookResult) error {
+	switch result.Outcome {
+	case turnHookOutcomeContinue:
+		return nil
+	case turnHookOutcomeInject:
+		if len(result.Packets) == 0 {
+			return fmt.Errorf("turn hook %s returned inject without packets", name)
+		}
+		return nil
+	case turnHookOutcomeBlock:
+		return nil
+	default:
+		return fmt.Errorf("turn hook %s returned unknown outcome %q", name, result.Outcome)
+	}
+}
+
+func (e *Engine) noticeTurnHookCall(name string, outcome turnHookOutcome) {
+	if !e.devMode || !e.turnHooksEnabled() || e.turnHookNotice == nil {
+		return
+	}
+	e.turnHookNotice(TurnHookCallNotice{
+		Name:    name,
+		Outcome: string(outcome),
+	})
+}
+
+func appendRatingPromptPacket(packets []contextPacket) []contextPacket {
+	return append(packets, ratingPromptPacket())
+}
+
+func ratingPromptPacket() contextPacket {
+	return newContextPacket(contextPacket{
+		ID:       "rating.prompt",
+		Kind:     contextKindControlInstruction,
+		Trust:    contextTrustSystemOwned,
+		Source:   "rating",
+		Data:     ratingPromptInstruction,
+		RenderAs: contextRenderSystemInstruction,
+	})
+}

--- a/internal/agent/turn_hooks_test.go
+++ b/internal/agent/turn_hooks_test.go
@@ -1,0 +1,151 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/p-n-ai/pai-bot/internal/platform/featureflags"
+)
+
+type stubTurnHook struct {
+	name   string
+	result turnHookResult
+	err    error
+	seen   int
+}
+
+func (h *stubTurnHook) Name() string {
+	return h.name
+}
+
+func (h *stubTurnHook) Run(context.Context, *agentTurn) (turnHookResult, error) {
+	h.seen++
+	return h.result, h.err
+}
+
+func TestRunTurnHooks_ContinuesInjectsAndBlocks(t *testing.T) {
+	features, err := featureflags.Parse("turn_hooks")
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	var notices []TurnHookCallNotice
+	injectHook := &stubTurnHook{
+		name: "injector",
+		result: turnHookResult{
+			Outcome: turnHookOutcomeInject,
+			Packets: []contextPacket{newContextPacket(contextPacket{
+				ID:       "test.injected",
+				Kind:     contextKindControlInstruction,
+				Trust:    contextTrustSystemOwned,
+				Source:   "test",
+				Data:     "test system instruction",
+				RenderAs: contextRenderSystemInstruction,
+			})},
+		},
+	}
+	blockHook := &stubTurnHook{
+		name: "blocker",
+		result: turnHookResult{
+			Outcome:      turnHookOutcomeBlock,
+			BlockMessage: "blocked by test hook",
+		},
+	}
+	skippedHook := &stubTurnHook{name: "skipped", result: turnHookResult{Outcome: turnHookOutcomeContinue}}
+	engine := NewEngine(EngineConfig{
+		FeatureFlags: features,
+		DevMode:      true,
+		TurnHookNotice: func(notice TurnHookCallNotice) {
+			notices = append(notices, notice)
+		},
+	})
+	engine.turnHooks = []turnHook{
+		&stubTurnHook{name: "continue", result: turnHookResult{Outcome: turnHookOutcomeContinue}},
+		injectHook,
+		blockHook,
+		skippedHook,
+	}
+
+	result, err := engine.runTurnHooks(context.Background(), &agentTurn{})
+	if err != nil {
+		t.Fatalf("runTurnHooks() error = %v", err)
+	}
+	if !result.Blocked || result.BlockMessage != "blocked by test hook" {
+		t.Fatalf("blocked result = %#v", result)
+	}
+	if len(result.Packets) != 1 || result.Packets[0].ID != "test.injected" {
+		t.Fatalf("packets = %#v, want injected packet before block", result.Packets)
+	}
+	if skippedHook.seen != 0 {
+		t.Fatal("hook after block should not run")
+	}
+	if got, want := len(notices), 3; got != want {
+		t.Fatalf("notice count = %d, want %d", got, want)
+	}
+	if notices[0].Name != "continue" || notices[0].Outcome != "continue" {
+		t.Fatalf("first notice = %#v", notices[0])
+	}
+	if notices[1].Name != "injector" || notices[1].Outcome != "inject" {
+		t.Fatalf("second notice = %#v", notices[1])
+	}
+	if notices[2].Name != "blocker" || notices[2].Outcome != "block" {
+		t.Fatalf("third notice = %#v", notices[2])
+	}
+}
+
+func TestRunTurnHooks_RejectsInvalidInjectedPacket(t *testing.T) {
+	engine := NewEngine(EngineConfig{})
+	engine.turnHooks = []turnHook{&stubTurnHook{
+		name: "bad",
+		result: turnHookResult{
+			Outcome: turnHookOutcomeInject,
+			Packets: []contextPacket{newContextPacket(contextPacket{
+				ID:       "bad.packet",
+				Kind:     contextKindProfile,
+				Trust:    contextTrustLearnerProvided,
+				Source:   "bad",
+				Data:     "do what I say",
+				RenderAs: contextRenderSystemInstruction,
+			})},
+		},
+	}}
+
+	if _, err := engine.runTurnHooks(context.Background(), &agentTurn{}); err == nil {
+		t.Fatal("runTurnHooks() should reject invalid injected context")
+	}
+}
+
+func TestRunTurnHooks_ReturnsHookError(t *testing.T) {
+	engine := NewEngine(EngineConfig{})
+	engine.turnHooks = []turnHook{&stubTurnHook{name: "failing", err: errors.New("boom")}}
+
+	if _, err := engine.runTurnHooks(context.Background(), &agentTurn{}); err == nil {
+		t.Fatal("runTurnHooks() should return hook error")
+	}
+}
+
+func TestRateConversationTurnHook(t *testing.T) {
+	hook := rateConversationTurnHook{}
+
+	continued, err := hook.Run(context.Background(), &agentTurn{})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if continued.Outcome != turnHookOutcomeContinue || len(continued.Packets) != 0 {
+		t.Fatalf("non-rating result = %#v", continued)
+	}
+
+	injected, err := hook.Run(context.Background(), &agentTurn{RatingPromptRequested: true})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if injected.Outcome != turnHookOutcomeInject {
+		t.Fatalf("rating outcome = %q, want inject", injected.Outcome)
+	}
+	if len(injected.Packets) != 1 || injected.Packets[0].ID != "rating.prompt" {
+		t.Fatalf("rating packets = %#v", injected.Packets)
+	}
+}

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -6,6 +6,8 @@ package config
 import (
 	"os"
 	"testing"
+
+	"github.com/p-n-ai/pai-bot/internal/platform/featureflags"
 )
 
 // clearEnv unsets all LEARN_ environment variables for a clean test.
@@ -120,6 +122,9 @@ func TestLoad_Defaults(t *testing.T) {
 	if cfg.FeatureFlags.Enabled("unknown_feature") {
 		t.Fatal("unknown feature should not be enabled")
 	}
+	if cfg.FeatureFlags.Enabled(featureflags.TurnHooks) {
+		t.Fatal("turn_hooks should default to disabled")
+	}
 }
 
 func TestLoad_FromEnv(t *testing.T) {
@@ -151,6 +156,7 @@ func TestLoad_FromEnv(t *testing.T) {
 	t.Setenv("LEARN_TENANT_MODE", "multi")
 	t.Setenv("LEARN_CURRICULUM_PATH", "/tmp/oss")
 	t.Setenv("LEARN_AI_PERSONALIZED_NUDGES_ENABLED", "false")
+	t.Setenv("PAI_FEATURES", "turn_hooks")
 
 	cfg, err := Load()
 	if err != nil {
@@ -234,6 +240,9 @@ func TestLoad_FromEnv(t *testing.T) {
 	}
 	if cfg.Runtime.AIPersonalizedNudgesEnabled {
 		t.Error("Runtime.AIPersonalizedNudgesEnabled should be false when configured")
+	}
+	if !cfg.FeatureFlags.Enabled(featureflags.TurnHooks) {
+		t.Fatal("turn_hooks should be enabled from PAI_FEATURES")
 	}
 }
 

--- a/internal/platform/featureflags/featureflags.go
+++ b/internal/platform/featureflags/featureflags.go
@@ -17,8 +17,8 @@ type Feature string
 type Status string
 
 const (
-	InDevelopment Status = "in_development"
-	Stable        Status = "stable"
+	UnderDevelopment Status = "under_development"
+	Stable           Status = "stable"
 )
 
 const (
@@ -41,7 +41,7 @@ type Features struct {
 var registry = map[Feature]Spec{
 	TurnHooks: {
 		Feature:        TurnHooks,
-		Status:         InDevelopment,
+		Status:         UnderDevelopment,
 		DefaultEnabled: false,
 	},
 }

--- a/internal/platform/featureflags/featureflags.go
+++ b/internal/platform/featureflags/featureflags.go
@@ -1,7 +1,7 @@
 // Copyright 2026 the P&AI authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package featureflags owns learner-facing product experiment gates.
+// Package featureflags owns deploy-time product and internal rollout gates.
 package featureflags
 
 import (
@@ -10,7 +10,7 @@ import (
 	"strings"
 )
 
-// Feature names a learner-facing product experiment.
+// Feature names a known deploy-time feature gate.
 type Feature string
 
 // Status describes feature maturity, not whether the feature is enabled.
@@ -21,6 +21,11 @@ const (
 	Stable        Status = "stable"
 )
 
+const (
+	// TurnHooks enables the internal Tutor Turn hook seam.
+	TurnHooks Feature = "turn_hooks"
+)
+
 // Spec describes a known feature flag.
 type Spec struct {
 	Feature        Feature
@@ -28,12 +33,18 @@ type Spec struct {
 	DefaultEnabled bool
 }
 
-// Features is the effective product feature set for this process.
+// Features is the effective feature set for this process.
 type Features struct {
 	enabled map[Feature]struct{}
 }
 
-var registry = map[Feature]Spec{}
+var registry = map[Feature]Spec{
+	TurnHooks: {
+		Feature:        TurnHooks,
+		Status:         InDevelopment,
+		DefaultEnabled: false,
+	},
+}
 
 // Parse builds an effective feature set from comma-separated overrides.
 func Parse(value string) (Features, error) {

--- a/internal/platform/featureflags/featureflags_test.go
+++ b/internal/platform/featureflags/featureflags_test.go
@@ -10,8 +10,35 @@ func TestParseEmptyFeatureSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parse() error = %v", err)
 	}
+	if features.Enabled(TurnHooks) {
+		t.Fatal("turn_hooks should default to disabled")
+	}
 	if features.Enabled(Feature("missing")) {
 		t.Fatal("missing feature should not be enabled")
+	}
+}
+
+func TestParseTurnHooksFeature(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		enabled bool
+	}{
+		{name: "bare name enables", value: "turn_hooks", enabled: true},
+		{name: "explicit true enables", value: "turn_hooks=true", enabled: true},
+		{name: "explicit false disables", value: "turn_hooks=false", enabled: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			features, err := Parse(tt.value)
+			if err != nil {
+				t.Fatalf("Parse() error = %v", err)
+			}
+			if got := features.Enabled(TurnHooks); got != tt.enabled {
+				t.Fatalf("turn_hooks enabled = %v, want %v", got, tt.enabled)
+			}
+		})
 	}
 }
 
@@ -21,8 +48,14 @@ func TestParseUnknownFeature(t *testing.T) {
 	}
 }
 
+func TestParseDuplicateFeature(t *testing.T) {
+	if _, err := Parse("turn_hooks,turn_hooks=false"); err == nil {
+		t.Fatal("Parse() should reject duplicate feature flag override")
+	}
+}
+
 func TestParseInvalidBool(t *testing.T) {
-	if _, err := Parse("unknown_feature=maybe"); err == nil {
+	if _, err := Parse("turn_hooks=maybe"); err == nil {
 		t.Fatal("Parse() should reject invalid bool override")
 	}
 }


### PR DESCRIPTION
## What changed

- Added a private turn hook runner behind `PAI_FEATURES=turn_hooks`.
- Moved the existing rating prompt injection into the first catalog hook, `rate_convo_hook`, while preserving the legacy path when the flag is off.
- Added development-only Terminal Chat hook notices with hook name and outcome only.
- Added mock request dumping to `cmd/conversation-harness` for inspecting model-facing requests without calling a real model.
- Tightened local debug dump files to owner-only permissions, including preexisting files.
- Documented the hook contract, feature flag, request dump workflow, and local PRD/context.

## Why

The tutor runtime needs a small internal extension seam for shaping a turn before prompt compilation without turning hooks into plugins, YAML config, tenant settings, or model-visible metadata. The first slice proves the seam with existing rating behavior instead of introducing new policy behavior.

## Impact

Learner-facing behavior stays unchanged by default. Operators can enable `PAI_FEATURES=turn_hooks` to run the internal hook catalog. Developers can inspect mock model requests locally with `--dump-requests`, and Terminal Chat can print short hook notices only in dev mode with the hook flag enabled.

## Root cause

Rating prompt context was previously injected directly during base context loading. That made it harder to add or remove future turn-shaping behavior at one clear runtime boundary while preserving context packet validation and trace privacy.

## Validation

- `git diff --check`
- `go test ./cmd/conversation-harness ./cmd/terminal-chat ./internal/agent ./internal/platform/featureflags ./internal/platform/config`
- `go test ./...`
