### PR TITLE
feat(retrieval): prototype GitHub curriculum ingest

### DIFF
--- a/.claude/skills/github-deep-review/SKILL.md
+++ b/.claude/skills/github-deep-review/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: github-deep-review
+description: Deep review GitHub issues, pull requests, bug reports, and maintainer threads for pai-bot. Use when asked to review, dig in, find root cause, judge the best fix, check whether an issue is still real, or decide whether a refactor is worth doing.
+argument-hint: [issue-or-pr-ref]
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+# GitHub Deep Review
+
+Review with evidence first. Goal: understand the bug class, trace the real code path, judge the fix quality, and say what remains unproven.
+
+## Start
+
+Use `gh`, not browser URLs.
+
+```bash
+gh issue view <n> --json number,title,state,author,body,comments,labels,updatedAt,url
+gh pr view <n> --json number,title,state,author,body,comments,reviews,files,commits,statusCheckRollup,mergeStateStatus,headRefName,headRepositoryOwner,url
+gh pr diff <n> --patch
+```
+
+Before deciding, read local rules and repo context:
+
+```bash
+git status --short --branch
+docs-list
+```
+
+Open only relevant docs from `docs-list`. For PRs, also inspect touched files, adjacent owners, and tests. If behavior depends on a dependency or platform contract, check the current upstream docs/source before assuming.
+
+## Review Contract
+
+Always answer:
+
+- Ref: issue/PR number and affected surface.
+- Bug: what behavior is broken or being changed.
+- Cause: root cause with code path, or exact missing evidence.
+- Fix: whether the proposed/current fix is the best available shape.
+- Refactor: whether a larger refactor improves correctness or only adds risk.
+- Proof: tests, CI, live repro, docs/source, or current branch behavior.
+- Risk: remaining uncertainty or coverage gap.
+
+## Code Reading Depth
+
+Follow the real path:
+
+- entrypoint -> validation/parsing -> routing/dispatch -> owner module -> shared helper -> persistence/network/runtime boundary
+- config/docs -> runtime usage -> doctor/migration/fix path
+- channel/provider owner -> shared core only when the bug crosses owners
+- tests around touched surface plus adjacent regression tests
+
+Prefer current code and executable proof over issue comments. Treat stale comments, old CI, and old release behavior as hints until rechecked.
+
+## Fix Bar
+
+Good fixes:
+
+- live at the ownership boundary where the bug belongs
+- preserve public behavior unless retiring it is the point
+- add the smallest meaningful regression test
+- avoid hidden migrations, semantic sentinels, broad special cases, or provider IDs in generic core
+- update docs/changelog when user-visible behavior changes
+- fail clearly and repair through established doctor/migration paths when they exist
+
+Call out symptom-level fixes. Recommend a refactor only when it makes the invariant clearer or reduces the bug class without widening risk too much.
+
+## PR Review Shape
+
+Lead with findings. Each finding needs file/line/symbol reference and a concrete failure mode. Avoid vague "consider" comments.
+
+If no blocking issue:
+
+- say no blocking correctness issues found
+- list strongest proof checked
+- name residual risks/test gaps
+- answer whether the design is the best available shape
+
+Do not approve, comment, close, merge, push, or land unless explicitly asked.
+
+## Issue Review Shape
+
+1. Reconstruct reporter scenario and affected version/surface.
+2. Check whether current branch already fixes it.
+3. Reproduce or create minimal proof when feasible.
+4. Identify cause and best fix when clear.
+5. If solved already, only comment/close when asked; include proof and canonical commit/PR if known.
+
+If reproduction is blocked, say exactly what is missing.
+
+## Output Template
+
+```text
+Ref: #123 / PR #456
+Surface: <runtime/CLI/provider/channel/docs>
+
+Bug: <one or two sentences>
+Cause: <code path + confidence>
+Best fix: <what should change and why>
+Refactor: <yes/no, specific shape>
+Proof: <tests/live/CI/source/dependency docs>
+Risk: <remaining uncertainty>
+```
+
+Keep it concise. Do not skip cause/fix/refactor/proof.

--- a/cmd/curriculum-knowledge-prototype/cli_test.go
+++ b/cmd/curriculum-knowledge-prototype/cli_test.go
@@ -1,0 +1,21 @@
+package main
+
+import "testing"
+
+func TestParseCLIFlags(t *testing.T) {
+	cfg, err := parseCLIFlags("ingest", []string{
+		"--query",
+		"pola jujukan",
+		"--cache",
+		"/tmp/retrieval-cache",
+	})
+	if err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	if cfg.Query != "pola jujukan" {
+		t.Fatalf("query = %q", cfg.Query)
+	}
+	if cfg.CacheDir != "/tmp/retrieval-cache" {
+		t.Fatalf("cache dir = %q", cfg.CacheDir)
+	}
+}

--- a/cmd/curriculum-knowledge-prototype/content.go
+++ b/cmd/curriculum-knowledge-prototype/content.go
@@ -1,0 +1,531 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type CurriculumContent struct {
+	ID               int
+	CurriculumSource string
+	Kind             string
+	Title            string
+	Body             string
+	Metadata         map[string]string
+	SearchText       string
+}
+
+type syllabusFile struct {
+	ID        string   `yaml:"id"`
+	Name      string   `yaml:"name"`
+	NameEN    string   `yaml:"name_en"`
+	CountryID string   `yaml:"country_id"`
+	Language  string   `yaml:"language"`
+	Subjects  []string `yaml:"subjects"`
+}
+
+type subjectFile struct {
+	ID         string `yaml:"id"`
+	Name       string `yaml:"name"`
+	NameEN     string `yaml:"name_en"`
+	SyllabusID string `yaml:"syllabus_id"`
+	CountryID  string `yaml:"country_id"`
+	Language   string `yaml:"language"`
+}
+
+type subjectGradeFile struct {
+	ID         string   `yaml:"id"`
+	Name       string   `yaml:"name"`
+	NameEN     string   `yaml:"name_en"`
+	SubjectID  string   `yaml:"subject_id"`
+	SyllabusID string   `yaml:"syllabus_id"`
+	GradeID    string   `yaml:"grade_id"`
+	CountryID  string   `yaml:"country_id"`
+	Language   string   `yaml:"language"`
+	Topics     []string `yaml:"topics"`
+}
+
+type topicFile struct {
+	ID                 string           `yaml:"id"`
+	OfficialRef        string           `yaml:"official_ref"`
+	Name               string           `yaml:"name"`
+	NameEN             string           `yaml:"name_en"`
+	SubjectGradeID     string           `yaml:"subject_grade_id"`
+	SubjectID          string           `yaml:"subject_id"`
+	SyllabusID         string           `yaml:"syllabus_id"`
+	CountryID          string           `yaml:"country_id"`
+	Language           string           `yaml:"language"`
+	Difficulty         string           `yaml:"difficulty"`
+	Tier               string           `yaml:"tier"`
+	ContentStandards   []standardFile   `yaml:"content_standards"`
+	LearningObjectives []objectiveFile  `yaml:"learning_objectives"`
+	Prerequisites      prerequisiteFile `yaml:"prerequisites"`
+	QualityLevel       int              `yaml:"quality_level"`
+	Provenance         string           `yaml:"provenance"`
+	Teaching           teachingFile     `yaml:"teaching"`
+}
+
+type standardFile struct {
+	ID     string `yaml:"id"`
+	Text   string `yaml:"text"`
+	TextEN string `yaml:"text_en"`
+}
+
+type objectiveFile struct {
+	ID                string `yaml:"id"`
+	Text              string `yaml:"text"`
+	TextEN            string `yaml:"text_en"`
+	Bloom             string `yaml:"bloom"`
+	ContentStandardID string `yaml:"content_standard_id"`
+}
+
+type prerequisiteFile struct {
+	Required    []prerequisiteRef `yaml:"required"`
+	Recommended []prerequisiteRef `yaml:"recommended"`
+}
+
+func (p *prerequisiteFile) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.SequenceNode {
+		var required []prerequisiteRef
+		if err := value.Decode(&required); err != nil {
+			return err
+		}
+		p.Required = required
+		return nil
+	}
+
+	type raw prerequisiteFile
+	var decoded raw
+	if err := value.Decode(&decoded); err != nil {
+		return err
+	}
+	*p = prerequisiteFile(decoded)
+	return nil
+}
+
+type prerequisiteRef struct {
+	ID     string `yaml:"id"`
+	NameEN string `yaml:"name_en"`
+}
+
+func (r *prerequisiteRef) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.ScalarNode {
+		r.ID = strings.TrimSpace(value.Value)
+		return nil
+	}
+
+	type raw prerequisiteRef
+	var decoded raw
+	if err := value.Decode(&decoded); err != nil {
+		return err
+	}
+	*r = prerequisiteRef(decoded)
+	return nil
+}
+
+type teachingFile struct {
+	Sequence             []string            `yaml:"sequence"`
+	CommonMisconceptions []misconceptionFile `yaml:"common_misconceptions"`
+	EngagementHooks      []string            `yaml:"engagement_hooks"`
+}
+
+type misconceptionFile struct {
+	Misconception string `yaml:"misconception"`
+	Remediation   string `yaml:"remediation"`
+}
+
+type examplesFile struct {
+	TopicID        string          `yaml:"topic_id"`
+	Provenance     string          `yaml:"provenance"`
+	WorkedExamples []workedExample `yaml:"worked_examples"`
+}
+
+type workedExample struct {
+	ID                 string `yaml:"id"`
+	Topic              string `yaml:"topic"`
+	Difficulty         string `yaml:"difficulty"`
+	TPLevel            int    `yaml:"tp_level"`
+	KBAT               bool   `yaml:"kbat"`
+	LearningObjective  string `yaml:"learning_objective"`
+	RealWorldAnalogy   string `yaml:"real_world_analogy"`
+	MisconceptionAlert string `yaml:"misconception_alert"`
+	Scenario           string `yaml:"scenario"`
+	Working            string `yaml:"working"`
+}
+
+func buildCurriculumContent(root string) ([]CurriculumContent, error) {
+	return buildCurriculumContentFromSource(root, "")
+}
+
+func buildCurriculumContentFromSource(root string, curriculumSource string) ([]CurriculumContent, error) {
+	rows := []CurriculumContent{}
+
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if entry.Name() == "translations" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		base := filepath.Base(path)
+		switch {
+		case base == "syllabus.yaml" || base == "syllabus.yml":
+			return appendYAMLContent(path, &rows, buildSyllabusContent)
+		case base == "subject.yaml" || base == "subject.yml":
+			return appendYAMLContent(path, &rows, buildSubjectContent)
+		case base == "subject-grade.yaml" || base == "subject-grade.yml":
+			return appendYAMLContent(path, &rows, buildSubjectGradeContent)
+		case strings.HasSuffix(base, ".teaching.md"):
+			return appendTeachingContent(path, &rows)
+		case strings.HasSuffix(base, ".examples.yaml") || strings.HasSuffix(base, ".examples.yml"):
+			return appendOptionalYAMLContent(path, &rows, buildExamplesContent)
+		case strings.HasSuffix(base, ".assessments.yaml") || strings.HasSuffix(base, ".assessments.yml"):
+			return appendOptionalYAMLContent(path, &rows, buildAssessmentContent)
+		case strings.HasSuffix(base, ".yaml") || strings.HasSuffix(base, ".yml"):
+			return appendYAMLContent(path, &rows, buildTopicContent)
+		default:
+			return nil
+		}
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walk curriculum: %w", err)
+	}
+
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Kind == rows[j].Kind {
+			return rows[i].Title < rows[j].Title
+		}
+		return rows[i].Kind < rows[j].Kind
+	})
+	for i := range rows {
+		rows[i].ID = i + 1
+		rows[i].CurriculumSource = curriculumSource
+	}
+	return rows, nil
+}
+
+func appendYAMLContent[T any](
+	path string,
+	rows *[]CurriculumContent,
+	build func(T) []CurriculumContent,
+) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read yaml %s: %w", path, err)
+	}
+
+	var value T
+	if err := yaml.Unmarshal(data, &value); err != nil {
+		return fmt.Errorf("parse yaml %s: %w", path, err)
+	}
+
+	for _, row := range build(value) {
+		if row.Body == "" {
+			continue
+		}
+		*rows = append(*rows, row)
+	}
+	return nil
+}
+
+func appendOptionalYAMLContent[T any](
+	path string,
+	rows *[]CurriculumContent,
+	build func(T) []CurriculumContent,
+) error {
+	if err := appendYAMLContent(path, rows, build); err != nil {
+		return nil
+	}
+	return nil
+}
+
+func buildSyllabusContent(value syllabusFile) []CurriculumContent {
+	if value.ID == "" {
+		return nil
+	}
+
+	title := firstNonEmpty(value.NameEN, value.Name, value.ID)
+	body := strings.Join([]string{
+		"syllabus: " + title,
+		"subjects: " + strings.Join(value.Subjects, ", "),
+	}, "\n")
+	return []CurriculumContent{newContent("syllabus", title, body, map[string]string{
+		"syllabus_id": value.ID,
+		"country_id":  value.CountryID,
+		"language":    value.Language,
+	})}
+}
+
+func buildSubjectContent(value subjectFile) []CurriculumContent {
+	if value.ID == "" {
+		return nil
+	}
+
+	title := firstNonEmpty(value.NameEN, value.Name, value.ID)
+	body := strings.Join([]string{
+		"subject: " + title,
+		"syllabus: " + value.SyllabusID,
+	}, "\n")
+	return []CurriculumContent{newContent("subject", title, body, map[string]string{
+		"subject_id":  value.ID,
+		"syllabus_id": value.SyllabusID,
+		"country_id":  value.CountryID,
+		"language":    value.Language,
+	})}
+}
+
+func buildSubjectGradeContent(value subjectGradeFile) []CurriculumContent {
+	if value.ID == "" {
+		return nil
+	}
+
+	title := firstNonEmpty(value.NameEN, value.Name, value.ID)
+	body := strings.Join([]string{
+		"subject grade: " + title,
+		"topics: " + strings.Join(value.Topics, ", "),
+	}, "\n")
+	return []CurriculumContent{newContent("subject_grade", title, body, map[string]string{
+		"subject_grade_id": value.ID,
+		"subject_id":       value.SubjectID,
+		"syllabus_id":      value.SyllabusID,
+		"grade_id":         value.GradeID,
+		"country_id":       value.CountryID,
+		"language":         value.Language,
+	})}
+}
+
+func buildTopicContent(value topicFile) []CurriculumContent {
+	if value.ID == "" {
+		return nil
+	}
+
+	title := firstNonEmpty(value.NameEN, value.Name, value.ID)
+	parts := []string{
+		"topic: " + title,
+		"official ref: " + value.OfficialRef,
+		"difficulty: " + value.Difficulty,
+		"tier: " + value.Tier,
+	}
+	for _, standard := range value.ContentStandards {
+		text := firstNonEmpty(standard.TextEN, standard.Text)
+		if text != "" {
+			parts = append(parts, "standard "+standard.ID+": "+text)
+		}
+	}
+	for _, objective := range value.LearningObjectives {
+		text := firstNonEmpty(objective.TextEN, objective.Text)
+		if text != "" {
+			parts = append(parts, "objective "+objective.ID+": "+text)
+		}
+	}
+	if len(value.Prerequisites.Required) > 0 {
+		parts = append(parts, "required prerequisites: "+joinPrerequisites(value.Prerequisites.Required))
+	}
+	for _, step := range value.Teaching.Sequence {
+		parts = append(parts, "teaching step: "+step)
+	}
+	for _, item := range value.Teaching.CommonMisconceptions {
+		if item.Misconception != "" {
+			parts = append(parts, "misconception: "+item.Misconception)
+		}
+		if item.Remediation != "" {
+			parts = append(parts, "remediation: "+item.Remediation)
+		}
+	}
+	for _, hook := range value.Teaching.EngagementHooks {
+		parts = append(parts, "engagement hook: "+hook)
+	}
+
+	return []CurriculumContent{newContent("topic_card", title, strings.Join(parts, "\n"), map[string]string{
+		"topic_id":         value.ID,
+		"subject_grade_id": value.SubjectGradeID,
+		"subject_id":       value.SubjectID,
+		"syllabus_id":      value.SyllabusID,
+		"country_id":       value.CountryID,
+		"language":         value.Language,
+		"difficulty":       value.Difficulty,
+		"tier":             value.Tier,
+		"provenance":       value.Provenance,
+	})}
+}
+
+func appendTeachingContent(path string, rows *[]CurriculumContent) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read teaching notes: %w", err)
+	}
+
+	topicID := strings.TrimSuffix(filepath.Base(path), ".teaching.md")
+	for _, section := range splitMarkdownSections(string(data)) {
+		body := strings.TrimSpace(section.text)
+		if body == "" {
+			continue
+		}
+		*rows = append(*rows, newContent("teaching_note", section.title, body, map[string]string{
+			"topic_id": topicID,
+			"heading":  section.title,
+		}))
+	}
+	return nil
+}
+
+func buildExamplesContent(value examplesFile) []CurriculumContent {
+	if value.TopicID == "" {
+		return nil
+	}
+
+	rows := make([]CurriculumContent, 0, len(value.WorkedExamples))
+	for _, example := range value.WorkedExamples {
+		title := firstNonEmpty(example.Topic, example.Scenario, example.ID)
+		body := strings.Join(nonEmptyStrings(
+			"scenario: "+example.Scenario,
+			"analogy: "+example.RealWorldAnalogy,
+			"misconception: "+example.MisconceptionAlert,
+			"working: "+example.Working,
+		), "\n")
+		rows = append(rows, newContent("worked_example", title, body, map[string]string{
+			"topic_id":           value.TopicID,
+			"example_id":         example.ID,
+			"difficulty":         example.Difficulty,
+			"learning_objective": example.LearningObjective,
+			"provenance":         value.Provenance,
+			"tp_level":           fmt.Sprint(example.TPLevel),
+			"kbat":               fmt.Sprint(example.KBAT),
+		}))
+	}
+	return rows
+}
+
+func buildAssessmentContent(value curriculumAssessmentFile) []CurriculumContent {
+	if value.TopicID == "" {
+		return nil
+	}
+
+	rows := make([]CurriculumContent, 0, len(value.Questions))
+	for _, question := range value.Questions {
+		title := firstNonEmpty(question.Text, question.ID)
+		body := strings.Join(nonEmptyStrings(
+			"question: "+question.Text,
+			"answer: "+question.Answer.Value,
+			"working: "+question.Answer.Working,
+			"hints: "+joinHints(question.Hints),
+		), "\n")
+		rows = append(rows, newContent("assessment_item", title, body, map[string]string{
+			"topic_id":           value.TopicID,
+			"question_id":        question.ID,
+			"difficulty":         question.Difficulty,
+			"learning_objective": question.LearningObjective,
+			"answer_type":        question.Answer.Type,
+			"marks":              fmt.Sprint(question.Marks),
+			"provenance":         value.Provenance,
+		}))
+	}
+	return rows
+}
+
+type curriculumAssessmentFile struct {
+	TopicID    string                     `yaml:"topic_id"`
+	Provenance string                     `yaml:"provenance"`
+	Questions  []curriculumAssessmentItem `yaml:"questions"`
+}
+
+type curriculumAssessmentItem struct {
+	ID                string           `yaml:"id"`
+	Text              string           `yaml:"text"`
+	Difficulty        string           `yaml:"difficulty"`
+	LearningObjective string           `yaml:"learning_objective"`
+	Answer            curriculumAnswer `yaml:"answer"`
+	Marks             int              `yaml:"marks"`
+	Hints             []curriculumHint `yaml:"hints"`
+}
+
+type curriculumAnswer struct {
+	Type    string `yaml:"type"`
+	Value   string `yaml:"value"`
+	Working string `yaml:"working"`
+}
+
+type curriculumHint struct {
+	Level int    `yaml:"level"`
+	Text  string `yaml:"text"`
+}
+
+func newContent(kind string, title string, body string, metadata map[string]string) CurriculumContent {
+	searchTextParts := []string{
+		"kind: " + kind,
+		"title: " + title,
+		"body: " + body,
+	}
+
+	keys := make([]string, 0, len(metadata))
+	for key := range metadata {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		value := metadata[key]
+		if value != "" {
+			searchTextParts = append(searchTextParts, key+": "+value)
+		}
+	}
+
+	return CurriculumContent{
+		Kind:       kind,
+		Title:      title,
+		Body:       body,
+		Metadata:   metadata,
+		SearchText: strings.Join(searchTextParts, "\n"),
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func nonEmptyStrings(values ...string) []string {
+	out := []string{}
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func joinHints(hints []curriculumHint) string {
+	parts := make([]string, 0, len(hints))
+	for _, hint := range hints {
+		if hint.Text != "" {
+			parts = append(parts, fmt.Sprintf("%d: %s", hint.Level, hint.Text))
+		}
+	}
+	return strings.Join(parts, "; ")
+}
+
+func joinPrerequisites(prerequisites []prerequisiteRef) string {
+	parts := make([]string, 0, len(prerequisites))
+	for _, prerequisite := range prerequisites {
+		label := firstNonEmpty(prerequisite.ID, prerequisite.NameEN)
+		if prerequisite.ID != "" && prerequisite.NameEN != "" {
+			label = prerequisite.ID + " " + prerequisite.NameEN
+		}
+		if label != "" {
+			parts = append(parts, label)
+		}
+	}
+	return strings.Join(parts, ", ")
+}

--- a/cmd/curriculum-knowledge-prototype/content_test.go
+++ b/cmd/curriculum-knowledge-prototype/content_test.go
@@ -144,7 +144,7 @@ func TestNewContentBuildsDeterministicSearchText(t *testing.T) {
 	if countryIndex < 0 || gradeIndex < 0 || topicIndex < 0 {
 		t.Fatalf("search text missing metadata:\n%s", row.SearchText)
 	}
-	if !(countryIndex < gradeIndex && gradeIndex < topicIndex) {
+	if countryIndex >= gradeIndex || gradeIndex >= topicIndex {
 		t.Fatalf("metadata should be sorted in search text:\n%s", row.SearchText)
 	}
 }

--- a/cmd/curriculum-knowledge-prototype/content_test.go
+++ b/cmd/curriculum-knowledge-prototype/content_test.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestBuildCurriculumContentMapsOSSShape(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "syllabus.yaml", `
+id: malaysia-kssm
+name: KSSM
+name_en: KSSM
+country_id: malaysia
+language: ms
+subjects:
+  - malaysia-kssm-matematik
+`)
+	writeFile(t, root, "malaysia-kssm-matematik/subject.yaml", `
+id: malaysia-kssm-matematik
+name: Matematik
+name_en: Mathematics
+syllabus_id: malaysia-kssm
+country_id: malaysia
+language: ms
+`)
+	writeFile(t, root, "malaysia-kssm-matematik/malaysia-kssm-matematik-tingkatan-2/subject-grade.yaml", `
+id: malaysia-kssm-matematik-tingkatan-2
+name: Matematik Tingkatan 2
+name_en: Mathematics Form 2
+subject_id: malaysia-kssm-matematik
+syllabus_id: malaysia-kssm
+grade_id: tingkatan-2
+country_id: malaysia
+language: ms
+topics:
+  - MT2-01
+`)
+	writeFile(t, root, "malaysia-kssm-matematik/malaysia-kssm-matematik-tingkatan-2/topics/MT2-01.yaml", `
+id: MT2-01
+official_ref: Bab 1
+name: Pola dan Jujukan
+name_en: Patterns and Sequences
+subject_grade_id: malaysia-kssm-matematik-tingkatan-2
+subject_id: malaysia-kssm-matematik
+syllabus_id: malaysia-kssm
+country_id: malaysia
+language: en
+difficulty: intermediate
+tier: core
+content_standards:
+  - id: "1.1"
+    text_en: Patterns
+learning_objectives:
+  - id: 1.1.1
+    text_en: Identify patterns.
+    bloom: understand
+prerequisites:
+  required:
+    - id: MT1-00
+      name_en: Prior Topic
+quality_level: 3
+provenance: ai-assisted
+`)
+	writeFile(t, root, "malaysia-kssm-matematik/malaysia-kssm-matematik-tingkatan-2/topics/MT2-01.teaching.md", `
+#### Overview
+Teach patterns with short examples.
+
+#### High Alert Misconceptions
+Students may assume the first jump is enough.
+`)
+	writeFile(t, root, "malaysia-kssm-matematik/malaysia-kssm-matematik-tingkatan-2/topics/MT2-01.examples.yaml", `
+topic_id: MT2-01
+provenance: ai-assisted
+worked_examples:
+  - id: WE-01
+    topic: Identifying Patterns
+    difficulty: easy
+    misconception_alert: Check every jump.
+    scenario: Extend 2, 4, 6.
+    working: Add 2 each time.
+`)
+	writeFile(t, root, "malaysia-kssm-matematik/malaysia-kssm-matematik-tingkatan-2/topics/MT2-01.assessments.yaml", `
+topic_id: MT2-01
+provenance: ai-assisted
+questions:
+  - id: Q1
+    text: What comes next after 2, 4, 6?
+    difficulty: easy
+    learning_objective: 1.1.1
+    answer:
+      type: exact
+      value: "8"
+    marks: 1
+`)
+
+	rows, err := buildCurriculumContent(root)
+	if err != nil {
+		t.Fatalf("build content: %v", err)
+	}
+
+	got := make([]string, 0, len(rows))
+	for _, row := range rows {
+		got = append(got, row.Kind)
+		if row.Body == "" {
+			t.Fatalf("row %q has empty body", row.Kind)
+		}
+		if row.SearchText == "" {
+			t.Fatalf("row %q has empty search text", row.Kind)
+		}
+	}
+	slices.Sort(got)
+
+	want := []string{
+		"assessment_item",
+		"subject",
+		"subject_grade",
+		"syllabus",
+		"teaching_note",
+		"teaching_note",
+		"topic_card",
+		"worked_example",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("kinds mismatch\ngot:  %v\nwant: %v", got, want)
+	}
+}
+
+func TestNewContentBuildsDeterministicSearchText(t *testing.T) {
+	row := newContent("topic_card", "Patterns", "body", map[string]string{
+		"topic_id":   "MT2-01",
+		"country_id": "malaysia",
+		"grade_id":   "tingkatan-2",
+	})
+
+	countryIndex := strings.Index(row.SearchText, "country_id: malaysia")
+	gradeIndex := strings.Index(row.SearchText, "grade_id: tingkatan-2")
+	topicIndex := strings.Index(row.SearchText, "topic_id: MT2-01")
+	if countryIndex < 0 || gradeIndex < 0 || topicIndex < 0 {
+		t.Fatalf("search text missing metadata:\n%s", row.SearchText)
+	}
+	if !(countryIndex < gradeIndex && gradeIndex < topicIndex) {
+		t.Fatalf("metadata should be sorted in search text:\n%s", row.SearchText)
+	}
+}
+
+func TestPrerequisitesCanBeASequence(t *testing.T) {
+	var got topicFile
+	data := []byte(`
+id: MT4-07
+name_en: Graphs of Motion
+prerequisites:
+  - "Form 1: Basic linear equations."
+  - "Form 2: Speed, distance, and time."
+`)
+	if err := yaml.Unmarshal(data, &got); err != nil {
+		t.Fatalf("parse topic: %v", err)
+	}
+	if len(got.Prerequisites.Required) != 2 {
+		t.Fatalf("required prerequisites = %v", got.Prerequisites.Required)
+	}
+}
+
+func writeFile(t *testing.T, root, name, body string) {
+	t.Helper()
+
+	path := filepath.Join(root, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+}

--- a/cmd/curriculum-knowledge-prototype/main.go
+++ b/cmd/curriculum-knowledge-prototype/main.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/p-n-ai/pai-bot/internal/platform/database"
+)
+
+func main() {
+	if err := runCLI(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func runCLI(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("command is required: ingest, search, or drop")
+	}
+
+	command := args[0]
+	args = args[1:]
+
+	switch command {
+	case "ingest":
+		cfg, err := parseCLIFlags(command, args)
+		if err != nil {
+			return err
+		}
+		return runPostgresPrototype(cfg.Query, cfg.CacheDir)
+	case "search":
+		cfg, err := parseCLIFlags(command, args)
+		if err != nil {
+			return err
+		}
+		return runPostgresSearch(cfg.Query)
+	case "drop":
+		return runPostgresDrop()
+	default:
+		return fmt.Errorf("unknown command %q", command)
+	}
+}
+
+type cliConfig struct {
+	Query    string
+	CacheDir string
+}
+
+func parseCLIFlags(command string, args []string) (cliConfig, error) {
+	flags := flag.NewFlagSet(command, flag.ContinueOnError)
+	query := flags.String("query", "linear equations", "query to run")
+	cacheDir := flags.String("cache", filepath.Join("tmp", "curriculum-knowledge-prototype"), "temporary source cache")
+	if err := flags.Parse(args); err != nil {
+		return cliConfig{}, err
+	}
+	return cliConfig{
+		Query:    *query,
+		CacheDir: *cacheDir,
+	}, nil
+}
+
+func runPostgresPrototype(query string, cacheDir string) error {
+	databaseURL := os.Getenv("DATABASE_URL")
+	if strings.TrimSpace(databaseURL) == "" {
+		return fmt.Errorf("database url is required for postgres prototype")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	db, err := database.New(ctx, databaseURL, 4, 0)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	store := newContentStore(db.Pool)
+	source := os.Getenv("CURRICULUM_SOURCE")
+	if strings.TrimSpace(source) == "" {
+		return fmt.Errorf("curriculum source is required for ingest")
+	}
+
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return fmt.Errorf("create cache directory: %w", err)
+	}
+	root, cleanup, err := materializeSource(ctx, source, cacheDir)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	rows, err := buildCurriculumContentFromSource(root, source)
+	if err != nil {
+		return err
+	}
+	if len(rows) == 0 {
+		return fmt.Errorf("no curriculum content found")
+	}
+
+	if err := store.applySchema(ctx); err != nil {
+		return err
+	}
+	if err := store.replaceContent(ctx, rows); err != nil {
+		return err
+	}
+
+	hits, err := store.searchText(ctx, query, 5)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("postgres prototype: PASS")
+	fmt.Printf("content_rows: %d\n", len(rows))
+	fmt.Printf("query: %q\n", query)
+	fmt.Println("top_hits:")
+	for _, hit := range hits {
+		fmt.Printf("- score=%.4f kind=%s title=%q\n", hit.Score, hit.Content.Kind, hit.Content.Title)
+	}
+	return nil
+}
+
+func runPostgresSearch(query string) error {
+	databaseURL := os.Getenv("DATABASE_URL")
+	if strings.TrimSpace(databaseURL) == "" {
+		return fmt.Errorf("database url is required for postgres prototype")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	db, err := database.New(ctx, databaseURL, 4, 0)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	store := newContentStore(db.Pool)
+	hits, err := store.searchText(ctx, query, 5)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("query: %q\n", query)
+	fmt.Println("top_hits:")
+	for _, hit := range hits {
+		fmt.Printf("- id=%d score=%.4f kind=%s title=%q\n", hit.Content.ID, hit.Score, hit.Content.Kind, hit.Content.Title)
+	}
+	return nil
+}
+
+func runPostgresDrop() error {
+	databaseURL := os.Getenv("DATABASE_URL")
+	if strings.TrimSpace(databaseURL) == "" {
+		return fmt.Errorf("database url is required for postgres prototype")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	db, err := database.New(ctx, databaseURL, 4, 0)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	store := newContentStore(db.Pool)
+	if err := store.drop(ctx); err != nil {
+		return err
+	}
+	fmt.Println("dropped retrieval_prototype schema")
+	return nil
+}

--- a/cmd/curriculum-knowledge-prototype/markdown.go
+++ b/cmd/curriculum-knowledge-prototype/markdown.go
@@ -1,0 +1,45 @@
+package main
+
+import "strings"
+
+type markdownSection struct {
+	title string
+	text  string
+}
+
+func splitMarkdownSections(markdown string) []markdownSection {
+	lines := strings.Split(markdown, "\n")
+	sections := []markdownSection{}
+	title := "Overview"
+	body := []string{}
+
+	flush := func() {
+		text := strings.TrimSpace(strings.Join(body, "\n"))
+		if text == "" {
+			return
+		}
+		sections = append(sections, markdownSection{
+			title: title,
+			text:  text,
+		})
+	}
+
+	for _, line := range lines {
+		if strings.HasPrefix(line, "#") {
+			flush()
+			title = strings.TrimSpace(strings.TrimLeft(line, "#"))
+			body = body[:0]
+			continue
+		}
+		body = append(body, line)
+	}
+	flush()
+
+	if len(sections) == 0 && strings.TrimSpace(markdown) != "" {
+		return []markdownSection{{
+			title: "Notes",
+			text:  markdown,
+		}}
+	}
+	return sections
+}

--- a/cmd/curriculum-knowledge-prototype/source.go
+++ b/cmd/curriculum-knowledge-prototype/source.go
@@ -112,7 +112,7 @@ func downloadArchive(ctx context.Context, sourceURL string, dst string) error {
 	if err != nil {
 		return fmt.Errorf("download source archive: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("download source archive: status %d", resp.StatusCode)
@@ -122,10 +122,12 @@ func downloadArchive(ctx context.Context, sourceURL string, dst string) error {
 	if err != nil {
 		return fmt.Errorf("create archive file: %w", err)
 	}
-	defer out.Close()
-
 	if _, err := io.Copy(out, resp.Body); err != nil {
+		_ = out.Close()
 		return fmt.Errorf("write archive file: %w", err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("close archive file: %w", err)
 	}
 	return nil
 }
@@ -135,7 +137,7 @@ func extractZip(src string, dst string) error {
 	if err != nil {
 		return fmt.Errorf("open source archive: %w", err)
 	}
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 
 	for _, file := range reader.File {
 		cleanName := filepath.Clean(file.Name)
@@ -179,16 +181,18 @@ func extractZipFile(file *zip.File, target string) error {
 	if err != nil {
 		return fmt.Errorf("open archive member: %w", err)
 	}
-	defer in.Close()
+	defer func() { _ = in.Close() }()
 
 	out, err := os.Create(target)
 	if err != nil {
 		return fmt.Errorf("create extracted file: %w", err)
 	}
-	defer out.Close()
-
 	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
 		return fmt.Errorf("extract archive member: %w", err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("close extracted file: %w", err)
 	}
 	return nil
 }

--- a/cmd/curriculum-knowledge-prototype/source.go
+++ b/cmd/curriculum-knowledge-prototype/source.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"archive/zip"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func materializeSource(ctx context.Context, source string, cacheDir string) (string, func(), error) {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return "", func() {}, fmt.Errorf("curriculum source is empty")
+	}
+
+	sourceRef, err := parseGitHubSource(source)
+	if err != nil {
+		return "", func() {}, err
+	}
+
+	workDir, err := os.MkdirTemp(cacheDir, "curriculum-source-*")
+	if err != nil {
+		return "", func() {}, fmt.Errorf("create source cache: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(workDir) }
+
+	archivePath := filepath.Join(workDir, "source.zip")
+	if err := downloadArchive(ctx, sourceRef.ArchiveURL, archivePath); err != nil {
+		cleanup()
+		return "", func() {}, err
+	}
+
+	extractDir := filepath.Join(workDir, "extract")
+	if err := extractZip(archivePath, extractDir); err != nil {
+		cleanup()
+		return "", func() {}, err
+	}
+
+	root, err := singleExtractedRoot(extractDir)
+	if err != nil {
+		cleanup()
+		return "", func() {}, err
+	}
+	if sourceRef.Subpath != "" {
+		root = filepath.Join(root, sourceRef.Subpath)
+		if stat, err := os.Stat(root); err != nil || !stat.IsDir() {
+			cleanup()
+			return "", func() {}, fmt.Errorf("github source path not found: %s", sourceRef.Subpath)
+		}
+	}
+	return root, cleanup, nil
+}
+
+func archiveURLForSource(source string) (string, error) {
+	sourceRef, err := parseGitHubSource(source)
+	if err != nil {
+		return "", err
+	}
+	return sourceRef.ArchiveURL, nil
+}
+
+type githubSource struct {
+	ArchiveURL string
+	Subpath    string
+}
+
+func parseGitHubSource(source string) (githubSource, error) {
+	parsed, err := url.Parse(source)
+	if err != nil || parsed.Scheme == "" {
+		return githubSource{}, fmt.Errorf("source must be a GitHub repository URL")
+	}
+	if parsed.Host != "github.com" {
+		return githubSource{}, fmt.Errorf("github source must use github.com")
+	}
+
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(parts) < 2 {
+		return githubSource{}, fmt.Errorf("github source must include owner and repo")
+	}
+
+	branch := "main"
+	subpath := ""
+	if len(parts) >= 4 && parts[2] == "tree" {
+		branch = parts[3]
+		if len(parts) > 4 {
+			subpath = filepath.Join(parts[4:]...)
+		}
+	}
+	return githubSource{
+		ArchiveURL: fmt.Sprintf("https://codeload.github.com/%s/%s/zip/refs/heads/%s", parts[0], parts[1], branch),
+		Subpath:    subpath,
+	}, nil
+}
+
+func downloadArchive(ctx context.Context, sourceURL string, dst string) error {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, sourceURL, nil)
+	if err != nil {
+		return fmt.Errorf("create source request: %w", err)
+	}
+
+	client := http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("download source archive: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("download source archive: status %d", resp.StatusCode)
+	}
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return fmt.Errorf("create archive file: %w", err)
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, resp.Body); err != nil {
+		return fmt.Errorf("write archive file: %w", err)
+	}
+	return nil
+}
+
+func extractZip(src string, dst string) error {
+	reader, err := zip.OpenReader(src)
+	if err != nil {
+		return fmt.Errorf("open source archive: %w", err)
+	}
+	defer reader.Close()
+
+	for _, file := range reader.File {
+		cleanName := filepath.Clean(file.Name)
+		if strings.HasPrefix(cleanName, "..") || filepath.IsAbs(cleanName) {
+			return fmt.Errorf("unsafe archive path")
+		}
+
+		target := filepath.Join(dst, cleanName)
+		if !isPathInside(dst, target) {
+			return fmt.Errorf("unsafe archive path")
+		}
+		if file.FileInfo().IsDir() {
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return fmt.Errorf("create archive directory: %w", err)
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return fmt.Errorf("create archive parent: %w", err)
+		}
+
+		if err := extractZipFile(file, target); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func isPathInside(root string, path string) bool {
+	root = filepath.Clean(root)
+	path = filepath.Clean(path)
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)))
+}
+
+func extractZipFile(file *zip.File, target string) error {
+	in, err := file.Open()
+	if err != nil {
+		return fmt.Errorf("open archive member: %w", err)
+	}
+	defer in.Close()
+
+	out, err := os.Create(target)
+	if err != nil {
+		return fmt.Errorf("create extracted file: %w", err)
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return fmt.Errorf("extract archive member: %w", err)
+	}
+	return nil
+}
+
+func singleExtractedRoot(root string) (string, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return "", fmt.Errorf("read extracted source: %w", err)
+	}
+	if len(entries) == 1 && entries[0].IsDir() {
+		return filepath.Join(root, entries[0].Name()), nil
+	}
+	return root, nil
+}

--- a/cmd/curriculum-knowledge-prototype/source_test.go
+++ b/cmd/curriculum-knowledge-prototype/source_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestExtractZipFindsArchiveRoot(t *testing.T) {
+	archive := newZip(t, map[string]string{
+		"oss-main/curricula/malaysia/malaysia-kssm/syllabus.yaml": `
+id: malaysia-kssm
+name: KSSM
+subjects: []
+`,
+	})
+
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "source.zip")
+	if err := os.WriteFile(archivePath, archive, 0o644); err != nil {
+		t.Fatalf("write archive: %v", err)
+	}
+
+	extractDir := filepath.Join(dir, "extract")
+	if err := extractZip(archivePath, extractDir); err != nil {
+		t.Fatalf("extract source: %v", err)
+	}
+	root, err := singleExtractedRoot(extractDir)
+	if err != nil {
+		t.Fatalf("find root: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(root, "curricula", "malaysia", "malaysia-kssm", "syllabus.yaml")); err != nil {
+		t.Fatalf("expected extracted syllabus: %v", err)
+	}
+}
+
+func TestArchiveURLForGitHubSource(t *testing.T) {
+	got, err := archiveURLForSource("https://github.com/p-n-ai/oss")
+	if err != nil {
+		t.Fatalf("archive url: %v", err)
+	}
+	if !strings.Contains(got, "https://codeload.github.com/p-n-ai/oss/zip/refs/heads/main") {
+		t.Fatalf("unexpected archive url: %s", got)
+	}
+}
+
+func TestParseGitHubSourceKeepsTreeSubpath(t *testing.T) {
+	got, err := parseGitHubSource("https://github.com/p-n-ai/oss/tree/main/curricula/malaysia")
+	if err != nil {
+		t.Fatalf("parse source: %v", err)
+	}
+	if !strings.Contains(got.ArchiveURL, "https://codeload.github.com/p-n-ai/oss/zip/refs/heads/main") {
+		t.Fatalf("unexpected archive url: %s", got.ArchiveURL)
+	}
+	if got.Subpath != filepath.Join("curricula", "malaysia") {
+		t.Fatalf("subpath = %q", got.Subpath)
+	}
+}
+
+func TestArchiveURLRejectsNonGitHubHTTPSource(t *testing.T) {
+	if _, err := archiveURLForSource("https://example.com/curriculum.zip"); err == nil {
+		t.Fatal("expected non-github http source to fail")
+	}
+}
+
+func TestArchiveURLRejectsLocalPath(t *testing.T) {
+	if _, err := archiveURLForSource("/tmp/curriculum"); err == nil {
+		t.Fatal("expected local path source to fail")
+	}
+}
+
+func TestExtractZipRejectsPathTraversal(t *testing.T) {
+	archive := newZip(t, map[string]string{
+		"../escape.txt": "nope",
+	})
+
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "source.zip")
+	if err := os.WriteFile(archivePath, archive, 0o644); err != nil {
+		t.Fatalf("write archive: %v", err)
+	}
+
+	if err := extractZip(archivePath, filepath.Join(dir, "extract")); err == nil {
+		t.Fatal("expected unsafe archive path to fail")
+	}
+}
+
+func newZip(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for name, body := range files {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatalf("create zip file: %v", err)
+		}
+		if _, err := w.Write([]byte(body)); err != nil {
+			t.Fatalf("write zip file: %v", err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+	return buf.Bytes()
+}

--- a/cmd/curriculum-knowledge-prototype/store.go
+++ b/cmd/curriculum-knowledge-prototype/store.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+type dbExecQuerier interface {
+	Begin(ctx context.Context) (pgx.Tx, error)
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+}
+
+type contentStore struct {
+	db dbExecQuerier
+}
+
+func newContentStore(db dbExecQuerier) contentStore {
+	return contentStore{db: db}
+}
+
+func schemaSQL() string {
+	return `
+CREATE SCHEMA IF NOT EXISTS retrieval_prototype;
+
+CREATE TABLE IF NOT EXISTS retrieval_prototype.curriculum_content (
+    id            BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    curriculum_source TEXT NOT NULL DEFAULT '',
+    kind          TEXT NOT NULL,
+    title         TEXT NOT NULL DEFAULT '',
+    body          TEXT NOT NULL,
+    metadata      JSONB NOT NULL DEFAULT '{}',
+    search_text   TEXT NOT NULL,
+    search_vector TSVECTOR GENERATED ALWAYS AS (
+        to_tsvector('simple', search_text)
+    ) STORED,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS curriculum_content_kind_idx
+    ON retrieval_prototype.curriculum_content (kind);
+
+CREATE INDEX IF NOT EXISTS curriculum_content_metadata_gin_idx
+    ON retrieval_prototype.curriculum_content USING GIN (metadata);
+
+CREATE INDEX IF NOT EXISTS curriculum_content_search_vector_idx
+    ON retrieval_prototype.curriculum_content USING GIN (search_vector);
+`
+}
+
+func dropSQL() string {
+	return `DROP SCHEMA IF EXISTS retrieval_prototype CASCADE;`
+}
+
+func (s contentStore) applySchema(ctx context.Context) error {
+	if _, err := s.db.Exec(ctx, schemaSQL()); err != nil {
+		return fmt.Errorf("apply retrieval schema: %w", err)
+	}
+	return nil
+}
+
+func (s contentStore) drop(ctx context.Context) error {
+	if _, err := s.db.Exec(ctx, dropSQL()); err != nil {
+		return fmt.Errorf("drop retrieval schema: %w", err)
+	}
+	return nil
+}
+
+func (s contentStore) replaceContent(ctx context.Context, rows []CurriculumContent) error {
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin replace content transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx, `TRUNCATE retrieval_prototype.curriculum_content`); err != nil {
+		return fmt.Errorf("clear curriculum content: %w", err)
+	}
+
+	for _, row := range rows {
+		metadata, err := json.Marshal(row.Metadata)
+		if err != nil {
+			return fmt.Errorf("marshal content metadata: %w", err)
+		}
+
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO retrieval_prototype.curriculum_content (
+				curriculum_source, kind, title, body, metadata, search_text
+			)
+			VALUES ($1, $2, $3, $4, $5::jsonb, $6)
+		`, row.CurriculumSource, row.Kind, row.Title, row.Body, string(metadata), row.SearchText); err != nil {
+			return fmt.Errorf("insert curriculum content: %w", err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit replace content transaction: %w", err)
+	}
+	return nil
+}
+
+func (s contentStore) searchText(ctx context.Context, query string, limit int) ([]CurriculumContentHit, error) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return []CurriculumContentHit{}, nil
+	}
+	if limit <= 0 {
+		limit = 5
+	}
+
+	rows, err := s.db.Query(ctx, `
+		SELECT
+			id,
+			curriculum_source,
+			kind,
+			title,
+			body,
+			metadata,
+			search_text,
+			ts_rank_cd(search_vector, websearch_to_tsquery('simple', $1)) AS score
+		FROM retrieval_prototype.curriculum_content
+		WHERE search_vector @@ websearch_to_tsquery('simple', $1)
+		ORDER BY score DESC
+		LIMIT $2
+	`, query, limit)
+	if err != nil {
+		return nil, fmt.Errorf("search curriculum content: %w", err)
+	}
+	defer rows.Close()
+
+	hits := []CurriculumContentHit{}
+	for rows.Next() {
+		var (
+			row         CurriculumContent
+			metadataRaw []byte
+			score       float64
+		)
+		if err := rows.Scan(
+			&row.ID,
+			&row.CurriculumSource,
+			&row.Kind,
+			&row.Title,
+			&row.Body,
+			&metadataRaw,
+			&row.SearchText,
+			&score,
+		); err != nil {
+			return nil, fmt.Errorf("scan curriculum content hit: %w", err)
+		}
+		if len(metadataRaw) > 0 {
+			if err := json.Unmarshal(metadataRaw, &row.Metadata); err != nil {
+				return nil, fmt.Errorf("parse curriculum metadata: %w", err)
+			}
+		}
+		hits = append(hits, CurriculumContentHit{Content: row, Score: score})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate curriculum content hits: %w", err)
+	}
+	return hits, nil
+}
+
+type CurriculumContentHit struct {
+	Content CurriculumContent
+	Score   float64
+}

--- a/cmd/curriculum-knowledge-prototype/store_test.go
+++ b/cmd/curriculum-knowledge-prototype/store_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSchemaSQLIsOneContentTable(t *testing.T) {
+	sql := schemaSQL()
+
+	if got := strings.Count(sql, "CREATE TABLE"); got != 1 {
+		t.Fatalf("schema should create one table, got %d", got)
+	}
+	forbidden := []string{
+		"source_url",
+		"source_path",
+		"external_id",
+		"tenant_id",
+		"owner",
+		"curriculum_sources",
+		"curriculum_chunks",
+	}
+	for _, term := range forbidden {
+		if strings.Contains(sql, term) {
+			t.Fatalf("schema should not contain %q", term)
+		}
+	}
+
+	required := []string{
+		"curriculum_content",
+		"curriculum_source",
+		"body",
+		"search_text",
+		"search_vector",
+	}
+	for _, term := range required {
+		if !strings.Contains(sql, term) {
+			t.Fatalf("schema should contain %q", term)
+		}
+	}
+}

--- a/docs/retrieval.md
+++ b/docs/retrieval.md
@@ -1,0 +1,339 @@
+---
+title: "GitHub To Postgres Curriculum Retrieval"
+summary: >-
+  Fetch OSS-shaped curriculum from GitHub, store it in Postgres, and retrieve it
+  without the local oss submodule.
+read_when:
+  - You are implementing or reviewing the curriculum retrieval prototype.
+  - You need the GitHub-to-Postgres data flow, schema contract, or verification steps.
+---
+
+# GitHub To Postgres Curriculum Retrieval
+
+## Objective
+
+Document the prototype path for using curriculum content without depending on a
+local `oss/` submodule at runtime.
+
+The prototype fetches curriculum from GitHub during ingest. Retrieval then
+reads from Postgres:
+
+```text
+GitHub repo URL
+-> temp zip download
+-> safe extraction
+-> OSS curriculum parsing
+-> Postgres content rows
+-> Postgres full-text search
+```
+
+After ingest, retrieval reads Postgres rows only. It does not read GitHub, temp
+files, `oss/`, or `LEARN_CURRICULUM_PATH`.
+
+## Command Contract
+
+Ingest from GitHub:
+
+```sh
+DATABASE_URL=postgres://... \
+CURRICULUM_SOURCE=https://github.com/p-n-ai/oss \
+go run ./cmd/curriculum-knowledge-prototype ingest --query "linear equations"
+```
+
+Search stored content:
+
+```sh
+DATABASE_URL=postgres://... \
+go run ./cmd/curriculum-knowledge-prototype search --query "linear equations"
+```
+
+Drop prototype state:
+
+```sh
+DATABASE_URL=postgres://... \
+go run ./cmd/curriculum-knowledge-prototype drop
+```
+
+Inputs:
+
+- `DATABASE_URL`: Postgres connection string.
+- `CURRICULUM_SOURCE`: GitHub repository URL. Local paths and non-GitHub HTTP
+  URLs are rejected.
+- `--query`: smoke-test query printed after ingest or used by `search`.
+- `--cache`: disposable archive workspace. Defaults to
+  `tmp/curriculum-knowledge-prototype`.
+
+## Data Flow
+
+### 1. Resolve Source
+
+The prototype accepts a GitHub repository URL:
+
+```text
+https://github.com/<owner>/<repo>
+```
+
+It converts that to a GitHub codeload zip URL:
+
+```text
+https://github.com/p-n-ai/oss
+-> https://codeload.github.com/p-n-ai/oss/zip/refs/heads/main
+```
+
+The URL is used for ingest. Retrieval uses stored content rows.
+
+### 2. Download Archive
+
+The zip is downloaded to a disposable workspace:
+
+```text
+tmp/curriculum-knowledge-prototype/<temp-dir>/source.zip
+```
+
+The HTTP request has an explicit timeout. Download failures stop ingest before
+database replacement.
+
+### 3. Extract Safely
+
+The archive is extracted under the same temp workspace.
+
+Extraction rejects unsafe paths so archive members cannot write outside the temp
+directory. After extraction, the prototype detects the archive root:
+
+```text
+oss-main/
+```
+
+### 4. Parse Curriculum Files
+
+The parser walks the extracted repository and maps OSS-shaped curriculum files
+into semantic rows.
+
+Translation sync directories are skipped; the prototype reads canonical
+curriculum files only.
+
+| File shape | Row kind | Purpose |
+| --- | --- | --- |
+| `syllabus.yaml` | `syllabus` | Inventory and scope |
+| `subject.yaml` | `subject` | Inventory and filtering |
+| `subject-grade.yaml` | `subject_grade` | Grade/form context |
+| topic YAML | `topic_card` | Topic resolution |
+| `*.teaching.md` sections | `teaching_note` | Tutor explanation context |
+| `*.examples.yaml` items | `worked_example` | Worked-example retrieval |
+| `*.assessments.yaml` questions | `assessment_item` | Future quiz/practice retrieval |
+
+This prototype chunks by curriculum semantics first, not blind token windows.
+Malformed example or assessment files are skipped so one optional practice file
+does not block topic and teaching-note ingest.
+
+### 5. Replace Postgres Content
+
+Ingest creates the scratch schema/table if needed, then replaces content rows in
+one transaction.
+
+The table is small:
+
+```sql
+CREATE TABLE retrieval_prototype.curriculum_content (
+    id                BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    curriculum_source TEXT NOT NULL DEFAULT '',
+    kind              TEXT NOT NULL,
+    title             TEXT NOT NULL DEFAULT '',
+    body              TEXT NOT NULL,
+    metadata          JSONB NOT NULL DEFAULT '{}',
+    search_text       TEXT NOT NULL,
+    search_vector     TSVECTOR GENERATED ALWAYS AS (
+        to_tsvector('simple', search_text)
+    ) STORED,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+Indexes:
+
+```sql
+CREATE INDEX curriculum_content_kind_idx
+    ON retrieval_prototype.curriculum_content (kind);
+
+CREATE INDEX curriculum_content_metadata_gin_idx
+    ON retrieval_prototype.curriculum_content USING GIN (metadata);
+
+CREATE INDEX curriculum_content_search_vector_idx
+    ON retrieval_prototype.curriculum_content USING GIN (search_vector);
+```
+
+Prototype rules:
+
+- one table only;
+- one source label only: `curriculum_source`;
+- no pgvector;
+- no source path, external ID, owner, tenant, or activation model;
+- no persisted ingest/index status;
+- re-ingest replaces rows instead of appending duplicates.
+
+### 6. Seed And Schema Boundary
+
+This prototype does not change the normal app seed path or production
+migrations.
+
+The CLI creates `retrieval_prototype.curriculum_content` at runtime so the
+GitHub-to-Postgres flow can be tested without committing a product schema yet.
+The scratch schema is disposable and removed by `drop`.
+
+Production work should replace this with:
+
+- a real migration;
+- tenant-scoped retrieval tables;
+- persisted source/run status such as `pending`, `fetching`, `ingesting`,
+  `indexing`, `ready`, and `failed`;
+- a real ingest or seed command;
+- admin check/activate behavior.
+
+Admin activation should only be allowed after a source reaches `ready`.
+Search/fetch consumers should treat missing or non-ready status as unavailable,
+not as an empty curriculum.
+
+### 7. Search Postgres Rows
+
+Search uses Postgres full-text search:
+
+```sql
+SELECT
+    id,
+    curriculum_source,
+    kind,
+    title,
+    body,
+    metadata,
+    search_text,
+    ts_rank_cd(search_vector, websearch_to_tsquery('simple', $1)) AS score
+FROM retrieval_prototype.curriculum_content
+WHERE search_vector @@ websearch_to_tsquery('simple', $1)
+ORDER BY score DESC
+LIMIT $2;
+```
+
+The CLI prints top hits with score, kind, and title.
+
+## Tutor Runtime Boundary
+
+Runtime integration should keep this boundary:
+
+```text
+child message
+-> search stored curriculum content
+-> resolve topic
+-> fetch teaching-note rows for that topic
+-> emit curriculum.topic and curriculum.teaching_notes packets
+```
+
+Render selected rows through `curriculum.topic` and `curriculum.teaching_notes`
+packets.
+
+First slice behavior:
+
+- topic rows identify the likely curriculum topic;
+- teaching-note rows provide explanation context;
+- assessment rows stay out of ordinary teaching prompts;
+- quiz requests stay on the quiz path;
+- weak or ambiguous hits should abstain.
+
+## Verification Checklist
+
+- `ingest` works with `CURRICULUM_SOURCE=https://github.com/p-n-ai/oss`.
+- Local paths fail.
+- Non-GitHub HTTP URLs fail.
+- Content rows exist in `retrieval_prototype.curriculum_content`.
+- `search` returns relevant rows without re-reading the source archive.
+- Temp cache can be deleted after ingest.
+- `drop` removes the scratch schema.
+- The prototype has no runtime retrieval dependency on `oss/`, GitHub, temp
+  files, or `LEARN_CURRICULUM_PATH`.
+
+## Local Test Run
+
+Use this flow to test more than unit behavior. It exercises GitHub download,
+archive extraction, OSS parsing, Postgres insert, search, and teardown.
+
+Start local Postgres:
+
+```sh
+docker compose up -d postgres
+```
+
+Set the local database URL used by this repo's Docker Compose file:
+
+```sh
+export DATABASE_URL='postgres://pai:pai@127.0.0.1:5432/pai?sslmode=disable'
+export CURRICULUM_SOURCE='https://github.com/p-n-ai/oss'
+```
+
+Run unit tests:
+
+```sh
+go test ./cmd/curriculum-knowledge-prototype
+```
+
+Run the full ingest path:
+
+```sh
+go run ./cmd/curriculum-knowledge-prototype ingest --query "linear equations"
+```
+
+Expected shape:
+
+```text
+postgres prototype: PASS
+content_rows: 2272
+query: "linear equations"
+top_hits:
+- score=... kind=topic_card title="Linear Equations"
+```
+
+Run search again without re-ingesting:
+
+```sh
+go run ./cmd/curriculum-knowledge-prototype search --query "linear equations"
+```
+
+Check the stored row mix:
+
+```sh
+psql "$DATABASE_URL" -Atqc "
+select
+  count(*),
+  count(*) filter (where kind='topic_card'),
+  count(*) filter (where kind='teaching_note'),
+  count(*) filter (where kind='assessment_item')
+from retrieval_prototype.curriculum_content;
+"
+```
+
+Expected shape from the current OSS corpus:
+
+```text
+2272|154|1151|613
+```
+
+Tear down scratch data:
+
+```sh
+go run ./cmd/curriculum-knowledge-prototype drop
+```
+
+Stop the local Postgres service if this test started it:
+
+```sh
+docker compose stop postgres
+```
+
+## Not In This Prototype
+
+Later production work can add:
+
+- tenant-scoped active source;
+- admin check/activate flow;
+- ingest run history and stable error categories;
+- source/content/chunk tables;
+- embedding rows or pgvector as a derived index over stored content;
+- Tutor Turn integration tests for `curriculum.topic` and `curriculum.teaching_notes`.


### PR DESCRIPTION
## Summary

This PR adds a local prototype proving OSS curriculum can be fetched from GitHub,
parsed into Postgres-owned content rows, searched with Postgres full-text search,
and torn down without relying on the local `oss` submodule at runtime. No
production migration or normal seed path is changed.

## Status

Blue: prototype only. No action needed beyond review.

## Why it matters

- Tests whether curriculum can become Postgres-owned content instead of local
  checkout state.
- Gives reviewers a concrete GitHub -> temp archive -> OSS parse -> Postgres FTS
  path to evaluate.
- Keeps the production schema/seed boundary explicit before we decide the real
  migration and admin activation model.

## What changed

- Added `cmd/curriculum-knowledge-prototype` for disposable ingest, search, and
  drop commands.
- Added OSS-shaped curriculum mapping for topics, teaching notes, examples, and
  assessments.
- Handles current OSS corpus quirks found during local runtime validation:
  optional malformed practice files, translation sync directories, and multiple
  prerequisite YAML shapes.
- Added `docs/retrieval.md` with data flow, schema boundary, local test run, and
  teardown instructions.

## Review focus

- Is the prototype boundary clear enough: scratch schema only, no production
  migration, no normal seed change?
- Is GitHub archive fetch -> Postgres content row the right first proof before
  pgvector/admin activation work?
- Are the curriculum chunk kinds useful enough for the next Tutor Turn
  integration slice?

## Validation

- `go test ./cmd/curriculum-knowledge-prototype`
- `git diff --check`
- Local end-to-end run against Docker Postgres and `https://github.com/p-n-ai/oss`:
  - ingest inserted 2,272 rows
  - default search `linear equations` returned top hit `topic_card "Linear Equations"`
  - search worked again without re-ingesting
  - scratch schema dropped with `drop`
  - local Postgres service stopped after validation
