### PR TITLE
refactor(server): quarantine embed-admin routes

### DIFF
--- a/cmd/server/embed_admin.go
+++ b/cmd/server/embed_admin.go
@@ -1,6 +1,8 @@
 // Copyright 2026 the P&AI authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+// TODO(quarantine): embed-admin routes unregistered pending deletion decision
+
 package main
 
 import (

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -355,22 +355,6 @@ func main() {
 	topMux.Handle("GET /embed/pai-chat.js", chat.HandleWidgetJS())
 	topMux.Handle("GET /embed/chat", chat.HandleChatPage(embedConfigStore))
 
-	// Embed guest auth (public, rate-limited: 5 req/min/IP).
-	guestSvc := auth.NewGuestService(db.Pool, embedTokenManager)
-	embedGuestLimiter := newFixedWindowLimiter(5, time.Minute)
-	topMux.Handle("POST /api/embed/auth/guest", withCORS(withIPRateLimit(
-		handleEmbedGuestAuth(embedConfigStore, guestSvc),
-		embedGuestLimiter,
-	)))
-	topMux.Handle("OPTIONS /api/embed/auth/guest", withCORS(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})))
-	topMux.Handle("POST /api/embed/auth/upgrade", withCORS(withIPRateLimit(
-		handleEmbedUpgradeGuest(guestSvc, embedTokenManager),
-		embedGuestLimiter,
-	)))
-	topMux.Handle("OPTIONS /api/embed/auth/upgrade", withCORS(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})))
-	topMux.Handle("GET /api/embed/messages", withCORS(handleEmbedMessages(db.Pool, embedTokenManager)))
-	topMux.Handle("OPTIONS /api/embed/messages", withCORS(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})))
-
 	if waCloudChannel != nil {
 		topMux.Handle("/webhook/whatsapp", waCloudChannel.WebhookHandler(handleInbound))
 	}
@@ -396,21 +380,6 @@ func main() {
 		topMux.Handle("GET /api/admin/whatsapp/status", waStatusHandler)
 		topMux.Handle("OPTIONS /api/admin/whatsapp/status", waStatusHandler)
 	}
-	// Embed admin routes (admin/platform_admin only).
-	{
-		embedManager := auth.NewTokenManager(cfg.Auth.JWTSecret, defaultAccessTokenTTL)
-		embedAdminAuth := chain(
-			authenticateRequests(authService, embedManager, time.Now),
-			auth.RequireRoles(auth.RoleAdmin, auth.RolePlatformAdmin),
-		)
-		topMux.Handle("GET /api/admin/embed/config", withCORS(embedAdminAuth(handleAdminGetEmbedConfig(embedConfigStore))))
-		topMux.Handle("PUT /api/admin/embed/config", withCORS(embedAdminAuth(handleAdminUpdateEmbedConfig(embedConfigStore))))
-		topMux.Handle("POST /api/admin/embed/origins", withCORS(embedAdminAuth(handleAdminAddEmbedOrigin(embedConfigStore))))
-		topMux.Handle("DELETE /api/admin/embed/origins", withCORS(embedAdminAuth(handleAdminDeleteEmbedOrigin(embedConfigStore))))
-		topMux.Handle("OPTIONS /api/admin/embed/config", withCORS(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})))
-		topMux.Handle("OPTIONS /api/admin/embed/origins", withCORS(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})))
-	}
-
 	topMux.Handle("/", apiHandler)
 
 	// Atomically swap to the full handler — no port gap, no reconnect.

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -2380,3 +2380,15 @@ func mustIssueTokenWithTenant(t *testing.T, role auth.Role, subject, tenantID st
 	}
 	return token
 }
+
+// TestEmbedAdminConfigRouteUnwired documents that embed-admin routes are quarantined
+// and must not be reachable through the handler mux.
+func TestEmbedAdminConfigRouteUnwired(t *testing.T) {
+	mux := newMux(stubAdminAPI{}, &chatGatewayStub{})
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/embed/config", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d (embed-admin quarantined)", rec.Code, http.StatusNotFound)
+	}
+}

--- a/cmd/server/security.go
+++ b/cmd/server/security.go
@@ -107,39 +107,6 @@ func withAPIRateLimit(next http.Handler, now func() time.Time, apiLimiter, authL
 	})
 }
 
-// withIPRateLimit wraps a handler with IP-based rate limiting.
-func withIPRateLimit(next http.HandlerFunc, limiter *fixedWindowLimiter) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		key := "ip:" + clientIP(r)
-		allowed, retryAfter := limiter.Allow(key, time.Now().UTC())
-		if !allowed {
-			seconds := int(math.Ceil(retryAfter.Seconds()))
-			if seconds < 1 {
-				seconds = 1
-			}
-			w.Header().Set("Retry-After", strconv.Itoa(seconds))
-			http.Error(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests)
-			return
-		}
-		next.ServeHTTP(w, r)
-	}
-}
-
-// clientIP extracts the client IP from the request.
-func clientIP(r *http.Request) string {
-	if xff := firstForwardedFor(r.Header.Get("X-Forwarded-For")); xff != "" {
-		return xff
-	}
-	if xri := strings.TrimSpace(r.Header.Get("X-Real-IP")); xri != "" {
-		return xri
-	}
-	host, _, err := net.SplitHostPort(strings.TrimSpace(r.RemoteAddr))
-	if err == nil {
-		return host
-	}
-	return "unknown"
-}
-
 func withSecurityHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Content-Type-Options", "nosniff")


### PR DESCRIPTION
Unwire the embed-admin and embed guest-auth surfaces from the server mux so they no longer ship.

## What
- Remove the embed-admin route block (`GET/PUT /api/admin/embed/config`, `POST/DELETE /api/admin/embed/origins`) and the embed guest-auth block (`/api/embed/auth/guest`, `/api/embed/auth/upgrade`, `GET /api/embed/messages`) from `topMux`.
- Handlers remain in `cmd/server/embed_admin.go` behind a `TODO(quarantine)` marker as a deletion candidate — no handler logic changed.
- Delete the now-orphaned `withIPRateLimit` / `clientIP` (their only callers were the removed embed guest routes).

## Behavior
Behavior-preserving for everything else. Public embed widget routes (`/embed/pai-chat.js`, `/embed/chat`) and all other admin routes/RBAC are untouched.

## Test
`TestEmbedAdminConfigRouteUnwired` asserts `GET /api/admin/embed/config` → 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
