### PR TITLE
perf(sql): optimize read query shapes

### DIFF
--- a/internal/adminapi/groups.go
+++ b/internal/adminapi/groups.go
@@ -82,6 +82,7 @@ type AdminLeaderboardEntry struct {
 
 const adminJoinCodeLen = 6
 const adminJoinCodeAlphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+const adminLeaderboardLimit = 10
 
 func (s *Service) ListGroups(groupType string) ([]AdminGroup, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -90,9 +91,10 @@ func (s *Service) ListGroups(groupType string) ([]AdminGroup, error) {
 	query := fmt.Sprintf(`
 		SELECT g.id::text, g.name, g.type, g.description, g.syllabus, g.subject, g.cadence,
 		       g.join_code, g.created_at, g.updated_at,
-		       (SELECT COUNT(*) FROM group_members gm WHERE gm.group_id = g.id)::int,
+		       COUNT(gm.id)::int,
 		       g.closed
 		FROM groups g
+		LEFT JOIN group_members gm ON gm.group_id = g.id
 		WHERE %s`, s.tenantPredicate("g.tenant_id", 1))
 
 	args := []any{s.tenantArg()}
@@ -100,7 +102,7 @@ func (s *Service) ListGroups(groupType string) ([]AdminGroup, error) {
 		query += ` AND g.type = $2`
 		args = append(args, groupType)
 	}
-	query += ` ORDER BY g.created_at DESC`
+	query += ` GROUP BY g.id ORDER BY g.created_at DESC`
 
 	rows, err := s.pool.Query(ctx, query, args...)
 	if err != nil {
@@ -361,27 +363,54 @@ func (s *Service) GetGroupLeaderboard(id string) ([]AdminLeaderboardEntry, error
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	rows, err := s.pool.Query(ctx, fmt.Sprintf(`
+	query, args := s.buildGroupLeaderboardQuery(id)
+	rows, err := s.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query group leaderboard: %w", err)
+	}
+	defer rows.Close()
+
+	entries := make([]AdminLeaderboardEntry, 0, adminLeaderboardLimit)
+	for rows.Next() {
+		var e AdminLeaderboardEntry
+		if err := rows.Scan(&e.UserID, &e.UserName, &e.MasteryGain, &e.Rank); err != nil {
+			return nil, fmt.Errorf("scan leaderboard entry: %w", err)
+		}
+		entries = append(entries, e)
+	}
+	return entries, rows.Err()
+}
+
+func (s *Service) buildGroupLeaderboardQuery(groupID string) (string, []any) {
+	return fmt.Sprintf(`
 		WITH members AS (
-			SELECT gm.user_id
+			SELECT gm.user_id, gm.tenant_id
 			FROM group_members gm
 			JOIN groups g ON g.id = gm.group_id
 			JOIN users u ON u.id = gm.user_id AND u.role = 'student'
 			WHERE gm.group_id = $1::uuid AND %s
-		),`, s.tenantPredicate("g.tenant_id", 2))+`
+		),
 		current_scores AS (
-			SELECT lp.user_id, lp.topic_id, lp.mastery_score
-			FROM learning_progress lp
-			WHERE lp.user_id IN (SELECT user_id FROM members)
+			SELECT m.user_id, lp.topic_id, lp.mastery_score
+			FROM members m
+			JOIN learning_progress lp
+			  ON lp.user_id = m.user_id
+			 AND lp.tenant_id = m.tenant_id
+		),
+		snapshot_window AS (
+			SELECT m.user_id, ms.topic_id, ms.mastery_score, ms.snapshot_date
+			FROM members m
+			JOIN mastery_snapshots ms
+			  ON ms.user_id = m.user_id
+			 AND ms.tenant_id = m.tenant_id
+			WHERE ms.snapshot_date >= (CURRENT_DATE - INTERVAL '7 days')::date
+			  AND ms.snapshot_date < CURRENT_DATE
 		),
 		baseline_scores AS (
-			SELECT DISTINCT ON (ms.user_id, ms.topic_id)
-			       ms.user_id, ms.topic_id, ms.mastery_score
-			FROM mastery_snapshots ms
-			WHERE ms.user_id IN (SELECT user_id FROM members)
-			  AND ms.snapshot_date >= (CURRENT_DATE - INTERVAL '7 days')::date
-			  AND ms.snapshot_date < CURRENT_DATE
-			ORDER BY ms.user_id, ms.topic_id, ms.snapshot_date ASC
+			SELECT DISTINCT ON (user_id, topic_id)
+			       user_id, topic_id, mastery_score
+			FROM snapshot_window
+			ORDER BY user_id, topic_id, snapshot_date ASC
 		),
 		gains AS (
 			SELECT cs.user_id,
@@ -395,23 +424,8 @@ func (s *Service) GetGroupLeaderboard(id string) ([]AdminLeaderboardEntry, error
 		FROM gains g
 		JOIN users u ON u.id = g.user_id
 		ORDER BY g.avg_gain DESC
-		LIMIT 10`,
-		id, s.tenantArg(),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("query group leaderboard: %w", err)
-	}
-	defer rows.Close()
-
-	var entries []AdminLeaderboardEntry
-	for rows.Next() {
-		var e AdminLeaderboardEntry
-		if err := rows.Scan(&e.UserID, &e.UserName, &e.MasteryGain, &e.Rank); err != nil {
-			return nil, fmt.Errorf("scan leaderboard entry: %w", err)
-		}
-		entries = append(entries, e)
-	}
-	return entries, rows.Err()
+		LIMIT %d`, s.tenantPredicate("g.tenant_id", 2), adminLeaderboardLimit),
+		[]any{groupID, s.tenantArg()}
 }
 
 // GetGroupClassProgress returns class progress for a real group (by UUID).

--- a/internal/adminapi/service.go
+++ b/internal/adminapi/service.go
@@ -918,25 +918,27 @@ func (s *Service) GetUserManagement() (UserManagementView, error) {
 			u.id::text,
 			u.name,
 			u.role,
-			COALESCE(
-				(SELECT ai.identifier
-				 FROM auth_identities ai
-				 WHERE ai.user_id = u.id
-				   AND ai.provider = 'password'
-				 ORDER BY ai.created_at ASC
-				 LIMIT 1),
-				(SELECT COALESCE(ai.provider_email, ai.identifier)
-				 FROM auth_identities ai
-				 WHERE ai.user_id = u.id
-				   AND ai.provider = 'google'
-				 ORDER BY ai.created_at ASC
-				 LIMIT 1),
-				''
-			) AS email,
+			COALESCE(password_identity.identifier, google_identity.email, '') AS email,
 			u.created_at,
 			COALESCE(t.name, '')
 		FROM users u
 		LEFT JOIN tenants t ON t.id = u.tenant_id
+		LEFT JOIN LATERAL (
+			SELECT ai.identifier
+			FROM auth_identities ai
+			WHERE ai.user_id = u.id
+				AND ai.provider = 'password'
+			ORDER BY ai.created_at ASC
+			LIMIT 1
+		) password_identity ON true
+		LEFT JOIN LATERAL (
+			SELECT COALESCE(ai.provider_email, ai.identifier) AS email
+			FROM auth_identities ai
+			WHERE ai.user_id = u.id
+				AND ai.provider = 'google'
+			ORDER BY ai.created_at ASC
+			LIMIT 1
+		) google_identity ON true
 		WHERE %s
 			AND u.role IN ('teacher', 'parent', 'admin', 'platform_admin')
 		ORDER BY
@@ -1314,7 +1316,7 @@ func (s *Service) loadRetention(ctx context.Context) ([]RetentionPoint, error) {
 			FROM users u
 			WHERE %s
 				AND u.role = 'student'
-				AND DATE(u.created_at AT TIME ZONE 'UTC') <= DATE(NOW() AT TIME ZONE 'UTC') - 1
+				AND u.created_at < DATE(NOW() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
 		),
 		activity AS (
 			SELECT DISTINCT e.user_id, DATE(e.created_at AT TIME ZONE 'UTC') AS activity_date

--- a/internal/adminapi/service_test.go
+++ b/internal/adminapi/service_test.go
@@ -158,6 +158,35 @@ func TestTenantPredicate(t *testing.T) {
 	}
 }
 
+func TestBuildGroupLeaderboardQueryUsesJoinedMemberSet(t *testing.T) {
+	service := Service{tenantID: "11111111-1111-1111-1111-111111111111"}
+
+	query, args := service.buildGroupLeaderboardQuery("22222222-2222-2222-2222-222222222222")
+
+	if len(args) != 2 {
+		t.Fatalf("args len = %d, want 2", len(args))
+	}
+	if args[0] != "22222222-2222-2222-2222-222222222222" || args[1] != service.tenantID {
+		t.Fatalf("args = %#v, want group id and tenant id", args)
+	}
+	if strings.Contains(query, "IN (SELECT user_id FROM members)") {
+		t.Fatalf("query should join the member set instead of repeated IN subqueries:\n%s", query)
+	}
+	for _, want := range []string{
+		"SELECT gm.user_id, gm.tenant_id",
+		"JOIN learning_progress lp",
+		"ON lp.user_id = m.user_id",
+		"AND lp.tenant_id = m.tenant_id",
+		"JOIN mastery_snapshots ms",
+		"AND ms.tenant_id = m.tenant_id",
+		"($2::uuid IS NULL OR g.tenant_id = $2::uuid)",
+	} {
+		if !strings.Contains(query, want) {
+			t.Fatalf("query missing %q:\n%s", want, query)
+		}
+	}
+}
+
 func TestComputeRetentionSeries(t *testing.T) {
 	base := time.Date(2026, 3, 1, 10, 0, 0, 0, time.UTC)
 

--- a/internal/agent/group_store_postgres.go
+++ b/internal/agent/group_store_postgres.go
@@ -244,12 +244,14 @@ func (s *PostgresGroupStore) GetUserGroups(userID string) ([]Group, error) {
 	rows, err := s.pool.Query(ctx, `
 		SELECT g.id::text, g.tenant_id::text, g.name, g.type, g.description, g.syllabus, g.subject, g.cadence,
 		       g.join_code, COALESCE(g.created_by::text, ''), g.created_at, g.updated_at,
-		       (SELECT COUNT(*) FROM group_members gm2 WHERE gm2.group_id = g.id)::int,
+		       COUNT(gm_count.id)::int,
 		       g.closed
 		FROM groups g
-		JOIN group_members gm ON gm.group_id = g.id
-		WHERE gm.user_id = $1::uuid
-		ORDER BY gm.joined_at DESC`,
+		JOIN group_members user_membership ON user_membership.group_id = g.id
+		LEFT JOIN group_members gm_count ON gm_count.group_id = g.id
+		WHERE user_membership.user_id = $1::uuid
+		GROUP BY g.id, user_membership.joined_at
+		ORDER BY user_membership.joined_at DESC`,
 		userID,
 	)
 	if err != nil {
@@ -276,9 +278,10 @@ func (s *PostgresGroupStore) ListGroups(tenantID, groupType string) ([]Group, er
 	query := `
 		SELECT g.id::text, g.tenant_id::text, g.name, g.type, g.description, g.syllabus, g.subject, g.cadence,
 		       g.join_code, COALESCE(g.created_by::text, ''), g.created_at, g.updated_at,
-		       (SELECT COUNT(*) FROM group_members gm WHERE gm.group_id = g.id)::int,
+		       COUNT(gm.id)::int,
 		       g.closed
 		FROM groups g
+		LEFT JOIN group_members gm ON gm.group_id = g.id
 		WHERE g.tenant_id = $1::uuid`
 	args := []any{tenantID}
 
@@ -286,7 +289,7 @@ func (s *PostgresGroupStore) ListGroups(tenantID, groupType string) ([]Group, er
 		query += ` AND g.type = $2`
 		args = append(args, groupType)
 	}
-	query += ` ORDER BY g.created_at DESC`
+	query += ` GROUP BY g.id ORDER BY g.created_at DESC`
 
 	rows, err := s.pool.Query(ctx, query, args...)
 	if err != nil {
@@ -343,29 +346,53 @@ func (s *PostgresGroupStore) GetWeeklyLeaderboard(groupID string, limit int) ([]
 		limit = 10
 	}
 
-	// Compare current mastery_score with the oldest snapshot within the past 7 days.
-	// Uses DISTINCT ON to pick the earliest snapshot per user/topic in the window.
-	// Only includes students (not teachers/leaders).
-	rows, err := s.pool.Query(ctx, `
+	query, args := buildWeeklyLeaderboardQuery(groupID, limit)
+	rows, err := s.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query weekly leaderboard: %w", err)
+	}
+	defer rows.Close()
+
+	entries := make([]LeaderboardEntry, 0, limit)
+	for rows.Next() {
+		var e LeaderboardEntry
+		if err := rows.Scan(&e.UserID, &e.UserName, &e.MasteryGain, &e.Rank); err != nil {
+			return nil, fmt.Errorf("scan leaderboard entry: %w", err)
+		}
+		entries = append(entries, e)
+	}
+	return entries, rows.Err()
+}
+
+func buildWeeklyLeaderboardQuery(groupID string, limit int) (string, []any) {
+	return `
 		WITH members AS (
-			SELECT gm.user_id
+			SELECT gm.user_id, gm.tenant_id
 			FROM group_members gm
 			JOIN users u ON u.id = gm.user_id AND u.role = 'student'
 			WHERE gm.group_id = $1::uuid
 		),
 		current_scores AS (
-			SELECT lp.user_id, lp.topic_id, lp.mastery_score
-			FROM learning_progress lp
-			WHERE lp.user_id IN (SELECT user_id FROM members)
+			SELECT m.user_id, lp.topic_id, lp.mastery_score
+			FROM members m
+			JOIN learning_progress lp
+			  ON lp.user_id = m.user_id
+			 AND lp.tenant_id = m.tenant_id
+		),
+		snapshot_window AS (
+			SELECT m.user_id, ms.topic_id, ms.mastery_score, ms.snapshot_date
+			FROM members m
+			JOIN mastery_snapshots ms
+			  ON ms.user_id = m.user_id
+			 AND ms.tenant_id = m.tenant_id
+			WHERE ms.snapshot_date >= (CURRENT_DATE - INTERVAL '7 days')::date
+			  AND ms.snapshot_date < CURRENT_DATE
 		),
 		baseline_scores AS (
-			SELECT DISTINCT ON (ms.user_id, ms.topic_id)
-			       ms.user_id, ms.topic_id, ms.mastery_score
-			FROM mastery_snapshots ms
-			WHERE ms.user_id IN (SELECT user_id FROM members)
-			  AND ms.snapshot_date >= (CURRENT_DATE - INTERVAL '7 days')::date
-			  AND ms.snapshot_date < CURRENT_DATE
-			ORDER BY ms.user_id, ms.topic_id, ms.snapshot_date ASC
+			SELECT DISTINCT ON (user_id, topic_id)
+			       user_id, topic_id, mastery_score
+			FROM snapshot_window
+			ORDER BY user_id, topic_id, snapshot_date ASC
 		),
 		gains AS (
 			SELECT cs.user_id,
@@ -379,23 +406,7 @@ func (s *PostgresGroupStore) GetWeeklyLeaderboard(groupID string, limit int) ([]
 		FROM gains g
 		JOIN users u ON u.id = g.user_id
 		ORDER BY g.avg_gain DESC
-		LIMIT $2`,
-		groupID, limit,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("query weekly leaderboard: %w", err)
-	}
-	defer rows.Close()
-
-	var entries []LeaderboardEntry
-	for rows.Next() {
-		var e LeaderboardEntry
-		if err := rows.Scan(&e.UserID, &e.UserName, &e.MasteryGain, &e.Rank); err != nil {
-			return nil, fmt.Errorf("scan leaderboard entry: %w", err)
-		}
-		entries = append(entries, e)
-	}
-	return entries, rows.Err()
+		LIMIT $2`, []any{groupID, limit}
 }
 
 const joinCodeAlphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789" // no I/O/0/1 to avoid confusion

--- a/internal/agent/group_store_postgres_test.go
+++ b/internal/agent/group_store_postgres_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildWeeklyLeaderboardQueryUsesJoinedMemberSet(t *testing.T) {
+	query, args := buildWeeklyLeaderboardQuery("33333333-3333-3333-3333-333333333333", 7)
+
+	if len(args) != 2 {
+		t.Fatalf("args len = %d, want 2", len(args))
+	}
+	if args[0] != "33333333-3333-3333-3333-333333333333" || args[1] != 7 {
+		t.Fatalf("args = %#v, want group id and limit", args)
+	}
+	if strings.Contains(query, "IN (SELECT user_id FROM members)") {
+		t.Fatalf("query should join the member set instead of repeated IN subqueries:\n%s", query)
+	}
+	for _, want := range []string{
+		"SELECT gm.user_id, gm.tenant_id",
+		"JOIN learning_progress lp",
+		"ON lp.user_id = m.user_id",
+		"AND lp.tenant_id = m.tenant_id",
+		"JOIN mastery_snapshots ms",
+		"AND ms.tenant_id = m.tenant_id",
+		"LIMIT $2",
+	} {
+		if !strings.Contains(query, want) {
+			t.Fatalf("query missing %q:\n%s", want, query)
+		}
+	}
+}

--- a/internal/agent/nudge_tracker_postgres.go
+++ b/internal/agent/nudge_tracker_postgres.go
@@ -17,6 +17,8 @@ type PostgresNudgeTracker struct {
 	tenantID string
 }
 
+const nudgeDayTimeZone = "Asia/Kuala_Lumpur"
+
 // NewPostgresNudgeTracker creates a PostgreSQL-backed nudge tracker.
 func NewPostgresNudgeTracker(pool *pgxpool.Pool, tenantID string) *PostgresNudgeTracker {
 	return &PostgresNudgeTracker{
@@ -30,22 +32,31 @@ func (t *PostgresNudgeTracker) NudgeCountToday(userID string) (int, error) {
 	defer cancel()
 
 	var count int
-	err := t.pool.QueryRow(ctx,
-		`SELECT COUNT(*)
-		 FROM nudge_log nl
-		 JOIN users u ON u.id = nl.user_id
-		 WHERE nl.tenant_id = $1::uuid
-		   AND u.external_id = $2
-		   AND (nl.sent_at AT TIME ZONE 'Asia/Kuala_Lumpur')::date =
-		       (NOW() AT TIME ZONE 'Asia/Kuala_Lumpur')::date`,
-		t.tenantID,
-		userID,
-	).Scan(&count)
+	query, args := buildNudgeCountTodayQuery(t.tenantID, userID)
+	err := t.pool.QueryRow(ctx, query, args...).Scan(&count)
 	if err != nil {
 		return 0, fmt.Errorf("count nudges today: %w", err)
 	}
 
 	return count, nil
+}
+
+func buildNudgeCountTodayQuery(tenantID, userID string) (string, []any) {
+	return `WITH target_user AS (
+			SELECT id
+			FROM users
+			WHERE tenant_id = $1::uuid
+			  AND external_id = $2
+			ORDER BY created_at ASC
+			LIMIT 1
+		 )
+		 SELECT COUNT(*)
+		 FROM nudge_log nl
+		 JOIN target_user u ON u.id = nl.user_id
+		 WHERE nl.tenant_id = $1::uuid
+		   AND nl.sent_at >= date_trunc('day', NOW() AT TIME ZONE $3) AT TIME ZONE $3
+		   AND nl.sent_at < (date_trunc('day', NOW() AT TIME ZONE $3) + INTERVAL '1 day') AT TIME ZONE $3`,
+		[]any{tenantID, userID, nudgeDayTimeZone}
 }
 
 func (t *PostgresNudgeTracker) RecordNudge(userID, nudgeType, topicID string) error {

--- a/internal/agent/nudge_tracker_postgres_test.go
+++ b/internal/agent/nudge_tracker_postgres_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildNudgeCountTodayQueryUsesSargableSentAtRange(t *testing.T) {
+	query, args := buildNudgeCountTodayQuery("tenant-1", "learner-1")
+
+	if len(args) != 3 {
+		t.Fatalf("args len = %d, want 3", len(args))
+	}
+	if args[0] != "tenant-1" || args[1] != "learner-1" || args[2] != nudgeDayTimeZone {
+		t.Fatalf("args = %#v, want tenant id, learner id, timezone", args)
+	}
+	if strings.Contains(query, "nl.sent_at AT TIME ZONE") {
+		t.Fatalf("query should not wrap indexed sent_at in a WHERE function:\n%s", query)
+	}
+	if strings.Contains(query, "JOIN users u ON u.id = nl.user_id") {
+		t.Fatalf("query should resolve one target user before joining nudge_log:\n%s", query)
+	}
+	for _, want := range []string{
+		"WITH target_user AS",
+		"ORDER BY created_at ASC",
+		"LIMIT 1",
+		"JOIN target_user u ON u.id = nl.user_id",
+		"nl.sent_at >=",
+		"nl.sent_at <",
+		"NOW() AT TIME ZONE $3",
+	} {
+		if !strings.Contains(query, want) {
+			t.Fatalf("query missing %q:\n%s", want, query)
+		}
+	}
+}

--- a/internal/progress/tracker_postgres.go
+++ b/internal/progress/tracker_postgres.go
@@ -108,9 +108,20 @@ func (p *PostgresTracker) GetMastery(userID, syllabusID, topicID string) (float6
 
 	var score float64
 	err := p.pool.QueryRow(ctx,
-		`SELECT mastery_score FROM learning_progress
-		 WHERE user_id = (SELECT id FROM users WHERE external_id = $1 AND tenant_id = $2)
-		   AND syllabus_id = $3 AND topic_id = $4`,
+		`WITH target_user AS (
+			SELECT id
+			FROM users
+			WHERE external_id = $1
+			  AND tenant_id = $2::uuid
+			ORDER BY created_at ASC
+			LIMIT 1
+		 )
+		 SELECT lp.mastery_score
+		 FROM target_user u
+		 JOIN learning_progress lp ON lp.user_id = u.id
+		 WHERE lp.tenant_id = $2::uuid
+		   AND lp.syllabus_id = $3
+		   AND lp.topic_id = $4`,
 		userID, p.tenantID, syllabusID, topicID,
 	).Scan(&score)
 
@@ -125,10 +136,19 @@ func (p *PostgresTracker) GetAllProgress(userID string) ([]ProgressItem, error) 
 	defer cancel()
 
 	rows, err := p.pool.Query(ctx,
-		`SELECT syllabus_id, topic_id, mastery_score, ease_factor, interval_days, repetitions, next_review_at, last_studied_at
-		 FROM learning_progress
-		 WHERE user_id = (SELECT id FROM users WHERE external_id = $1 AND tenant_id = $2)
-		 ORDER BY last_studied_at DESC`,
+		`WITH target_user AS (
+			SELECT id
+			FROM users
+			WHERE external_id = $1
+			  AND tenant_id = $2::uuid
+			ORDER BY created_at ASC
+			LIMIT 1
+		 )
+		 SELECT lp.syllabus_id, lp.topic_id, lp.mastery_score, lp.ease_factor, lp.interval_days, lp.repetitions, lp.next_review_at, lp.last_studied_at
+		 FROM target_user u
+		 JOIN learning_progress lp ON lp.user_id = u.id
+		 WHERE lp.tenant_id = $2::uuid
+		 ORDER BY lp.last_studied_at DESC`,
 		userID, p.tenantID,
 	)
 	if err != nil {
@@ -153,11 +173,20 @@ func (p *PostgresTracker) GetDueReviews(userID string) ([]ProgressItem, error) {
 	defer cancel()
 
 	rows, err := p.pool.Query(ctx,
-		`SELECT syllabus_id, topic_id, mastery_score, ease_factor, interval_days, repetitions, next_review_at, last_studied_at
-		 FROM learning_progress
-		 WHERE user_id = (SELECT id FROM users WHERE external_id = $1 AND tenant_id = $2)
-		   AND next_review_at <= NOW()
-		 ORDER BY next_review_at ASC`,
+		`WITH target_user AS (
+			SELECT id
+			FROM users
+			WHERE external_id = $1
+			  AND tenant_id = $2::uuid
+			ORDER BY created_at ASC
+			LIMIT 1
+		 )
+		 SELECT lp.syllabus_id, lp.topic_id, lp.mastery_score, lp.ease_factor, lp.interval_days, lp.repetitions, lp.next_review_at, lp.last_studied_at
+		 FROM target_user u
+		 JOIN learning_progress lp ON lp.user_id = u.id
+		 WHERE lp.tenant_id = $2::uuid
+		   AND lp.next_review_at <= NOW()
+		 ORDER BY lp.next_review_at ASC`,
 		userID, p.tenantID,
 	)
 	if err != nil {

--- a/internal/progress/tracker_postgres.go
+++ b/internal/progress/tracker_postgres.go
@@ -13,6 +13,15 @@ import (
 
 const dbTimeout = 5 * time.Second
 
+const targetUserCTE = `WITH target_user AS (
+	SELECT id
+	FROM users
+	WHERE external_id = $1
+	  AND tenant_id = $2::uuid
+	ORDER BY created_at ASC
+	LIMIT 1
+)`
+
 // PostgresTracker is a PostgreSQL-backed implementation of Tracker.
 type PostgresTracker struct {
 	pool     *pgxpool.Pool
@@ -108,14 +117,7 @@ func (p *PostgresTracker) GetMastery(userID, syllabusID, topicID string) (float6
 
 	var score float64
 	err := p.pool.QueryRow(ctx,
-		`WITH target_user AS (
-			SELECT id
-			FROM users
-			WHERE external_id = $1
-			  AND tenant_id = $2::uuid
-			ORDER BY created_at ASC
-			LIMIT 1
-		 )
+		targetUserCTE+`
 		 SELECT lp.mastery_score
 		 FROM target_user u
 		 JOIN learning_progress lp ON lp.user_id = u.id
@@ -136,14 +138,7 @@ func (p *PostgresTracker) GetAllProgress(userID string) ([]ProgressItem, error) 
 	defer cancel()
 
 	rows, err := p.pool.Query(ctx,
-		`WITH target_user AS (
-			SELECT id
-			FROM users
-			WHERE external_id = $1
-			  AND tenant_id = $2::uuid
-			ORDER BY created_at ASC
-			LIMIT 1
-		 )
+		targetUserCTE+`
 		 SELECT lp.syllabus_id, lp.topic_id, lp.mastery_score, lp.ease_factor, lp.interval_days, lp.repetitions, lp.next_review_at, lp.last_studied_at
 		 FROM target_user u
 		 JOIN learning_progress lp ON lp.user_id = u.id
@@ -173,14 +168,7 @@ func (p *PostgresTracker) GetDueReviews(userID string) ([]ProgressItem, error) {
 	defer cancel()
 
 	rows, err := p.pool.Query(ctx,
-		`WITH target_user AS (
-			SELECT id
-			FROM users
-			WHERE external_id = $1
-			  AND tenant_id = $2::uuid
-			ORDER BY created_at ASC
-			LIMIT 1
-		 )
+		targetUserCTE+`
 		 SELECT lp.syllabus_id, lp.topic_id, lp.mastery_score, lp.ease_factor, lp.interval_days, lp.repetitions, lp.next_review_at, lp.last_studied_at
 		 FROM target_user u
 		 JOIN learning_progress lp ON lp.user_id = u.id


### PR DESCRIPTION
## Summary

Optimizes PostgreSQL read-query shapes across admin, group, nudge, and progress paths, improving planner-friendly SQL while preserving tenant-safe behavior.

## Status

Green: local tests, lint, and qlty completed. No action needed beyond review.

## Why it matters

- Reduces correlated count subqueries and repeated member-set filters in group and leaderboard reads.
- Makes timestamp predicates more index-friendly by avoiding functions on indexed columns in `WHERE`.
- Prevents duplicate external-user rows from merging progress or nudge reads by resolving one target user before joining child tables.
- Adds query-shape tests for the more fragile SQL rewrites.

## What changed

- Replaced group member count correlated subqueries with grouped `LEFT JOIN` counts.
- Reworked admin and learner weekly leaderboard queries to join from a `members` CTE.
- Replaced date-wrapped timestamp filters with timestamp range predicates for retention and nudge count reads.
- Added `target_user` CTEs for progress and nudge reads.
- Added tests for leaderboard and nudge query shape.

## Review focus

- Confirm `ORDER BY created_at ASC LIMIT 1` is the desired tie-breaker when duplicate users share an external ID in a tenant.
- Confirm schema/index changes should remain out of scope until backed by `EXPLAIN ANALYZE` or production query stats.

## Validation

- `go test ./internal/progress`
- `go test ./internal/agent`
- `go test ./internal/adminapi ./internal/agent ./internal/progress`
- `just lint`
- `git diff --check`
- `qlty check` on touched files
