### PR TITLE
fix(site): derive base path from deployment URL

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -24,6 +24,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Configure GitHub Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
       - uses: pnpm/action-setup@v4
         with:
           version: 10
@@ -51,7 +55,7 @@ jobs:
       - name: Build
         working-directory: site
         env:
-          SITE_URL: ${{ vars.SITE_URL || 'https://p-n-ai.github.io/pai-bot' }}
+          SITE_URL: ${{ vars.SITE_URL || steps.pages.outputs.base_url }}
         run: pnpm build
 
       - uses: actions/upload-pages-artifact@v3

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -2,8 +2,12 @@ import { defineConfig } from "astro/config";
 import tailwindcss from "@tailwindcss/vite";
 import starlight from "@astrojs/starlight";
 
+const site = process.env.SITE_URL;
+const base = site ? new URL(site).pathname.replace(/\/$/, "") || "/" : "/";
+
 export default defineConfig({
-  site: process.env.SITE_URL || undefined,
+  site,
+  base,
   integrations: [
     starlight({
       title: "P&AI Bot",

--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -1,15 +1,17 @@
 ---
 const navItems = [
   { label: "Home", href: "/" },
-  { label: "Docs", href: "/getting-started/introduction" },
+  { label: "Docs", href: "/getting-started/introduction/" },
   { label: "GitHub", href: "https://github.com/p-n-ai/pai-bot", external: true },
 ];
+
+const withBase = (path) => `${import.meta.env.BASE_URL.replace(/\/$/, "")}${path}`;
 ---
 
 <header
   class="sticky top-4 z-50 mx-auto flex max-w-5xl items-center justify-between gap-3 rounded-full border border-border/80 bg-background/92 px-3 py-2 shadow-[0_10px_28px_color-mix(in_oklch,var(--foreground)_5%,transparent)] backdrop-blur sm:gap-6 sm:px-5 sm:py-3"
 >
-  <a href="/" class="flex shrink-0 items-center gap-2 sm:gap-3">
+  <a href={withBase("/")} class="flex shrink-0 items-center gap-2 sm:gap-3">
     <div class="flex size-8 items-center justify-center rounded-xl bg-primary text-primary-foreground sm:size-10 sm:rounded-2xl">
       <svg class="size-4 sm:size-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
         <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" />
@@ -24,7 +26,7 @@ const navItems = [
   <nav class="flex items-center gap-0.5 sm:gap-1">
     {navItems.map(({ label, href, external }) => (
       <a
-        href={href}
+        href={external ? href : withBase(href)}
         class="rounded-full px-2.5 py-1.5 text-xs font-medium text-muted-foreground transition hover:text-foreground sm:px-4 sm:py-2 sm:text-sm"
         {...(external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
       >

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -9,6 +9,7 @@ interface Props {
 }
 
 const { title, description = "Open-source AI learning agent that teaches students through chat." } = Astro.props;
+const withBase = (path: string) => `${import.meta.env.BASE_URL.replace(/\/$/, "")}${path}`;
 ---
 
 <!doctype html>
@@ -18,7 +19,7 @@ const { title, description = "Open-source AI learning agent that teaches student
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
     <title>{title}</title>
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href={withBase("/favicon.svg")} />
     <script is:inline>
       const saved = localStorage.getItem("theme");
       const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -37,6 +37,8 @@ const features = [
 const providers = [
   "OpenAI", "Anthropic", "Google Gemini", "DeepSeek", "OpenRouter", "Ollama",
 ];
+
+const withBase = (path: string) => `${import.meta.env.BASE_URL.replace(/\/$/, "")}${path}`;
 ---
 
 <BaseLayout title="P&AI Bot — Open-Source AI Learning Agent">
@@ -72,7 +74,7 @@ const providers = [
         Try on Telegram
       </a>
       <a
-        href="/getting-started/setup"
+        href={withBase("/getting-started/setup/")}
         class="inline-flex h-12 items-center gap-2 rounded-full border border-border/80 bg-card/80 px-7 text-sm font-semibold text-foreground shadow-[0_10px_24px_color-mix(in_oklch,var(--foreground)_5%,transparent)] backdrop-blur transition hover:bg-muted active:translate-y-px"
       >
         <svg class="size-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 016.5 17H20M4 19.5A2.5 2.5 0 004 17V5a2 2 0 012-2h14v14H6.5A2.5 2.5 0 004 19.5z"/></svg>


### PR DESCRIPTION
## Summary
- derive Astro's base path from the deployment URL so the site builds correctly for both GitHub Pages project sites and root-domain deployments
- use `actions/configure-pages` in the site workflow so Pages builds automatically receive the correct `SITE_URL`
- update the hand-authored landing-page links and favicon path to respect the computed base URL

## Testing
- `pnpm build` in `site/`
- `SITE_URL='https://p-n-ai.github.io/pai-bot' pnpm build` in `site/`
- `just test-all`