### PR TITLE
feat(piai): pi-ai core port — types, event protocol, registry, faux provider (PR1)

### DIFF
--- a/internal/piai/NOTICE
+++ b/internal/piai/NOTICE
@@ -1,0 +1,23 @@
+This package is a Go port of pi-ai (@earendil-works/pi-ai),
+https://github.com/earendil-works/pi — types, streaming event protocol,
+provider registry, and faux test provider.
+
+Original work: MIT License, Copyright (c) 2025 Mario Zechner
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/internal/piai/faux.go
+++ b/internal/piai/faux.go
@@ -1,0 +1,453 @@
+package piai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand/v2"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Faux provider — the in-package test double, port of pi-ai's faux provider.
+// It replays queued responses through the real streaming protocol, estimates
+// usage from the serialized context (~4 chars/token), and simulates per-session
+// prompt caching, so consumers exercise the exact contract live adapters obey.
+
+const (
+	fauxDefaultProvider     = "faux"
+	fauxDefaultModelID      = "faux-1"
+	fauxDefaultModelName    = "Faux Model"
+	fauxDefaultBaseURL      = "http://localhost:0"
+	fauxDefaultMinTokenSize = 3
+	fauxDefaultMaxTokenSize = 5
+)
+
+var fauxCounter atomic.Int64
+
+// FauxStep produces one queued response. callCount is 1-based across the
+// registration. A returned error terminates the stream as an error event.
+type FauxStep func(c Context, opts *StreamOptions, callCount int, model Model) (AssistantMessage, error)
+
+// FauxRespond queues a fixed message.
+func FauxRespond(msg AssistantMessage) FauxStep {
+	return func(Context, *StreamOptions, int, Model) (AssistantMessage, error) { return msg, nil }
+}
+
+func FauxText(text string) TextContent { return TextContent{Text: text} }
+
+func FauxThinking(thinking string) ThinkingContent { return ThinkingContent{Thinking: thinking} }
+
+func FauxToolCall(name string, arguments map[string]any) ToolCall {
+	return ToolCall{
+		ID:        fmt.Sprintf("tool:%d", fauxCounter.Add(1)),
+		Name:      name,
+		Arguments: arguments,
+	}
+}
+
+// FauxAssistantMessage builds an assistant message with stopReason "stop";
+// callers mutate StopReason/ErrorMessage for error shapes.
+func FauxAssistantMessage(blocks ...AssistantContent) AssistantMessage {
+	return AssistantMessage{
+		Content:    blocks,
+		API:        "faux",
+		Provider:   fauxDefaultProvider,
+		Model:      fauxDefaultModelID,
+		StopReason: StopReasonStop,
+		Timestamp:  time.Now(),
+	}
+}
+
+// FauxAssistantText builds a single-text-block assistant message.
+func FauxAssistantText(text string) AssistantMessage {
+	return FauxAssistantMessage(FauxText(text))
+}
+
+// FauxModel customizes one model exposed by a faux registration.
+type FauxModel struct {
+	ID        string
+	Name      string
+	Reasoning bool
+}
+
+// FauxOptions configures RegisterFauxProvider. Zero value works: unique API,
+// one default model, random 3–5-token chunks, no pacing.
+type FauxOptions struct {
+	API             string
+	Provider        string
+	Models          []FauxModel
+	TokensPerSecond float64 // 0 = emit chunks without delay
+	TokenSizeMin    int
+	TokenSizeMax    int
+}
+
+// FauxProvider is a registered faux provider with a mutable response queue.
+type FauxProvider struct {
+	API      string
+	Models   []Model
+	sourceID string
+	provider string
+	minTok   int
+	maxTok   int
+	tps      float64
+
+	mu          sync.Mutex
+	pending     []FauxStep
+	callCount   int
+	promptCache map[string]string // sessionID → last serialized prompt
+}
+
+// RegisterFauxProvider registers a faux provider in the global registry and
+// returns its handle. Call Unregister in test cleanup.
+func RegisterFauxProvider(opts FauxOptions) *FauxProvider {
+	n := fauxCounter.Add(1)
+	api := opts.API
+	if api == "" {
+		api = fmt.Sprintf("faux:%d", n)
+	}
+	provider := opts.Provider
+	if provider == "" {
+		provider = fauxDefaultProvider
+	}
+	minTok := opts.TokenSizeMin
+	if minTok < 1 {
+		minTok = fauxDefaultMinTokenSize
+	}
+	maxTok := opts.TokenSizeMax
+	if maxTok < minTok {
+		maxTok = max(minTok, fauxDefaultMaxTokenSize)
+	}
+	defs := opts.Models
+	if len(defs) == 0 {
+		defs = []FauxModel{{ID: fauxDefaultModelID, Name: fauxDefaultModelName}}
+	}
+	f := &FauxProvider{
+		API:         api,
+		sourceID:    fmt.Sprintf("faux-provider:%d", n),
+		provider:    provider,
+		minTok:      minTok,
+		maxTok:      maxTok,
+		tps:         opts.TokensPerSecond,
+		promptCache: map[string]string{},
+	}
+	for _, def := range defs {
+		name := def.Name
+		if name == "" {
+			name = def.ID
+		}
+		f.Models = append(f.Models, Model{
+			ID:            def.ID,
+			Name:          name,
+			API:           api,
+			Provider:      provider,
+			BaseURL:       fauxDefaultBaseURL,
+			Reasoning:     def.Reasoning,
+			ContextWindow: 128000,
+			MaxTokens:     16384,
+		})
+	}
+	RegisterProvider(api, f.stream, f.sourceID)
+	return f
+}
+
+// Model returns the first registered model.
+func (f *FauxProvider) Model() Model { return f.Models[0] }
+
+// ModelByID returns the model with the given ID, or false.
+func (f *FauxProvider) ModelByID(id string) (Model, bool) {
+	for _, m := range f.Models {
+		if m.ID == id {
+			return m, true
+		}
+	}
+	return Model{}, false
+}
+
+func (f *FauxProvider) SetResponses(steps ...FauxStep) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.pending = append([]FauxStep(nil), steps...)
+}
+
+func (f *FauxProvider) AppendResponses(steps ...FauxStep) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.pending = append(f.pending, steps...)
+}
+
+func (f *FauxProvider) PendingResponses() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.pending)
+}
+
+func (f *FauxProvider) CallCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.callCount
+}
+
+func (f *FauxProvider) Unregister() { UnregisterProviders(f.sourceID) }
+
+func (f *FauxProvider) stream(ctx context.Context, model Model, c Context, opts *StreamOptions) *EventStream {
+	s := NewEventStream()
+	f.mu.Lock()
+	var step FauxStep
+	if len(f.pending) > 0 {
+		step = f.pending[0]
+		f.pending = f.pending[1:]
+	}
+	f.callCount++
+	count := f.callCount
+	f.mu.Unlock()
+
+	go func() {
+		if step == nil {
+			s.endWithError(f.withUsageEstimate(f.errorMessage(model, "no more faux responses queued"), c, opts))
+			return
+		}
+		resolved, err := step(c, opts, count, model)
+		if err != nil {
+			s.endWithError(f.errorMessage(model, err.Error()))
+			return
+		}
+		resolved.API = f.API
+		resolved.Provider = f.provider
+		resolved.Model = model.ID
+		if resolved.Timestamp.IsZero() {
+			resolved.Timestamp = time.Now()
+		}
+		resolved = f.withUsageEstimate(resolved, c, opts)
+		f.streamWithDeltas(ctx, s, resolved)
+	}()
+	return s
+}
+
+func (f *FauxProvider) errorMessage(model Model, errText string) AssistantMessage {
+	return AssistantMessage{
+		API:          f.API,
+		Provider:     f.provider,
+		Model:        model.ID,
+		StopReason:   StopReasonError,
+		ErrorMessage: errText,
+		Timestamp:    time.Now(),
+	}
+}
+
+// streamWithDeltas replays a resolved message block-by-block through the
+// event protocol, honoring pacing and ctx cancellation between chunks.
+func (f *FauxProvider) streamWithDeltas(ctx context.Context, s *EventStream, msg AssistantMessage) {
+	partial := msg
+	partial.Content = nil
+	abort := func() {
+		aborted := partial
+		aborted.StopReason = StopReasonAborted
+		aborted.ErrorMessage = "request was aborted"
+		aborted.Timestamp = time.Now()
+		s.Push(AssistantMessageEvent{Type: EventError, Reason: StopReasonAborted, Message: &aborted})
+	}
+	push := func(typ EventType, mutate func(*AssistantMessageEvent)) {
+		snapshot := partial
+		snapshot.Content = append([]AssistantContent(nil), partial.Content...)
+		ev := AssistantMessageEvent{Type: typ, Partial: &snapshot}
+		if mutate != nil {
+			mutate(&ev)
+		}
+		s.Push(ev)
+	}
+
+	if ctx.Err() != nil {
+		abort()
+		return
+	}
+	push(EventStart, nil)
+
+	for i, block := range msg.Content {
+		switch b := block.(type) {
+		case ThinkingContent:
+			partial.Content = append(partial.Content, ThinkingContent{})
+			push(EventThinkingStart, func(ev *AssistantMessageEvent) { ev.ContentIndex = i })
+			written := 0
+			for _, chunk := range f.splitByTokenSize(b.Thinking) {
+				f.pace(chunk)
+				if ctx.Err() != nil {
+					abort()
+					return
+				}
+				written += len(chunk)
+				partial.Content[i] = ThinkingContent{Thinking: b.Thinking[:written]}
+				push(EventThinkingDelta, func(ev *AssistantMessageEvent) { ev.ContentIndex = i; ev.Delta = chunk })
+			}
+			push(EventThinkingEnd, func(ev *AssistantMessageEvent) { ev.ContentIndex = i; ev.Content = b.Thinking })
+		case TextContent:
+			partial.Content = append(partial.Content, TextContent{})
+			push(EventTextStart, func(ev *AssistantMessageEvent) { ev.ContentIndex = i })
+			written := 0
+			for _, chunk := range f.splitByTokenSize(b.Text) {
+				f.pace(chunk)
+				if ctx.Err() != nil {
+					abort()
+					return
+				}
+				written += len(chunk)
+				partial.Content[i] = TextContent{Text: b.Text[:written]}
+				push(EventTextDelta, func(ev *AssistantMessageEvent) { ev.ContentIndex = i; ev.Delta = chunk })
+			}
+			push(EventTextEnd, func(ev *AssistantMessageEvent) { ev.ContentIndex = i; ev.Content = b.Text })
+		case ToolCall:
+			partial.Content = append(partial.Content, ToolCall{ID: b.ID, Name: b.Name, Arguments: map[string]any{}})
+			push(EventToolCallStart, func(ev *AssistantMessageEvent) { ev.ContentIndex = i })
+			args, _ := json.Marshal(b.Arguments)
+			for _, chunk := range f.splitByTokenSize(string(args)) {
+				f.pace(chunk)
+				if ctx.Err() != nil {
+					abort()
+					return
+				}
+				push(EventToolCallDelta, func(ev *AssistantMessageEvent) { ev.ContentIndex = i; ev.Delta = chunk })
+			}
+			partial.Content[i] = b
+			toolCall := b
+			push(EventToolCallEnd, func(ev *AssistantMessageEvent) { ev.ContentIndex = i; ev.ToolCall = &toolCall })
+		}
+	}
+
+	final := msg
+	if final.StopReason == StopReasonError || final.StopReason == StopReasonAborted {
+		s.Push(AssistantMessageEvent{Type: EventError, Reason: final.StopReason, Message: &final})
+		return
+	}
+	s.Push(AssistantMessageEvent{Type: EventDone, Reason: final.StopReason, Message: &final})
+}
+
+func (f *FauxProvider) pace(chunk string) {
+	if f.tps <= 0 {
+		return
+	}
+	time.Sleep(time.Duration(float64(estimateTokens(chunk)) / f.tps * float64(time.Second)))
+}
+
+func (f *FauxProvider) splitByTokenSize(text string) []string {
+	var chunks []string
+	for i := 0; i < len(text); {
+		tok := f.minTok + rand.IntN(f.maxTok-f.minTok+1)
+		size := max(1, tok*4)
+		end := min(len(text), i+size)
+		chunks = append(chunks, text[i:end])
+		i = end
+	}
+	if len(chunks) == 0 {
+		chunks = []string{""}
+	}
+	return chunks
+}
+
+// withUsageEstimate fills Usage from the serialized prompt (~4 chars/token)
+// and simulates prompt caching per sessionID via longest common prefix, so
+// totalTokens always equals input+output+cacheRead+cacheWrite.
+func (f *FauxProvider) withUsageEstimate(msg AssistantMessage, c Context, opts *StreamOptions) AssistantMessage {
+	promptText := serializeContext(c)
+	promptTokens := estimateTokens(promptText)
+	outputTokens := estimateTokens(assistantContentToText(msg.Content))
+	input := promptTokens
+	cacheRead, cacheWrite := 0, 0
+
+	if opts != nil && opts.SessionID != "" && opts.CacheRetention != CacheRetentionNone {
+		f.mu.Lock()
+		previous := f.promptCache[opts.SessionID]
+		f.promptCache[opts.SessionID] = promptText
+		f.mu.Unlock()
+		if previous != "" {
+			cached := commonPrefixLen(previous, promptText)
+			cacheRead = estimateTokens(previous[:cached])
+			cacheWrite = estimateTokens(promptText[cached:])
+			input = max(0, promptTokens-cacheRead)
+		} else {
+			cacheWrite = promptTokens
+		}
+	}
+
+	msg.Usage = Usage{
+		Input:       input,
+		Output:      outputTokens,
+		CacheRead:   cacheRead,
+		CacheWrite:  cacheWrite,
+		TotalTokens: input + outputTokens + cacheRead + cacheWrite,
+	}
+	return msg
+}
+
+func estimateTokens(text string) int { return (len(text) + 3) / 4 }
+
+func commonPrefixLen(a, b string) int {
+	n := min(len(a), len(b))
+	i := 0
+	for i < n && a[i] == b[i] {
+		i++
+	}
+	return i
+}
+
+func userContentToText(content []UserContent) string {
+	parts := make([]string, 0, len(content))
+	for _, block := range content {
+		switch b := block.(type) {
+		case TextContent:
+			parts = append(parts, b.Text)
+		case ImageContent:
+			parts = append(parts, fmt.Sprintf("[image:%s:%d]", b.MimeType, len(b.Data)))
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+func assistantContentToText(content []AssistantContent) string {
+	parts := make([]string, 0, len(content))
+	for _, block := range content {
+		switch b := block.(type) {
+		case TextContent:
+			parts = append(parts, b.Text)
+		case ThinkingContent:
+			parts = append(parts, b.Thinking)
+		case ToolCall:
+			args, _ := json.Marshal(b.Arguments)
+			parts = append(parts, b.Name+":"+string(args))
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+func messageToText(m Message) (role, text string) {
+	switch msg := m.(type) {
+	case UserMessage:
+		return "user", userContentToText(msg.Content)
+	case AssistantMessage:
+		return "assistant", assistantContentToText(msg.Content)
+	case ToolResultMessage:
+		parts := []string{msg.ToolName}
+		for _, block := range msg.Content {
+			parts = append(parts, userContentToText([]UserContent{block}))
+		}
+		return "toolResult", strings.Join(parts, "\n")
+	}
+	return "", ""
+}
+
+func serializeContext(c Context) string {
+	var parts []string
+	if c.SystemPrompt != "" {
+		parts = append(parts, "system:"+c.SystemPrompt)
+	}
+	for _, m := range c.Messages {
+		role, text := messageToText(m)
+		parts = append(parts, role+":"+text)
+	}
+	if len(c.Tools) > 0 {
+		tools, _ := json.Marshal(c.Tools)
+		parts = append(parts, "tools:"+string(tools))
+	}
+	return strings.Join(parts, "\n\n")
+}

--- a/internal/piai/faux.go
+++ b/internal/piai/faux.go
@@ -312,6 +312,9 @@ func (f *FauxProvider) streamWithDeltas(ctx context.Context, s *EventStream, msg
 			partial.Content[i] = b
 			toolCall := b
 			push(EventToolCallEnd, func(ev *AssistantMessageEvent) { ev.ContentIndex = i; ev.ToolCall = &toolCall })
+		default:
+			// AssistantContent is sealed; a new variant must be handled here.
+			panic(fmt.Sprintf("piai: unhandled assistant content block %T", block))
 		}
 	}
 

--- a/internal/piai/faux.go
+++ b/internal/piai/faux.go
@@ -11,10 +11,8 @@ import (
 	"time"
 )
 
-// Faux provider — the in-package test double, port of pi-ai's faux provider.
-// It replays queued responses through the real streaming protocol, estimates
-// usage from the serialized context (~4 chars/token), and simulates per-session
-// prompt caching, so consumers exercise the exact contract live adapters obey.
+// Faux provider — in-package test double, port of pi-ai's faux provider. Replays
+// queued responses through the real streaming protocol with simulated usage/caching.
 
 const (
 	fauxDefaultProvider     = "faux"
@@ -237,8 +235,7 @@ func (f *FauxProvider) errorMessage(model Model, errText string) AssistantMessag
 	}
 }
 
-// streamWithDeltas replays a resolved message block-by-block through the
-// event protocol, honoring pacing and ctx cancellation between chunks.
+// streamWithDeltas replays the message through the event protocol, honoring pacing and ctx cancellation between chunks.
 func (f *FauxProvider) streamWithDeltas(ctx context.Context, s *EventStream, msg AssistantMessage) {
 	partial := msg
 	partial.Content = nil
@@ -348,9 +345,8 @@ func (f *FauxProvider) splitByTokenSize(text string) []string {
 	return chunks
 }
 
-// withUsageEstimate fills Usage from the serialized prompt (~4 chars/token)
-// and simulates prompt caching per sessionID via longest common prefix, so
-// totalTokens always equals input+output+cacheRead+cacheWrite.
+// withUsageEstimate estimates usage (~4 chars/token) and simulates per-session prompt
+// caching via longest common prefix; totalTokens = input+output+cacheRead+cacheWrite.
 func (f *FauxProvider) withUsageEstimate(msg AssistantMessage, c Context, opts *StreamOptions) AssistantMessage {
 	promptText := serializeContext(c)
 	promptTokens := estimateTokens(promptText)

--- a/internal/piai/faux_test.go
+++ b/internal/piai/faux_test.go
@@ -524,12 +524,20 @@ func TestFauxAbortBeforeFirstChunk(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	events := collectEvents(piai.Stream(ctx, f.Model(), userContext("hi"), nil))
+	stream := piai.Stream(ctx, f.Model(), userContext("hi"), nil)
+	events := collectEvents(stream)
 	if len(events) != 1 || events[0].Type != piai.EventError {
 		t.Fatalf("events = %v", eventTypes(events))
 	}
 	if events[0].Reason != piai.StopReasonAborted || events[0].Message.StopReason != piai.StopReasonAborted {
 		t.Fatalf("terminal = %+v", events[0].Message)
+	}
+
+	// Cancellation is classified: the error channel says aborted, not error.
+	_, err := stream.Result()
+	var streamErr *piai.StreamError
+	if !errors.As(err, &streamErr) || streamErr.Reason != piai.StopReasonAborted {
+		t.Fatalf("expected aborted StreamError, got %v", err)
 	}
 }
 

--- a/internal/piai/faux_test.go
+++ b/internal/piai/faux_test.go
@@ -1,0 +1,592 @@
+// Port of pi-ai's faux-provider.test.ts plus the total-tokens invariant from
+// total-tokens.test.ts: totalTokens must equal input+output+cacheRead+cacheWrite
+// on every response — it is the base for context-size accounting.
+package piai_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/p-n-ai/pai-bot/internal/piai"
+)
+
+func requireTotalTokensEqualsComponents(t *testing.T, u piai.Usage) {
+	t.Helper()
+	computed := u.Input + u.Output + u.CacheRead + u.CacheWrite
+	if u.TotalTokens != computed {
+		t.Fatalf("totalTokens = %d, want sum of components %d (%+v)", u.TotalTokens, computed, u)
+	}
+}
+
+func userContext(text string) piai.Context {
+	return piai.Context{Messages: []piai.Message{piai.UserText(text)}}
+}
+
+func textOf(t *testing.T, msg piai.AssistantMessage) string {
+	t.Helper()
+	if len(msg.Content) != 1 {
+		t.Fatalf("expected single content block, got %d", len(msg.Content))
+	}
+	block, ok := msg.Content[0].(piai.TextContent)
+	if !ok {
+		t.Fatalf("expected text block, got %T", msg.Content[0])
+	}
+	return block.Text
+}
+
+func TestFauxRegistersProviderAndEstimatesUsage(t *testing.T) {
+	f := piai.RegisterFauxProvider(piai.FauxOptions{})
+	defer f.Unregister()
+	f.SetResponses(piai.FauxRespond(piai.FauxAssistantText("hello world")))
+
+	c := piai.Context{SystemPrompt: "Be concise.", Messages: []piai.Message{piai.UserText("hi there")}}
+	msg, err := piai.Complete(context.Background(), f.Model(), c, nil)
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if got := textOf(t, msg); got != "hello world" {
+		t.Fatalf("content = %q", got)
+	}
+	if msg.Usage.Input == 0 || msg.Usage.Output == 0 {
+		t.Fatalf("expected non-zero usage, got %+v", msg.Usage)
+	}
+	if msg.Usage.TotalTokens != msg.Usage.Input+msg.Usage.Output {
+		t.Fatalf("totalTokens = %d, want input+output", msg.Usage.TotalTokens)
+	}
+	requireTotalTokensEqualsComponents(t, msg.Usage)
+	if f.CallCount() != 1 {
+		t.Fatalf("callCount = %d", f.CallCount())
+	}
+}
+
+func TestFauxHelperBlocks(t *testing.T) {
+	f := piai.RegisterFauxProvider(piai.FauxOptions{})
+	defer f.Unregister()
+	reply := piai.FauxAssistantMessage(
+		piai.FauxThinking("think"),
+		piai.FauxToolCall("echo", map[string]any{"text": "hi"}),
+		piai.FauxText("done"),
+	)
+	reply.StopReason = piai.StopReasonToolUse
+	f.SetResponses(piai.FauxRespond(reply))
+
+	msg, err := piai.Complete(context.Background(), f.Model(), userContext("hi"), nil)
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if msg.StopReason != piai.StopReasonToolUse {
+		t.Fatalf("stopReason = %q", msg.StopReason)
+	}
+	if len(msg.Content) != 3 {
+		t.Fatalf("content blocks = %d", len(msg.Content))
+	}
+	if th, ok := msg.Content[0].(piai.ThinkingContent); !ok || th.Thinking != "think" {
+		t.Fatalf("block 0 = %#v", msg.Content[0])
+	}
+	tc, ok := msg.Content[1].(piai.ToolCall)
+	if !ok || tc.Name != "echo" || tc.ID == "" || tc.Arguments["text"] != "hi" {
+		t.Fatalf("block 1 = %#v", msg.Content[1])
+	}
+	if txt, ok := msg.Content[2].(piai.TextContent); !ok || txt.Text != "done" {
+		t.Fatalf("block 2 = %#v", msg.Content[2])
+	}
+	requireTotalTokensEqualsComponents(t, msg.Usage)
+}
+
+func TestFauxMultipleModelsAndModelAwareFactories(t *testing.T) {
+	f := piai.RegisterFauxProvider(piai.FauxOptions{
+		Models: []piai.FauxModel{
+			{ID: "faux-fast", Name: "Faux Fast"},
+			{ID: "faux-thinker", Name: "Faux Thinker", Reasoning: true},
+		},
+	})
+	defer f.Unregister()
+	factory := func(_ piai.Context, _ *piai.StreamOptions, _ int, model piai.Model) (piai.AssistantMessage, error) {
+		return piai.FauxAssistantText(fmt.Sprintf("%s:%t", model.ID, model.Reasoning)), nil
+	}
+	f.SetResponses(factory, factory)
+
+	fast, ok := f.ModelByID("faux-fast")
+	if !ok || fast.Reasoning {
+		t.Fatalf("faux-fast = %+v ok=%v", fast, ok)
+	}
+	thinker, ok := f.ModelByID("faux-thinker")
+	if !ok || !thinker.Reasoning {
+		t.Fatalf("faux-thinker = %+v ok=%v", thinker, ok)
+	}
+	if f.Model().ID != "faux-fast" {
+		t.Fatalf("first model = %q", f.Model().ID)
+	}
+
+	fastMsg, err := piai.Complete(context.Background(), fast, userContext("hi"), nil)
+	if err != nil {
+		t.Fatalf("Complete fast: %v", err)
+	}
+	thinkerMsg, err := piai.Complete(context.Background(), thinker, userContext("hi"), nil)
+	if err != nil {
+		t.Fatalf("Complete thinker: %v", err)
+	}
+	if textOf(t, fastMsg) != "faux-fast:false" || textOf(t, thinkerMsg) != "faux-thinker:true" {
+		t.Fatalf("responses = %q, %q", textOf(t, fastMsg), textOf(t, thinkerMsg))
+	}
+}
+
+func TestFauxRewritesAPIProviderModel(t *testing.T) {
+	f := piai.RegisterFauxProvider(piai.FauxOptions{
+		API:      "faux:test",
+		Provider: "faux-provider",
+		Models:   []piai.FauxModel{{ID: "faux-model"}},
+	})
+	defer f.Unregister()
+	f.SetResponses(piai.FauxRespond(piai.FauxAssistantText("hello")))
+
+	msg, err := piai.Complete(context.Background(), f.Model(), userContext("hi"), nil)
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if msg.API != "faux:test" || msg.Provider != "faux-provider" || msg.Model != "faux-model" {
+		t.Fatalf("api/provider/model = %q/%q/%q", msg.API, msg.Provider, msg.Model)
+	}
+}
+
+func TestFauxConsumesQueueInOrderAndErrorsWhenExhausted(t *testing.T) {
+	f := piai.RegisterFauxProvider(piai.FauxOptions{})
+	defer f.Unregister()
+	f.SetResponses(
+		piai.FauxRespond(piai.FauxAssistantText("first")),
+		piai.FauxRespond(piai.FauxAssistantText("second")),
+	)
+
+	c := userContext("hi")
+	first, err := piai.Complete(context.Background(), f.Model(), c, nil)
+	if err != nil || textOf(t, first) != "first" {
+		t.Fatalf("first = %q err=%v", textOf(t, first), err)
+	}
+	second, err := piai.Complete(context.Background(), f.Model(), c, nil)
+	if err != nil || textOf(t, second) != "second" {
+		t.Fatalf("second = %q err=%v", textOf(t, second), err)
+	}
+	exhausted, err := piai.Complete(context.Background(), f.Model(), c, nil)
+	if err == nil {
+		t.Fatal("expected error when queue exhausted")
+	}
+	if exhausted.StopReason != piai.StopReasonError || exhausted.ErrorMessage != "no more faux responses queued" {
+		t.Fatalf("exhausted = %+v", exhausted)
+	}
+	requireTotalTokensEqualsComponents(t, exhausted.Usage)
+	if f.PendingResponses() != 0 || f.CallCount() != 3 {
+		t.Fatalf("pending=%d callCount=%d", f.PendingResponses(), f.CallCount())
+	}
+}
+
+func TestFauxReplaceAndAppendResponses(t *testing.T) {
+	f := piai.RegisterFauxProvider(piai.FauxOptions{})
+	defer f.Unregister()
+	c := userContext("hi")
+	mustText := func(want string) {
+		t.Helper()
+		msg, err := piai.Complete(context.Background(), f.Model(), c, nil)
+		if err != nil {
+			t.Fatalf("Complete: %v", err)
+		}
+		if got := textOf(t, msg); got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	}
+
+	f.SetResponses(piai.FauxRespond(piai.FauxAssistantText("first")))
+	mustText("first")
+	if f.PendingResponses() != 0 {
+		t.Fatalf("pending = %d", f.PendingResponses())
+	}
+
+	f.SetResponses(piai.FauxRespond(piai.FauxAssistantText("second")))
+	if f.PendingResponses() != 1 {
+		t.Fatalf("pending = %d", f.PendingResponses())
+	}
+	mustText("second")
+
+	f.AppendResponses(
+		piai.FauxRespond(piai.FauxAssistantText("third")),
+		piai.FauxRespond(piai.FauxAssistantText("fourth")),
+	)
+	if f.PendingResponses() != 2 {
+		t.Fatalf("pending = %d", f.PendingResponses())
+	}
+	mustText("third")
+	mustText("fourth")
+}
+
+func TestFauxFactorySeesContextAndCallCount(t *testing.T) {
+	f := piai.RegisterFauxProvider(piai.FauxOptions{})
+	defer f.Unregister()
+	f.SetResponses(func(c piai.Context, _ *piai.StreamOptions, callCount int, _ piai.Model) (piai.AssistantMessage, error) {
+		return piai.FauxAssistantText(fmt.Sprintf("%d:%d", len(c.Messages), callCount)), nil
+	})
+
+	msg, err := piai.Complete(context.Background(), f.Model(), userContext("hi"), nil)
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if got := textOf(t, msg); got != "1:1" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestFauxFactoryErrorBecomesTerminalErrorEvent(t *testing.T) {
+	f := piai.RegisterFauxProvider(piai.FauxOptions{})
+	defer f.Unregister()
+	f.SetResponses(func(piai.Context, *piai.StreamOptions, int, piai.Model) (piai.AssistantMessage, error) {
+		return piai.AssistantMessage{}, errors.New("boom")
+	})
+
+	events := collectEvents(piai.Stream(context.Background(), f.Model(), userContext("hi"), nil))
+	if len(events) != 1 || events[0].Type != piai.EventError {
+		t.Fatalf("events = %v", eventTypes(events))
+	}
+	if events[0].Message.StopReason != piai.StopReasonError || events[0].Message.ErrorMessage != "boom" {
+		t.Fatalf("terminal = %+v", events[0].Message)
+	}
+}
+
+func TestFauxEstimatesTokensFromSerializedContext(t *testing.T) {
+	f := piai.RegisterFauxProvider(piai.FauxOptions{})
+	defer f.Unregister()
+	f.SetResponses(piai.FauxRespond(piai.FauxAssistantText("done")))
+
+	tool := piai.Tool{
+		Name:        "echo",
+		Description: "Echo back text",
+		Parameters:  json.RawMessage(`{"type":"object","properties":{"text":{"type":"string"}}}`),
+	}
+	prior := piai.FauxAssistantText("prior")
+	c := piai.Context{
+		SystemPrompt: "sys",
+		Messages: []piai.Message{
+			piai.UserMessage{
+				Content: []piai.UserContent{
+					piai.TextContent{Text: "hello"},
+					piai.ImageContent{MimeType: "image/png", Data: "abcd"},
+				},
+			},
+			prior,
+			piai.ToolResultMessage{
+				ToolCallID: "tool-1",
+				ToolName:   "echo",
+				Content:    []piai.UserContent{piai.TextContent{Text: "tool out"}},
+			},
+		},
+		Tools: []piai.Tool{tool},
+	}
+
+	msg, err := piai.Complete(context.Background(), f.Model(), c, nil)
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	toolsJSON, _ := json.Marshal([]piai.Tool{tool})
+	promptText := strings.Join([]string{
+		"system:sys",
+		"user:hello\n[image:image/png:4]",
+		"assistant:prior",
+		"toolResult:echo\ntool out",
+		"tools:" + string(toolsJSON),
+	}, "\n\n")
+	wantInput := (len(promptText) + 3) / 4
+	wantOutput := (len("done") + 3) / 4
+
+	if msg.Usage.Input != wantInput || msg.Usage.Output != wantOutput {
+		t.Fatalf("usage = %+v, want input %d output %d", msg.Usage, wantInput, wantOutput)
+	}
+	if msg.Usage.CacheRead != 0 || msg.Usage.CacheWrite != 0 {
+		t.Fatalf("expected no cache activity: %+v", msg.Usage)
+	}
+	requireTotalTokensEqualsComponents(t, msg.Usage)
+}
+
+func TestFauxSimulatesPromptCachingPerSession(t *testing.T) {
+	f := piai.RegisterFauxProvider(piai.FauxOptions{})
+	defer f.Unregister()
+	f.SetResponses(
+		piai.FauxRespond(piai.FauxAssistantText("first")),
+		piai.FauxRespond(piai.FauxAssistantText("second")),
+	)
+
+	c := piai.Context{SystemPrompt: "Be concise.", Messages: []piai.Message{piai.UserText("hello")}}
+	opts := &piai.StreamOptions{SessionID: "session-1", CacheRetention: piai.CacheRetentionShort}
+
+	first, err := piai.Complete(context.Background(), f.Model(), c, opts)
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if first.Usage.CacheRead != 0 || first.Usage.CacheWrite == 0 {
+		t.Fatalf("first usage = %+v", first.Usage)
+	}
+	requireTotalTokensEqualsComponents(t, first.Usage)
+
+	c.Messages = append(c.Messages, first, piai.UserText("follow up"))
+	second, err := piai.Complete(context.Background(), f.Model(), c, opts)
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if second.Usage.CacheRead == 0 {
+		t.Fatalf("second usage = %+v, want cacheRead > 0", second.Usage)
+	}
+	requireTotalTokensEqualsComponents(t, second.Usage)
+}
+
+func TestFauxDoesNotShareCacheAcrossSessionsOrWithoutSessionID(t *testing.T) {
+	f := piai.RegisterFauxProvider(piai.FauxOptions{})
+	defer f.Unregister()
+	f.SetResponses(
+		piai.FauxRespond(piai.FauxAssistantText("first")),
+		piai.FauxRespond(piai.FauxAssistantText("second")),
+		piai.FauxRespond(piai.FauxAssistantText("third")),
+	)
+
+	c := userContext("hello")
+	first, err := piai.Complete(context.Background(), f.Model(), c,
+		&piai.StreamOptions{SessionID: "session-1", CacheRetention: piai.CacheRetentionShort})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if first.Usage.CacheWrite == 0 {
+		t.Fatalf("first usage = %+v", first.Usage)
+	}
+
+	c.Messages = append(c.Messages, first, piai.UserText("follow up"))
+	second, err := piai.Complete(context.Background(), f.Model(), c,
+		&piai.StreamOptions{SessionID: "session-2", CacheRetention: piai.CacheRetentionShort})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if second.Usage.CacheRead != 0 || second.Usage.CacheWrite == 0 {
+		t.Fatalf("second usage = %+v", second.Usage)
+	}
+
+	third, err := piai.Complete(context.Background(), f.Model(), c, nil)
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if third.Usage.CacheRead != 0 || third.Usage.CacheWrite != 0 {
+		t.Fatalf("third usage = %+v", third.Usage)
+	}
+}
+
+func TestFauxNoCachingWhenRetentionNone(t *testing.T) {
+	f := piai.RegisterFauxProvider(piai.FauxOptions{})
+	defer f.Unregister()
+	f.SetResponses(
+		piai.FauxRespond(piai.FauxAssistantText("first")),
+		piai.FauxRespond(piai.FauxAssistantText("second")),
+	)
+
+	c := userContext("hello")
+	opts := &piai.StreamOptions{SessionID: "session-1", CacheRetention: piai.CacheRetentionNone}
+	if _, err := piai.Complete(context.Background(), f.Model(), c, opts); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	c.Messages = append(c.Messages, piai.FauxAssistantText("first"), piai.UserText("follow up"))
+	second, err := piai.Complete(context.Background(), f.Model(), c, opts)
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if second.Usage.CacheRead != 0 || second.Usage.CacheWrite != 0 {
+		t.Fatalf("usage = %+v", second.Usage)
+	}
+}
+
+func TestFauxStreamsThinkingTextAndToolCallDeltas(t *testing.T) {
+	f := piai.RegisterFauxProvider(piai.FauxOptions{})
+	defer f.Unregister()
+	reply := piai.FauxAssistantMessage(
+		piai.FauxThinking("thinking text"),
+		piai.FauxText("answer text"),
+		piai.ToolCall{ID: "tool-1", Name: "echo", Arguments: map[string]any{"text": "hi", "count": float64(12)}},
+	)
+	reply.StopReason = piai.StopReasonToolUse
+	f.SetResponses(piai.FauxRespond(reply))
+
+	var toolCallDeltas []string
+	events := collectEvents(piai.Stream(context.Background(), f.Model(), userContext("hi"), nil))
+	for _, ev := range events {
+		if ev.Type == piai.EventToolCallDelta {
+			toolCallDeltas = append(toolCallDeltas, ev.Delta)
+		}
+	}
+
+	for _, want := range []piai.EventType{
+		piai.EventThinkingStart, piai.EventThinkingDelta,
+		piai.EventTextStart, piai.EventTextDelta,
+		piai.EventToolCallStart, piai.EventToolCallDelta, piai.EventToolCallEnd,
+	} {
+		if !containsType(events, want) {
+			t.Fatalf("missing event %q in %v", want, eventTypes(events))
+		}
+	}
+	if len(toolCallDeltas) < 2 {
+		t.Fatalf("toolcall deltas = %d, want > 1", len(toolCallDeltas))
+	}
+	var args map[string]any
+	if err := json.Unmarshal([]byte(strings.Join(toolCallDeltas, "")), &args); err != nil {
+		t.Fatalf("joined deltas not valid JSON: %v", err)
+	}
+	if args["text"] != "hi" || args["count"] != float64(12) {
+		t.Fatalf("args = %+v", args)
+	}
+}
+
+func TestFauxStreamsExactEventOrderForFixedChunks(t *testing.T) {
+	f := piai.RegisterFauxProvider(piai.FauxOptions{TokenSizeMin: 1, TokenSizeMax: 1})
+	defer f.Unregister()
+	reply := piai.FauxAssistantMessage(
+		piai.FauxThinking("go"),
+		piai.FauxText("ok"),
+		piai.ToolCall{ID: "tool-1", Name: "echo", Arguments: map[string]any{}},
+	)
+	reply.StopReason = piai.StopReasonToolUse
+	f.SetResponses(piai.FauxRespond(reply))
+
+	events := collectEvents(piai.Stream(context.Background(), f.Model(), userContext("hi"), nil))
+	if !equalTypes(eventTypes(events),
+		piai.EventStart,
+		piai.EventThinkingStart, piai.EventThinkingDelta, piai.EventThinkingEnd,
+		piai.EventTextStart, piai.EventTextDelta, piai.EventTextEnd,
+		piai.EventToolCallStart, piai.EventToolCallDelta, piai.EventToolCallEnd,
+		piai.EventDone,
+	) {
+		t.Fatalf("event order = %v", eventTypes(events))
+	}
+}
+
+func TestFauxStreamsMultipleToolCalls(t *testing.T) {
+	f := piai.RegisterFauxProvider(piai.FauxOptions{})
+	defer f.Unregister()
+	reply := piai.FauxAssistantMessage(
+		piai.ToolCall{ID: "tool-1", Name: "echo", Arguments: map[string]any{"text": "one"}},
+		piai.ToolCall{ID: "tool-2", Name: "echo", Arguments: map[string]any{"text": "two"}},
+	)
+	reply.StopReason = piai.StopReasonToolUse
+	f.SetResponses(piai.FauxRespond(reply))
+
+	events := collectEvents(piai.Stream(context.Background(), f.Model(), userContext("hi"), nil))
+	starts, ends := 0, 0
+	for _, ev := range events {
+		switch ev.Type {
+		case piai.EventToolCallStart:
+			starts++
+		case piai.EventToolCallEnd:
+			ends++
+		}
+	}
+	if starts != 2 || ends != 2 {
+		t.Fatalf("toolcall starts=%d ends=%d", starts, ends)
+	}
+}
+
+func TestFauxExplicitErrorMessageStreamsAsTerminalError(t *testing.T) {
+	for _, tc := range []struct {
+		reason  piai.StopReason
+		errText string
+	}{
+		{piai.StopReasonError, "upstream failed"},
+		{piai.StopReasonAborted, "request was aborted"},
+	} {
+		f := piai.RegisterFauxProvider(piai.FauxOptions{TokenSizeMin: 2, TokenSizeMax: 2})
+		reply := piai.FauxAssistantText("partial")
+		reply.StopReason = tc.reason
+		reply.ErrorMessage = tc.errText
+		f.SetResponses(piai.FauxRespond(reply))
+
+		events := collectEvents(piai.Stream(context.Background(), f.Model(), userContext("hi"), nil))
+		if !equalTypes(eventTypes(events),
+			piai.EventStart, piai.EventTextStart, piai.EventTextDelta, piai.EventTextEnd, piai.EventError,
+		) {
+			t.Fatalf("%s: event order = %v", tc.reason, eventTypes(events))
+		}
+		terminal := events[len(events)-1]
+		if terminal.Reason != tc.reason || terminal.Message.StopReason != tc.reason || terminal.Message.ErrorMessage != tc.errText {
+			t.Fatalf("%s: terminal = %+v", tc.reason, terminal.Message)
+		}
+		f.Unregister()
+	}
+}
+
+func TestFauxAbortBeforeFirstChunk(t *testing.T) {
+	f := piai.RegisterFauxProvider(piai.FauxOptions{TokensPerSecond: 50, TokenSizeMin: 3, TokenSizeMax: 3})
+	defer f.Unregister()
+	f.SetResponses(piai.FauxRespond(piai.FauxAssistantText("abcdefghijklmnopqrstuvwxyz")))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	events := collectEvents(piai.Stream(ctx, f.Model(), userContext("hi"), nil))
+	if len(events) != 1 || events[0].Type != piai.EventError {
+		t.Fatalf("events = %v", eventTypes(events))
+	}
+	if events[0].Reason != piai.StopReasonAborted || events[0].Message.StopReason != piai.StopReasonAborted {
+		t.Fatalf("terminal = %+v", events[0].Message)
+	}
+}
+
+func TestFauxAbortMidTextStream(t *testing.T) {
+	f := piai.RegisterFauxProvider(piai.FauxOptions{TokensPerSecond: 100, TokenSizeMin: 3, TokenSizeMax: 3})
+	defer f.Unregister()
+	f.SetResponses(piai.FauxRespond(piai.FauxAssistantText("abcdefghijklmnopqrstuvwxyz")))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var events []piai.AssistantMessageEvent
+	textDeltas := 0
+	for ev := range piai.Stream(ctx, f.Model(), userContext("hi"), nil).Events() {
+		events = append(events, ev)
+		if ev.Type == piai.EventTextDelta {
+			textDeltas++
+			cancel()
+		}
+	}
+
+	if textDeltas != 1 {
+		t.Fatalf("text deltas = %d, want 1", textDeltas)
+	}
+	if !containsType(events, piai.EventTextStart) || !containsType(events, piai.EventError) {
+		t.Fatalf("events = %v", eventTypes(events))
+	}
+	if containsType(events, piai.EventTextEnd) {
+		t.Fatalf("unexpected text_end after abort: %v", eventTypes(events))
+	}
+}
+
+func TestFauxUnregister(t *testing.T) {
+	f := piai.RegisterFauxProvider(piai.FauxOptions{})
+	f.SetResponses(piai.FauxRespond(piai.FauxAssistantText("hello")))
+	f.Unregister()
+
+	msg, err := piai.Complete(context.Background(), f.Model(), userContext("hi"), nil)
+	if err == nil {
+		t.Fatal("expected error for unregistered provider")
+	}
+	want := "no API provider registered for api: " + f.API
+	if msg.ErrorMessage != want {
+		t.Fatalf("errorMessage = %q, want %q", msg.ErrorMessage, want)
+	}
+}
+
+func TestFauxPacingSpreadsDeltasOverTime(t *testing.T) {
+	f := piai.RegisterFauxProvider(piai.FauxOptions{TokensPerSecond: 200, TokenSizeMin: 2, TokenSizeMax: 2})
+	defer f.Unregister()
+	f.SetResponses(piai.FauxRespond(piai.FauxAssistantText(strings.Repeat("a", 32))))
+
+	start := time.Now()
+	if _, err := piai.Complete(context.Background(), f.Model(), userContext("hi"), nil); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	// 32 chars → 4 chunks of 2 tokens at 200 tok/s → ≥ 40ms total.
+	if elapsed := time.Since(start); elapsed < 30*time.Millisecond {
+		t.Fatalf("elapsed = %v, expected pacing delay", elapsed)
+	}
+}

--- a/internal/piai/faux_test.go
+++ b/internal/piai/faux_test.go
@@ -1,6 +1,5 @@
-// Port of pi-ai's faux-provider.test.ts plus the total-tokens invariant from
-// total-tokens.test.ts: totalTokens must equal input+output+cacheRead+cacheWrite
-// on every response — it is the base for context-size accounting.
+// Port of pi-ai's faux-provider.test.ts plus total-tokens.test.ts's invariant:
+// totalTokens == input+output+cacheRead+cacheWrite on every response.
 package piai_test
 
 import (
@@ -533,7 +532,6 @@ func TestFauxAbortBeforeFirstChunk(t *testing.T) {
 		t.Fatalf("terminal = %+v", events[0].Message)
 	}
 
-	// Cancellation is classified: the error channel says aborted, not error.
 	_, err := stream.Result()
 	var streamErr *piai.StreamError
 	if !errors.As(err, &streamErr) || streamErr.Reason != piai.StopReasonAborted {

--- a/internal/piai/registry.go
+++ b/internal/piai/registry.go
@@ -7,10 +7,8 @@ import (
 	"time"
 )
 
-// StreamFunction is the provider contract. Once invoked, request/model/
-// runtime failures are encoded in the returned stream as a terminal error
-// event — never returned as a Go error or panic. Cancellation comes from ctx
-// and terminates the stream with stopReason "aborted".
+// StreamFunction is the provider contract: all failures surface as a terminal error
+// event on the stream (never a Go error or panic); ctx cancel ends with stopReason "aborted".
 type StreamFunction func(ctx context.Context, model Model, c Context, opts *StreamOptions) *EventStream
 
 type registeredProvider struct {
@@ -23,8 +21,7 @@ var (
 	registry   = map[string]registeredProvider{}
 )
 
-// RegisterProvider registers a StreamFunction for an API shape. sourceID
-// groups registrations for UnregisterProviders (test cleanup).
+// RegisterProvider registers a StreamFunction for an API shape; sourceID groups registrations for UnregisterProviders.
 func RegisterProvider(api string, stream StreamFunction, sourceID string) {
 	registryMu.Lock()
 	defer registryMu.Unlock()
@@ -42,9 +39,8 @@ func UnregisterProviders(sourceID string) {
 	}
 }
 
-// Stream starts a completion against model.API's registered provider. A
-// missing provider is reported as a terminal error event on the returned
-// stream, keeping one failure path for callers.
+// Stream starts a completion against model.API's registered provider; a missing
+// provider is reported as a terminal error event, keeping one failure path for callers.
 func Stream(ctx context.Context, model Model, c Context, opts *StreamOptions) *EventStream {
 	registryMu.RLock()
 	entry, ok := registry[model.API]

--- a/internal/piai/registry.go
+++ b/internal/piai/registry.go
@@ -1,0 +1,70 @@
+package piai
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// StreamFunction is the provider contract. Once invoked, request/model/
+// runtime failures are encoded in the returned stream as a terminal error
+// event — never returned as a Go error or panic. Cancellation comes from ctx
+// and terminates the stream with stopReason "aborted".
+type StreamFunction func(ctx context.Context, model Model, c Context, opts *StreamOptions) *EventStream
+
+type registeredProvider struct {
+	stream   StreamFunction
+	sourceID string
+}
+
+var (
+	registryMu sync.RWMutex
+	registry   = map[string]registeredProvider{}
+)
+
+// RegisterProvider registers a StreamFunction for an API shape. sourceID
+// groups registrations for UnregisterProviders (test cleanup).
+func RegisterProvider(api string, stream StreamFunction, sourceID string) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	registry[api] = registeredProvider{stream: stream, sourceID: sourceID}
+}
+
+// UnregisterProviders removes all providers registered under sourceID.
+func UnregisterProviders(sourceID string) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	for api, entry := range registry {
+		if entry.sourceID == sourceID {
+			delete(registry, api)
+		}
+	}
+}
+
+// Stream starts a completion against model.API's registered provider. A
+// missing provider is reported as a terminal error event on the returned
+// stream, keeping one failure path for callers.
+func Stream(ctx context.Context, model Model, c Context, opts *StreamOptions) *EventStream {
+	registryMu.RLock()
+	entry, ok := registry[model.API]
+	registryMu.RUnlock()
+	if !ok {
+		s := NewEventStream()
+		s.endWithError(AssistantMessage{
+			API:          model.API,
+			Provider:     model.Provider,
+			Model:        model.ID,
+			StopReason:   StopReasonError,
+			ErrorMessage: fmt.Sprintf("no API provider registered for api: %s", model.API),
+			Timestamp:    time.Now(),
+		})
+		return s
+	}
+	return entry.stream(ctx, model, c, opts)
+}
+
+// Complete runs Stream to completion and returns the final message.
+func Complete(ctx context.Context, model Model, c Context, opts *StreamOptions) (AssistantMessage, error) {
+	return Stream(ctx, model, c, opts).Result()
+}

--- a/internal/piai/stream.go
+++ b/internal/piai/stream.go
@@ -99,13 +99,23 @@ func (s *EventStream) Events() iter.Seq[AssistantMessageEvent] {
 	}
 }
 
+// StreamError is the typed failure returned by Result when a stream
+// terminates with stopReason "error" or "aborted". Reason lets callers
+// distinguish cancellation from provider failure without string matching.
+type StreamError struct {
+	Reason  StopReason // StopReasonError or StopReasonAborted
+	Message string
+}
+
+func (e *StreamError) Error() string { return fmt.Sprintf("piai: %s: %s", e.Reason, e.Message) }
+
 // Result blocks until the stream completes and returns the final
-// AssistantMessage. The error is non-nil when the stream terminated with
-// stopReason "error" or "aborted"; the message still carries the details.
+// AssistantMessage. The error is a *StreamError when the stream terminated
+// with stopReason "error" or "aborted"; the message still carries the details.
 func (s *EventStream) Result() (AssistantMessage, error) {
 	<-s.done
 	if s.final.StopReason == StopReasonError || s.final.StopReason == StopReasonAborted {
-		return s.final, fmt.Errorf("piai: %s: %s", s.final.StopReason, s.final.ErrorMessage)
+		return s.final, &StreamError{Reason: s.final.StopReason, Message: s.final.ErrorMessage}
 	}
 	return s.final, nil
 }

--- a/internal/piai/stream.go
+++ b/internal/piai/stream.go
@@ -1,0 +1,121 @@
+package piai
+
+import (
+	"fmt"
+	"iter"
+	"sync"
+)
+
+// EventType tags AssistantMessageEvent. Streams emit start first, then
+// per-block start/delta/end triples, and terminate with exactly one done or
+// error event.
+type EventType string
+
+const (
+	EventStart         EventType = "start"
+	EventTextStart     EventType = "text_start"
+	EventTextDelta     EventType = "text_delta"
+	EventTextEnd       EventType = "text_end"
+	EventThinkingStart EventType = "thinking_start"
+	EventThinkingDelta EventType = "thinking_delta"
+	EventThinkingEnd   EventType = "thinking_end"
+	EventToolCallStart EventType = "toolcall_start"
+	EventToolCallDelta EventType = "toolcall_delta"
+	EventToolCallEnd   EventType = "toolcall_end"
+	EventDone          EventType = "done"
+	EventError         EventType = "error"
+)
+
+// AssistantMessageEvent is one streaming event. Which fields are set depends
+// on Type: deltas carry Delta, *_end carries Content or ToolCall, done/error
+// carry Reason and the final Message. Partial is the message assembled so far.
+type AssistantMessageEvent struct {
+	Type         EventType
+	ContentIndex int
+	Delta        string
+	Content      string
+	ToolCall     *ToolCall
+	Partial      *AssistantMessage
+	Reason       StopReason
+	Message      *AssistantMessage // final message on done/error
+}
+
+// EventStream carries AssistantMessageEvents from a provider to a consumer.
+// The queue is unbounded so Push never blocks and Result can be awaited
+// without draining events. A done or error event completes the stream;
+// further pushes are dropped.
+type EventStream struct {
+	mu     sync.Mutex
+	cond   *sync.Cond
+	queue  []AssistantMessageEvent
+	closed bool
+	final  AssistantMessage
+	done   chan struct{}
+}
+
+func NewEventStream() *EventStream {
+	s := &EventStream{done: make(chan struct{})}
+	s.cond = sync.NewCond(&s.mu)
+	return s
+}
+
+// Push appends an event. A done or error event must carry Message and
+// completes the stream.
+func (s *EventStream) Push(ev AssistantMessageEvent) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return
+	}
+	s.queue = append(s.queue, ev)
+	if ev.Type == EventDone || ev.Type == EventError {
+		s.closed = true
+		s.final = *ev.Message
+		close(s.done)
+	}
+	s.cond.Broadcast()
+}
+
+// Events iterates all events in order, ending after the terminal event.
+func (s *EventStream) Events() iter.Seq[AssistantMessageEvent] {
+	return func(yield func(AssistantMessageEvent) bool) {
+		i := 0
+		for {
+			s.mu.Lock()
+			for i >= len(s.queue) && !s.closed {
+				s.cond.Wait()
+			}
+			if i >= len(s.queue) {
+				s.mu.Unlock()
+				return
+			}
+			ev := s.queue[i]
+			i++
+			s.mu.Unlock()
+			if !yield(ev) {
+				return
+			}
+		}
+	}
+}
+
+// Result blocks until the stream completes and returns the final
+// AssistantMessage. The error is non-nil when the stream terminated with
+// stopReason "error" or "aborted"; the message still carries the details.
+func (s *EventStream) Result() (AssistantMessage, error) {
+	<-s.done
+	if s.final.StopReason == StopReasonError || s.final.StopReason == StopReasonAborted {
+		return s.final, fmt.Errorf("piai: %s: %s", s.final.StopReason, s.final.ErrorMessage)
+	}
+	return s.final, nil
+}
+
+// endWithError terminates the stream with an error-shaped AssistantMessage.
+func (s *EventStream) endWithError(msg AssistantMessage) {
+	reason := msg.StopReason
+	if reason != StopReasonAborted {
+		reason = StopReasonError
+		msg.StopReason = StopReasonError
+	}
+	s.Push(AssistantMessageEvent{Type: EventError, Reason: reason, Message: &msg})
+}

--- a/internal/piai/stream.go
+++ b/internal/piai/stream.go
@@ -6,9 +6,8 @@ import (
 	"sync"
 )
 
-// EventType tags AssistantMessageEvent. Streams emit start first, then
-// per-block start/delta/end triples, and terminate with exactly one done or
-// error event.
+// EventType tags AssistantMessageEvent. Streams emit start, then per-block
+// start/delta/end triples, and terminate with exactly one done or error event.
 type EventType string
 
 const (
@@ -26,9 +25,9 @@ const (
 	EventError         EventType = "error"
 )
 
-// AssistantMessageEvent is one streaming event. Which fields are set depends
-// on Type: deltas carry Delta, *_end carries Content or ToolCall, done/error
-// carry Reason and the final Message. Partial is the message assembled so far.
+// AssistantMessageEvent is one streaming event. Fields set depend on Type:
+// deltas carry Delta, *_end carries Content or ToolCall, done/error carry
+// Reason and the final Message. Partial is the message assembled so far.
 type AssistantMessageEvent struct {
 	Type         EventType
 	ContentIndex int
@@ -37,13 +36,12 @@ type AssistantMessageEvent struct {
 	ToolCall     *ToolCall
 	Partial      *AssistantMessage
 	Reason       StopReason
-	Message      *AssistantMessage // final message on done/error
+	Message      *AssistantMessage
 }
 
-// EventStream carries AssistantMessageEvents from a provider to a consumer.
-// The queue is unbounded so Push never blocks and Result can be awaited
-// without draining events. A done or error event completes the stream;
-// further pushes are dropped.
+// EventStream carries AssistantMessageEvents from provider to consumer. The
+// queue is unbounded so Push never blocks and Result can be awaited without
+// draining events; a terminal event completes the stream, later pushes drop.
 type EventStream struct {
 	mu     sync.Mutex
 	cond   *sync.Cond
@@ -59,8 +57,7 @@ func NewEventStream() *EventStream {
 	return s
 }
 
-// Push appends an event. A done or error event must carry Message and
-// completes the stream.
+// Push appends an event; a done or error event must carry Message and completes the stream.
 func (s *EventStream) Push(ev AssistantMessageEvent) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -99,9 +96,8 @@ func (s *EventStream) Events() iter.Seq[AssistantMessageEvent] {
 	}
 }
 
-// StreamError is the typed failure returned by Result when a stream
-// terminates with stopReason "error" or "aborted". Reason lets callers
-// distinguish cancellation from provider failure without string matching.
+// StreamError is Result's typed failure for stopReason "error" or "aborted";
+// Reason distinguishes cancellation from provider failure without string matching.
 type StreamError struct {
 	Reason  StopReason // StopReasonError or StopReasonAborted
 	Message string
@@ -109,9 +105,8 @@ type StreamError struct {
 
 func (e *StreamError) Error() string { return fmt.Sprintf("piai: %s: %s", e.Reason, e.Message) }
 
-// Result blocks until the stream completes and returns the final
-// AssistantMessage. The error is a *StreamError when the stream terminated
-// with stopReason "error" or "aborted"; the message still carries the details.
+// Result blocks until the stream completes and returns the final message.
+// On stopReason "error"/"aborted" it also returns a *StreamError.
 func (s *EventStream) Result() (AssistantMessage, error) {
 	<-s.done
 	if s.final.StopReason == StopReasonError || s.final.StopReason == StopReasonAborted {
@@ -120,7 +115,6 @@ func (s *EventStream) Result() (AssistantMessage, error) {
 	return s.final, nil
 }
 
-// endWithError terminates the stream with an error-shaped AssistantMessage.
 func (s *EventStream) endWithError(msg AssistantMessage) {
 	reason := msg.StopReason
 	if reason != StopReasonAborted {

--- a/internal/piai/stream_test.go
+++ b/internal/piai/stream_test.go
@@ -1,0 +1,108 @@
+package piai_test
+
+import (
+	"testing"
+
+	"github.com/p-n-ai/pai-bot/internal/piai"
+)
+
+func collectEvents(s *piai.EventStream) []piai.AssistantMessageEvent {
+	var events []piai.AssistantMessageEvent
+	for ev := range s.Events() {
+		events = append(events, ev)
+	}
+	return events
+}
+
+func eventTypes(events []piai.AssistantMessageEvent) []piai.EventType {
+	types := make([]piai.EventType, len(events))
+	for i, ev := range events {
+		types[i] = ev.Type
+	}
+	return types
+}
+
+func equalTypes(a []piai.EventType, b ...piai.EventType) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func containsType(events []piai.AssistantMessageEvent, typ piai.EventType) bool {
+	for _, ev := range events {
+		if ev.Type == typ {
+			return true
+		}
+	}
+	return false
+}
+
+func TestEventStreamDeliversEventsInOrder(t *testing.T) {
+	s := piai.NewEventStream()
+	final := piai.FauxAssistantText("hi")
+	s.Push(piai.AssistantMessageEvent{Type: piai.EventStart, Partial: &piai.AssistantMessage{}})
+	s.Push(piai.AssistantMessageEvent{Type: piai.EventTextDelta, Delta: "hi"})
+	s.Push(piai.AssistantMessageEvent{Type: piai.EventDone, Reason: piai.StopReasonStop, Message: &final})
+
+	events := collectEvents(s)
+	if !equalTypes(eventTypes(events), piai.EventStart, piai.EventTextDelta, piai.EventDone) {
+		t.Fatalf("unexpected event order: %v", eventTypes(events))
+	}
+}
+
+func TestEventStreamResultWithoutDraining(t *testing.T) {
+	s := piai.NewEventStream()
+	final := piai.FauxAssistantText("done")
+	go func() {
+		s.Push(piai.AssistantMessageEvent{Type: piai.EventStart, Partial: &piai.AssistantMessage{}})
+		s.Push(piai.AssistantMessageEvent{Type: piai.EventTextDelta, Delta: "done"})
+		s.Push(piai.AssistantMessageEvent{Type: piai.EventDone, Reason: piai.StopReasonStop, Message: &final})
+	}()
+
+	// No consumer drains events; Result must still return.
+	msg, err := s.Result()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msg.StopReason != piai.StopReasonStop {
+		t.Fatalf("stopReason = %q, want stop", msg.StopReason)
+	}
+
+	// A late consumer still sees every event.
+	if got := eventTypes(collectEvents(s)); !equalTypes(got, piai.EventStart, piai.EventTextDelta, piai.EventDone) {
+		t.Fatalf("late consumer events: %v", got)
+	}
+}
+
+func TestEventStreamErrorTerminal(t *testing.T) {
+	s := piai.NewEventStream()
+	errMsg := piai.FauxAssistantText("")
+	errMsg.StopReason = piai.StopReasonError
+	errMsg.ErrorMessage = "upstream failed"
+	s.Push(piai.AssistantMessageEvent{Type: piai.EventError, Reason: piai.StopReasonError, Message: &errMsg})
+
+	msg, err := s.Result()
+	if err == nil {
+		t.Fatal("expected error from Result on error-terminated stream")
+	}
+	if msg.StopReason != piai.StopReasonError || msg.ErrorMessage != "upstream failed" {
+		t.Fatalf("final message = %+v", msg)
+	}
+}
+
+func TestEventStreamIgnoresPushesAfterTerminal(t *testing.T) {
+	s := piai.NewEventStream()
+	final := piai.FauxAssistantText("hi")
+	s.Push(piai.AssistantMessageEvent{Type: piai.EventDone, Reason: piai.StopReasonStop, Message: &final})
+	s.Push(piai.AssistantMessageEvent{Type: piai.EventTextDelta, Delta: "late"})
+
+	if events := collectEvents(s); len(events) != 1 || events[0].Type != piai.EventDone {
+		t.Fatalf("expected single done event, got %v", eventTypes(events))
+	}
+}

--- a/internal/piai/stream_test.go
+++ b/internal/piai/stream_test.go
@@ -1,6 +1,7 @@
 package piai_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/p-n-ai/pai-bot/internal/piai"
@@ -88,8 +89,12 @@ func TestEventStreamErrorTerminal(t *testing.T) {
 	s.Push(piai.AssistantMessageEvent{Type: piai.EventError, Reason: piai.StopReasonError, Message: &errMsg})
 
 	msg, err := s.Result()
-	if err == nil {
-		t.Fatal("expected error from Result on error-terminated stream")
+	var streamErr *piai.StreamError
+	if !errors.As(err, &streamErr) {
+		t.Fatalf("expected *StreamError from Result, got %v", err)
+	}
+	if streamErr.Reason != piai.StopReasonError || streamErr.Message != "upstream failed" {
+		t.Fatalf("stream error = %+v", streamErr)
 	}
 	if msg.StopReason != piai.StopReasonError || msg.ErrorMessage != "upstream failed" {
 		t.Fatalf("final message = %+v", msg)

--- a/internal/piai/types.go
+++ b/internal/piai/types.go
@@ -1,9 +1,6 @@
-// Package piai is a Go port of pi-ai (@earendil-works/pi-ai): a unified
-// multi-provider LLM API. Providers absorb vendor quirks and expose one
-// contract: Stream(model, context) → event stream → AssistantMessage.
-//
-// This package has no callers yet; adapters and the cut-over from
-// internal/ai land in follow-up PRs. See NOTICE for attribution.
+// Package piai is a Go port of pi-ai (@earendil-works/pi-ai), a unified
+// multi-provider LLM API: Stream(model, context) → event stream →
+// AssistantMessage. See NOTICE for attribution.
 package piai
 
 import (
@@ -44,9 +41,6 @@ type Usage struct {
 	Cost        Cost `json:"cost"`
 }
 
-// Content blocks. User messages carry text/image; assistant messages carry
-// text/thinking/tool-call. The marker interfaces encode those unions.
-
 type TextContent struct {
 	Text string `json:"text"`
 }
@@ -58,8 +52,7 @@ type ImageContent struct {
 
 type ThinkingContent struct {
 	Thinking string `json:"thinking"`
-	// Signature is an opaque provider payload (e.g. reasoning item ID or
-	// encrypted redacted thinking) replayed for multi-turn continuity.
+	// Signature: opaque provider payload replayed for multi-turn continuity.
 	Signature string `json:"thinkingSignature,omitempty"`
 	Redacted  bool   `json:"redacted,omitempty"`
 }

--- a/internal/piai/types.go
+++ b/internal/piai/types.go
@@ -1,0 +1,169 @@
+// Package piai is a Go port of pi-ai (@earendil-works/pi-ai): a unified
+// multi-provider LLM API. Providers absorb vendor quirks and expose one
+// contract: Stream(model, context) → event stream → AssistantMessage.
+//
+// This package has no callers yet; adapters and the cut-over from
+// internal/ai land in follow-up PRs. See NOTICE for attribution.
+package piai
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// StopReason mirrors pi-ai's stop reasons. "error" and "aborted" terminate a
+// stream via an error event; the others via a done event.
+type StopReason string
+
+const (
+	StopReasonStop    StopReason = "stop"
+	StopReasonLength  StopReason = "length"
+	StopReasonToolUse StopReason = "toolUse"
+	StopReasonError   StopReason = "error"
+	StopReasonAborted StopReason = "aborted"
+)
+
+// Cost is USD cost per usage component.
+type Cost struct {
+	Input      float64 `json:"input"`
+	Output     float64 `json:"output"`
+	CacheRead  float64 `json:"cacheRead"`
+	CacheWrite float64 `json:"cacheWrite"`
+	Total      float64 `json:"total"`
+}
+
+// Usage is token usage for one assistant response. TotalTokens is the total
+// processed by the LLM — input (with cache) plus output — and must equal
+// Input + Output + CacheRead + CacheWrite.
+type Usage struct {
+	Input       int  `json:"input"`
+	Output      int  `json:"output"`
+	CacheRead   int  `json:"cacheRead"`
+	CacheWrite  int  `json:"cacheWrite"`
+	TotalTokens int  `json:"totalTokens"`
+	Cost        Cost `json:"cost"`
+}
+
+// Content blocks. User messages carry text/image; assistant messages carry
+// text/thinking/tool-call. The marker interfaces encode those unions.
+
+type TextContent struct {
+	Text string `json:"text"`
+}
+
+type ImageContent struct {
+	Data     string `json:"data"` // base64
+	MimeType string `json:"mimeType"`
+}
+
+type ThinkingContent struct {
+	Thinking string `json:"thinking"`
+	// Signature is an opaque provider payload (e.g. reasoning item ID or
+	// encrypted redacted thinking) replayed for multi-turn continuity.
+	Signature string `json:"thinkingSignature,omitempty"`
+	Redacted  bool   `json:"redacted,omitempty"`
+}
+
+type ToolCall struct {
+	ID        string         `json:"id"`
+	Name      string         `json:"name"`
+	Arguments map[string]any `json:"arguments"`
+}
+
+// UserContent is TextContent or ImageContent.
+type UserContent interface{ isUserContent() }
+
+// AssistantContent is TextContent, ThinkingContent, or ToolCall.
+type AssistantContent interface{ isAssistantContent() }
+
+func (TextContent) isUserContent()          {}
+func (ImageContent) isUserContent()         {}
+func (TextContent) isAssistantContent()     {}
+func (ThinkingContent) isAssistantContent() {}
+func (ToolCall) isAssistantContent()        {}
+
+// Message is UserMessage, AssistantMessage, or ToolResultMessage.
+type Message interface{ isMessage() }
+
+type UserMessage struct {
+	Content   []UserContent
+	Timestamp time.Time
+}
+
+type AssistantMessage struct {
+	Content      []AssistantContent
+	API          string
+	Provider     string
+	Model        string
+	ResponseID   string
+	Usage        Usage
+	StopReason   StopReason
+	ErrorMessage string
+	Timestamp    time.Time
+}
+
+type ToolResultMessage struct {
+	ToolCallID string
+	ToolName   string
+	Content    []UserContent
+	IsError    bool
+	Timestamp  time.Time
+}
+
+func (UserMessage) isMessage()       {}
+func (AssistantMessage) isMessage()  {}
+func (ToolResultMessage) isMessage() {}
+
+// UserText builds a plain-text user message.
+func UserText(text string) UserMessage {
+	return UserMessage{Content: []UserContent{TextContent{Text: text}}, Timestamp: time.Now()}
+}
+
+// Tool describes a callable tool. Parameters is a JSON Schema document.
+type Tool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Parameters  json.RawMessage `json:"parameters"`
+}
+
+// Context is the full request context for one completion.
+type Context struct {
+	SystemPrompt string
+	Messages     []Message
+	Tools        []Tool
+}
+
+// CacheRetention is the prompt-cache retention preference. Zero value means
+// the provider default ("short"); "none" disables caching.
+type CacheRetention string
+
+const (
+	CacheRetentionNone  CacheRetention = "none"
+	CacheRetentionShort CacheRetention = "short"
+	CacheRetentionLong  CacheRetention = "long"
+)
+
+// StreamOptions are per-request options shared by all providers. Cancellation
+// rides the context.Context passed to StreamFunction, not an option. Fields
+// grow as adapters need them.
+type StreamOptions struct {
+	Temperature    *float64
+	MaxTokens      int
+	APIKey         string
+	SessionID      string
+	CacheRetention CacheRetention
+	Headers        map[string]string
+}
+
+// Model identifies a concrete model behind an API shape.
+type Model struct {
+	ID            string
+	Name          string
+	API           string // API wire shape, e.g. "openai-completions"
+	Provider      string // provider slug, e.g. "openai"
+	BaseURL       string
+	Reasoning     bool
+	Cost          Cost // $/million tokens per component
+	ContextWindow int
+	MaxTokens     int
+}


### PR DESCRIPTION
## What problems was I solving

pai-bot's AI layer is a bespoke gateway (`internal/ai`: Task enum, `CompleteJSON` parallel path, cross-provider fallback + dual circuit breakers) that we've decided to replace by collapsing hard onto the shape of [pi-ai](https://github.com/earendil-works/pi): one contract — `Stream(model, context) → event stream → AssistantMessage` — with providers absorbing vendor quirks and streaming as the load-bearing protocol.

This is **PR1 of the staged delivery plan**: land the ported core as **dead code** (zero callers), so merging and deploying is a guaranteed no-op and trunk stays deployable on every merge. Success = the package exists with pi-ai's own test suites passing in Go, unblocking PR2 (openai-completions adapter) immediately.

## What user-facing changes did I ship

None — deliberately. No production code imports `internal/piai`. All seven files are new:

- [internal/piai/types.go](https://github.com/p-n-ai/pai-bot/pull/161/files#diff-8dfebd93e589534fc4cd105cd352f3385450b2c5a32ce739b04fe00c5f2295ba) — value types: `Model`, `Context`, message union, sealed content unions, `Tool`, `Usage`, `StopReason`, `StreamOptions`
- [internal/piai/stream.go](https://github.com/p-n-ai/pai-bot/pull/161/files#diff-e779ec7a3f83c4460b08c4e153e566e2b0ebf0da788451432839e0c4f04a5e4e) — `AssistantMessageEvent` protocol + `EventStream` + typed `StreamError`
- [internal/piai/registry.go](https://github.com/p-n-ai/pai-bot/pull/161/files#diff-559e862570bbdd7c2f070713d252564904523d9cd49feb1ff5f1fd58cade5260) — provider registry keyed by API shape; `Stream`/`Complete` entry points
- [internal/piai/faux.go](https://github.com/p-n-ai/pai-bot/pull/161/files#diff-559fef42658307af2a9d0ffb5f5989bd78453aff4d967cc4bb67315884a0adf0) — faux test provider (the `internal/ai/mock.go` analog for the piai era)
- [internal/piai/faux_test.go](https://github.com/p-n-ai/pai-bot/pull/161/files#diff-927697195b36a4582796f41b1374280e611bc55a0ee14bb52fbd1401c26e659e) — port of pi's `faux-provider.test.ts` + the `totalTokens` invariant (20 tests)
- [internal/piai/stream_test.go](https://github.com/p-n-ai/pai-bot/pull/161/files#diff-8a9a88547a35f56047f0f07916ad3796895b281cbb14b5fba099148815e364b0) — `EventStream` unit tests (4 tests)
- [internal/piai/NOTICE](https://github.com/p-n-ai/pai-bot/pull/161/files#diff-20a5868e24091bb816329d39b7a516011ddd71759781492f5a77ec98fa65deb3) — MIT attribution (pi-ai, © 2025 Mario Zechner)

## How I implemented it

Architectural port using Go idioms, not a literal TS transcription — pi semantics preserved exactly where they're load-bearing:

### The contract ([types.go](https://github.com/p-n-ai/pai-bot/pull/161/files#diff-8dfebd93e589534fc4cd105cd352f3385450b2c5a32ce739b04fe00c5f2295ba))
- Content unions are **sealed** via unexported marker methods (`isUserContent`/`isAssistantContent`) — external packages cannot construct illegal block/role combinations (e.g. thinking content inside a user message).
- `Usage.TotalTokens` carries pi's invariant (`== Input+Output+CacheRead+CacheWrite`), asserted on every response in tests.

### The protocol ([stream.go](https://github.com/p-n-ai/pai-bot/pull/161/files#diff-e779ec7a3f83c4460b08c4e153e566e2b0ebf0da788451432839e0c4f04a5e4e))
- `EventStream` uses an **unbounded queue** (mutex + cond, no goroutines): `Push` never blocks and `Result()` can be awaited without draining events — the same guarantee pi's promise-backed stream gives, and what makes `Complete()` a one-liner.
- Failures are **terminal error events**, never Go errors/panics from providers; `Result()` fails with a typed `*StreamError{Reason, Message}` so callers branch on `aborted` vs `error` without string matching.
- Cancellation rides `context.Context` (repo convention: ctx-first), replacing pi's `AbortSignal` option, and is classified as `aborted` before wrapping.

### The seam ([registry.go](https://github.com/p-n-ai/pai-bot/pull/161/files#diff-559e862570bbdd7c2f070713d252564904523d9cd49feb1ff5f1fd58cade5260))
- `StreamFunction` is the entire provider contract. PR2's adapter registers here; resilience middleware (retry/fallback), if wanted later, composes as an edge `StreamFunction` — a fresh design decision, not a carry-forward of the old Router's breakers.
- A missing provider is reported as a terminal error event — one failure path for callers.

### The spec ([faux.go](https://github.com/p-n-ai/pai-bot/pull/161/files#diff-559fef42658307af2a9d0ffb5f5989bd78453aff4d967cc4bb67315884a0adf0) + tests)
- Faux replays queued responses/factories through the **real streaming protocol** (usage estimation at ~4 chars/token, per-session prompt-cache simulation via longest common prefix, pacing, ctx aborts), so anything tested against faux exercises the exact contract live adapters obey.
- Tests are an external package (`piai_test`) — everything through the exported API, no test-only backdoors.

## Deviations from the plan

Plan: `06-pr-delivery-plan.md`, PR1 row.

### Implemented as planned
- Value types, content-block and event unions, `EventStream` with `Result()`, registry skeleton, faux provider, MIT NOTICE.
- Test-first: `total-tokens.test.ts` invariant and `faux-provider.test.ts` event-ordering/queue/cache/abort suites ported as Go table tests.
- Streaming-first confirmed: the event protocol is the core contract even though today's `internal/ai` is pseudo-streaming.

### Deviations/surprises
- **`AbortSignal` → `context.Context`** (ctx-first per repo convention) instead of a signal option; abort semantics identical.
- **One tagged event struct** (`AssistantMessageEvent{Type, ...}`) instead of a 12-member union — Go-idiomatic for channels/iterators; field validity per `Type` is documented.
- **`Tool.Parameters` is `json.RawMessage`**, not the planned `invopop/jsonschema` TypeBox analog — validation (`ValidateToolArguments`) is deferred to the PR that introduces a real tool-calling caller; no new dependency in dead code.
- No separate `end()`: terminal `done`/`error` events complete the stream (smaller API, same protocol).

### Additions not in plan
- Typed `*StreamError` on `Result()` (coding-standards pass: cancellation vs failure classifiable through the error channel).
- Loud defect `panic` on unknown assistant content blocks (sealed union — silent skip would hide future variants).

### Items planned but not implemented (by design — later PRs)
- openai-completions adapter (PR2), live parity tests (PR3), flag-gated shim (PR4), cut-overs + old-provider deletions (PR5+).

## How to verify it

### Manual Testing
- [ ] Confirm dead code: `rg -l "internal/piai" --glob '!internal/piai/**'` → no hits outside the package itself.
- [ ] Confirm no-op deploy surface: `go build ./...` green, no wiring changes in `cmd/` or `internal/server`.

### Automated Tests
```bash
git fetch origin thor/piai-core && git checkout thor/piai-core
go vet ./internal/piai/
go test ./internal/piai/ -count=1 -race   # 24 tests
just lint                                  # golangci-lint, 0 issues
```

## Description for the changelog

Add `internal/piai`: pi-ai core port (types, streaming event protocol, provider registry, faux test provider) as dead code — PR1 of the staged AI-layer migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
