### PR TITLE
build(admin-spa): harden static nginx serving

### DIFF
--- a/deploy/docker/admin-spa.nginx.conf
+++ b/deploy/docker/admin-spa.nginx.conf
@@ -5,6 +5,15 @@ server {
   root /usr/share/nginx/html;
   index index.html;
 
+  add_header X-Content-Type-Options "nosniff" always;
+  add_header Referrer-Policy "no-referrer" always;
+  add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+  add_header Content-Security-Policy "frame-ancestors 'none'; base-uri 'self'; object-src 'none'" always;
+
+  location /api/ {
+    return 404;
+  }
+
   location / {
     try_files $uri $uri/ /index.html;
   }


### PR DESCRIPTION
## Context

The admin SPA is now served as static nginx content in deployment. This hardening keeps the static admin surface closer to production security expectations and reduces risk if the admin container is reached directly instead of through the intended reverse proxy path.

## Description

Adds baseline response security headers to the admin SPA nginx config and makes direct /api/ requests to the admin container return 404. The intended API path remains Caddy/Ingress -> Go backend, while the SPA fallback remains available for frontend routes.

## Changes in the codebase

- Updated deploy/docker/admin-spa.nginx.conf with X-Content-Type-Options, Referrer-Policy, Permissions-Policy, and a minimal Content-Security-Policy.
- Added a direct /api/ nginx location that returns 404 before the SPA fallback.
- Kept the existing Vite/TanStack Router SPA fallback unchanged for normal admin routes.

## Changes outside the codebase

N/A. No external service, database, environment variable, or infrastructure state change was applied outside this repository.

## Aditional information

- Validation: docker compose config
- Validation: docker compose build admin
- Reviewer note: this branch was created from latest origin/main and contains only the nginx hardening commit.
