### PR TITLE
feat(piai): openai-completions adapter (PR2)

### DIFF
--- a/internal/piai/faux.go
+++ b/internal/piai/faux.go
@@ -11,9 +11,6 @@ import (
 	"time"
 )
 
-// Faux provider — in-package test double, port of pi-ai's faux provider. Replays
-// queued responses through the real streaming protocol with simulated usage/caching.
-
 const (
 	fauxDefaultProvider     = "faux"
 	fauxDefaultModelID      = "faux-1"
@@ -25,11 +22,8 @@ const (
 
 var fauxCounter atomic.Int64
 
-// FauxStep produces one queued response. callCount is 1-based across the
-// registration. A returned error terminates the stream as an error event.
 type FauxStep func(c Context, opts *StreamOptions, callCount int, model Model) (AssistantMessage, error)
 
-// FauxRespond queues a fixed message.
 func FauxRespond(msg AssistantMessage) FauxStep {
 	return func(Context, *StreamOptions, int, Model) (AssistantMessage, error) { return msg, nil }
 }
@@ -46,8 +40,6 @@ func FauxToolCall(name string, arguments map[string]any) ToolCall {
 	}
 }
 
-// FauxAssistantMessage builds an assistant message with stopReason "stop";
-// callers mutate StopReason/ErrorMessage for error shapes.
 func FauxAssistantMessage(blocks ...AssistantContent) AssistantMessage {
 	return AssistantMessage{
 		Content:    blocks,
@@ -59,30 +51,25 @@ func FauxAssistantMessage(blocks ...AssistantContent) AssistantMessage {
 	}
 }
 
-// FauxAssistantText builds a single-text-block assistant message.
 func FauxAssistantText(text string) AssistantMessage {
 	return FauxAssistantMessage(FauxText(text))
 }
 
-// FauxModel customizes one model exposed by a faux registration.
 type FauxModel struct {
 	ID        string
 	Name      string
 	Reasoning bool
 }
 
-// FauxOptions configures RegisterFauxProvider. Zero value works: unique API,
-// one default model, random 3–5-token chunks, no pacing.
 type FauxOptions struct {
 	API             string
 	Provider        string
 	Models          []FauxModel
-	TokensPerSecond float64 // 0 = emit chunks without delay
+	TokensPerSecond float64
 	TokenSizeMin    int
 	TokenSizeMax    int
 }
 
-// FauxProvider is a registered faux provider with a mutable response queue.
 type FauxProvider struct {
 	API      string
 	Models   []Model
@@ -95,11 +82,9 @@ type FauxProvider struct {
 	mu          sync.Mutex
 	pending     []FauxStep
 	callCount   int
-	promptCache map[string]string // sessionID → last serialized prompt
+	promptCache map[string]string
 }
 
-// RegisterFauxProvider registers a faux provider in the global registry and
-// returns its handle. Call Unregister in test cleanup.
 func RegisterFauxProvider(opts FauxOptions) *FauxProvider {
 	n := fauxCounter.Add(1)
 	api := opts.API
@@ -151,10 +136,8 @@ func RegisterFauxProvider(opts FauxOptions) *FauxProvider {
 	return f
 }
 
-// Model returns the first registered model.
 func (f *FauxProvider) Model() Model { return f.Models[0] }
 
-// ModelByID returns the model with the given ID, or false.
 func (f *FauxProvider) ModelByID(id string) (Model, bool) {
 	for _, m := range f.Models {
 		if m.ID == id {
@@ -235,7 +218,6 @@ func (f *FauxProvider) errorMessage(model Model, errText string) AssistantMessag
 	}
 }
 
-// streamWithDeltas replays the message through the event protocol, honoring pacing and ctx cancellation between chunks.
 func (f *FauxProvider) streamWithDeltas(ctx context.Context, s *EventStream, msg AssistantMessage) {
 	partial := msg
 	partial.Content = nil
@@ -310,7 +292,7 @@ func (f *FauxProvider) streamWithDeltas(ctx context.Context, s *EventStream, msg
 			toolCall := b
 			push(EventToolCallEnd, func(ev *AssistantMessageEvent) { ev.ContentIndex = i; ev.ToolCall = &toolCall })
 		default:
-			// AssistantContent is sealed; a new variant must be handled here.
+
 			panic(fmt.Sprintf("piai: unhandled assistant content block %T", block))
 		}
 	}
@@ -345,8 +327,6 @@ func (f *FauxProvider) splitByTokenSize(text string) []string {
 	return chunks
 }
 
-// withUsageEstimate estimates usage (~4 chars/token) and simulates per-session prompt
-// caching via longest common prefix; totalTokens = input+output+cacheRead+cacheWrite.
 func (f *FauxProvider) withUsageEstimate(msg AssistantMessage, c Context, opts *StreamOptions) AssistantMessage {
 	promptText := serializeContext(c)
 	promptTokens := estimateTokens(promptText)

--- a/internal/piai/faux_test.go
+++ b/internal/piai/faux_test.go
@@ -1,5 +1,3 @@
-// Port of pi-ai's faux-provider.test.ts plus total-tokens.test.ts's invariant:
-// totalTokens == input+output+cacheRead+cacheWrite on every response.
 package piai_test
 
 import (
@@ -591,7 +589,7 @@ func TestFauxPacingSpreadsDeltasOverTime(t *testing.T) {
 	if _, err := piai.Complete(context.Background(), f.Model(), userContext("hi"), nil); err != nil {
 		t.Fatalf("Complete: %v", err)
 	}
-	// 32 chars → 4 chunks of 2 tokens at 200 tok/s → ≥ 40ms total.
+
 	if elapsed := time.Since(start); elapsed < 30*time.Millisecond {
 		t.Fatalf("elapsed = %v, expected pacing delay", elapsed)
 	}

--- a/internal/piai/openai.go
+++ b/internal/piai/openai.go
@@ -1,0 +1,475 @@
+package piai
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const APIOpenAICompletions = "openai-completions"
+
+func RegisterOpenAICompletions() {
+	RegisterProvider(APIOpenAICompletions, StreamOpenAICompletions, "builtin:openai-completions")
+}
+
+var openAIHTTPClient = &http.Client{}
+
+func StreamOpenAICompletions(ctx context.Context, model Model, c Context, opts *StreamOptions) *EventStream {
+	s := NewEventStream()
+	go func() {
+		out := AssistantMessage{
+			API:        model.API,
+			Provider:   model.Provider,
+			Model:      model.ID,
+			StopReason: StopReasonStop,
+			Timestamp:  time.Now(),
+		}
+		fail := func(err error) {
+			out.StopReason = StopReasonError
+			if ctx.Err() != nil {
+				out.StopReason = StopReasonAborted
+			}
+			out.ErrorMessage = err.Error()
+			out.Timestamp = time.Now()
+			s.Push(AssistantMessageEvent{Type: EventError, Reason: out.StopReason, Message: &out})
+		}
+
+		if opts == nil || opts.APIKey == "" {
+			fail(fmt.Errorf("no API key for provider: %s", model.Provider))
+			return
+		}
+		body, err := buildOpenAIRequest(model, c, opts)
+		if err != nil {
+			fail(err)
+			return
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, openAIEndpoint(model.BaseURL), bytes.NewReader(body))
+		if err != nil {
+			fail(err)
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+opts.APIKey)
+		req.Header.Set("Accept", "text/event-stream")
+		for k, v := range opts.Headers {
+			req.Header.Set(k, v)
+		}
+
+		resp, err := openAIHTTPClient.Do(req)
+		if err != nil {
+			fail(err)
+			return
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+			fail(fmt.Errorf("openai-completions: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(msg))))
+			return
+		}
+
+		if err := consumeOpenAIStream(ctx, s, &out, model, resp.Body); err != nil {
+			fail(err)
+		}
+	}()
+	return s
+}
+
+func openAIEndpoint(baseURL string) string {
+	return strings.TrimRight(baseURL, "/") + "/chat/completions"
+}
+
+type oaMessage struct {
+	Role       string       `json:"role"`
+	Content    any          `json:"content,omitempty"`
+	ToolCalls  []oaToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string       `json:"tool_call_id,omitempty"`
+}
+
+type oaToolCall struct {
+	ID       string     `json:"id"`
+	Type     string     `json:"type"`
+	Function oaFunction `json:"function"`
+}
+
+type oaFunction struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+type oaTextPart struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type oaImagePart struct {
+	Type     string `json:"type"`
+	ImageURL struct {
+		URL string `json:"url"`
+	} `json:"image_url"`
+}
+
+type oaTool struct {
+	Type     string `json:"type"`
+	Function struct {
+		Name        string          `json:"name"`
+		Description string          `json:"description"`
+		Parameters  json.RawMessage `json:"parameters"`
+	} `json:"function"`
+}
+
+func buildOpenAIRequest(model Model, c Context, opts *StreamOptions) ([]byte, error) {
+	params := map[string]any{
+		"model":          model.ID,
+		"messages":       convertOpenAIMessages(model, c),
+		"stream":         true,
+		"stream_options": map[string]any{"include_usage": true},
+	}
+	if strings.Contains(model.BaseURL, "api.openai.com") {
+		params["store"] = false
+	}
+	if opts.Temperature != nil {
+		params["temperature"] = *opts.Temperature
+	}
+	if opts.MaxTokens > 0 {
+		params["max_completion_tokens"] = opts.MaxTokens
+	}
+	if len(c.Tools) > 0 {
+		params["tools"] = convertOpenAITools(c.Tools)
+	} else if hasToolHistory(c.Messages) {
+
+		params["tools"] = []oaTool{}
+	}
+	return json.Marshal(params)
+}
+
+func hasToolHistory(messages []Message) bool {
+	for _, m := range messages {
+		switch msg := m.(type) {
+		case ToolResultMessage:
+			return true
+		case AssistantMessage:
+			for _, b := range msg.Content {
+				if _, ok := b.(ToolCall); ok {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func convertOpenAITools(tools []Tool) []oaTool {
+	out := make([]oaTool, len(tools))
+	for i, t := range tools {
+		out[i].Type = "function"
+		out[i].Function.Name = t.Name
+		out[i].Function.Description = t.Description
+		out[i].Function.Parameters = t.Parameters
+	}
+	return out
+}
+
+func convertOpenAIMessages(model Model, c Context) []oaMessage {
+	var params []oaMessage
+	if c.SystemPrompt != "" {
+		role := "system"
+		if model.Reasoning {
+			role = "developer"
+		}
+		params = append(params, oaMessage{Role: role, Content: c.SystemPrompt})
+	}
+	for _, m := range c.Messages {
+		switch msg := m.(type) {
+		case UserMessage:
+			params = append(params, convertOpenAIUserMessage(msg)...)
+		case AssistantMessage:
+			var texts []string
+			var toolCalls []oaToolCall
+			for _, b := range msg.Content {
+				switch block := b.(type) {
+				case TextContent:
+					if strings.TrimSpace(block.Text) != "" {
+						texts = append(texts, block.Text)
+					}
+				case ToolCall:
+					args, _ := json.Marshal(block.Arguments)
+					toolCalls = append(toolCalls, oaToolCall{
+						ID: block.ID, Type: "function",
+						Function: oaFunction{Name: block.Name, Arguments: string(args)},
+					})
+				case ThinkingContent:
+
+				}
+			}
+			am := oaMessage{Role: "assistant", ToolCalls: toolCalls}
+			if text := strings.Join(texts, ""); text != "" {
+				am.Content = text
+			}
+
+			if am.Content == nil && len(am.ToolCalls) == 0 {
+				continue
+			}
+			params = append(params, am)
+		case ToolResultMessage:
+			var texts []string
+			for _, b := range msg.Content {
+				if t, ok := b.(TextContent); ok {
+					texts = append(texts, t.Text)
+				}
+			}
+			content := strings.Join(texts, "\n")
+			if content == "" {
+				content = "(no text result)"
+			}
+			params = append(params, oaMessage{Role: "tool", Content: content, ToolCallID: msg.ToolCallID})
+		}
+	}
+	return params
+}
+
+func convertOpenAIUserMessage(msg UserMessage) []oaMessage {
+	onlyText := true
+	for _, b := range msg.Content {
+		if _, ok := b.(TextContent); !ok {
+			onlyText = false
+			break
+		}
+	}
+	if onlyText {
+		var texts []string
+		for _, b := range msg.Content {
+			texts = append(texts, b.(TextContent).Text)
+		}
+		return []oaMessage{{Role: "user", Content: strings.Join(texts, "\n")}}
+	}
+	var parts []any
+	for _, b := range msg.Content {
+		switch block := b.(type) {
+		case TextContent:
+			parts = append(parts, oaTextPart{Type: "text", Text: block.Text})
+		case ImageContent:
+			p := oaImagePart{Type: "image_url"}
+			p.ImageURL.URL = "data:" + block.MimeType + ";base64," + block.Data
+			parts = append(parts, p)
+		}
+	}
+	if len(parts) == 0 {
+		return nil
+	}
+	return []oaMessage{{Role: "user", Content: parts}}
+}
+
+type oaChunk struct {
+	ID      string     `json:"id"`
+	Model   string     `json:"model"`
+	Usage   *oaUsage   `json:"usage"`
+	Choices []oaChoice `json:"choices"`
+}
+
+type oaUsage struct {
+	PromptTokens        int `json:"prompt_tokens"`
+	CompletionTokens    int `json:"completion_tokens"`
+	PromptTokensDetails *struct {
+		CachedTokens     int `json:"cached_tokens"`
+		CacheWriteTokens int `json:"cache_write_tokens"`
+	} `json:"prompt_tokens_details"`
+}
+
+type oaChoice struct {
+	FinishReason string `json:"finish_reason"`
+	Delta        struct {
+		Content   string `json:"content"`
+		ToolCalls []struct {
+			Index    *int   `json:"index"`
+			ID       string `json:"id"`
+			Function struct {
+				Name      string `json:"name"`
+				Arguments string `json:"arguments"`
+			} `json:"function"`
+		} `json:"tool_calls"`
+	} `json:"delta"`
+}
+
+type streamingToolCall struct {
+	contentIndex int
+	partialArgs  strings.Builder
+}
+
+func consumeOpenAIStream(ctx context.Context, s *EventStream, out *AssistantMessage, model Model, body io.Reader) error {
+	s.Push(AssistantMessageEvent{Type: EventStart, Partial: snapshot(out)})
+
+	textIndex := -1
+	toolByStreamIndex := map[int]*streamingToolCall{}
+	var toolOrder []*streamingToolCall
+	var currentTool *streamingToolCall
+	hasFinish := false
+
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		line := scanner.Text()
+		data, ok := strings.CutPrefix(line, "data:")
+		if !ok {
+			continue
+		}
+		data = strings.TrimSpace(data)
+		if data == "" || data == "[DONE]" {
+			continue
+		}
+		var chunk oaChunk
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			return fmt.Errorf("openai-completions: bad SSE chunk: %w", err)
+		}
+
+		if out.ResponseID == "" {
+			out.ResponseID = chunk.ID
+		}
+		if chunk.Usage != nil {
+			out.Usage = parseOpenAIUsage(*chunk.Usage, model)
+		}
+		if len(chunk.Choices) == 0 {
+			continue
+		}
+		choice := chunk.Choices[0]
+
+		if choice.FinishReason != "" {
+			reason, errMsg := mapOpenAIStopReason(choice.FinishReason)
+			out.StopReason = reason
+			out.ErrorMessage = errMsg
+			hasFinish = true
+		}
+
+		if choice.Delta.Content != "" {
+			if textIndex == -1 {
+				out.Content = append(out.Content, TextContent{})
+				textIndex = len(out.Content) - 1
+				s.Push(AssistantMessageEvent{Type: EventTextStart, ContentIndex: textIndex, Partial: snapshot(out)})
+			}
+			block := out.Content[textIndex].(TextContent)
+			block.Text += choice.Delta.Content
+			out.Content[textIndex] = block
+			s.Push(AssistantMessageEvent{Type: EventTextDelta, ContentIndex: textIndex, Delta: choice.Delta.Content, Partial: snapshot(out)})
+		}
+
+		for _, tc := range choice.Delta.ToolCalls {
+			tool := currentTool
+			if tc.Index != nil {
+				if existing, ok := toolByStreamIndex[*tc.Index]; ok {
+					tool = existing
+				} else {
+					tool = nil
+				}
+			} else if tc.ID != "" {
+				tool = nil
+			}
+			if tool == nil {
+				out.Content = append(out.Content, ToolCall{ID: tc.ID, Name: tc.Function.Name, Arguments: map[string]any{}})
+				tool = &streamingToolCall{contentIndex: len(out.Content) - 1}
+				if tc.Index != nil {
+					toolByStreamIndex[*tc.Index] = tool
+				}
+				toolOrder = append(toolOrder, tool)
+				s.Push(AssistantMessageEvent{Type: EventToolCallStart, ContentIndex: tool.contentIndex, Partial: snapshot(out)})
+			}
+			currentTool = tool
+			block := out.Content[tool.contentIndex].(ToolCall)
+			if block.ID == "" && tc.ID != "" {
+				block.ID = tc.ID
+			}
+			if block.Name == "" && tc.Function.Name != "" {
+				block.Name = tc.Function.Name
+			}
+			out.Content[tool.contentIndex] = block
+			if tc.Function.Arguments != "" {
+				tool.partialArgs.WriteString(tc.Function.Arguments)
+			}
+			s.Push(AssistantMessageEvent{Type: EventToolCallDelta, ContentIndex: tool.contentIndex, Delta: tc.Function.Arguments, Partial: snapshot(out)})
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		return fmt.Errorf("openai-completions: reading stream: %w", err)
+	}
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	if textIndex != -1 {
+		text := out.Content[textIndex].(TextContent).Text
+		s.Push(AssistantMessageEvent{Type: EventTextEnd, ContentIndex: textIndex, Content: text, Partial: snapshot(out)})
+	}
+	for _, tool := range toolOrder {
+		block := out.Content[tool.contentIndex].(ToolCall)
+		var args map[string]any
+		if err := json.Unmarshal([]byte(tool.partialArgs.String()), &args); err == nil {
+			block.Arguments = args
+		}
+		out.Content[tool.contentIndex] = block
+		s.Push(AssistantMessageEvent{Type: EventToolCallEnd, ContentIndex: tool.contentIndex, ToolCall: &block, Partial: snapshot(out)})
+	}
+
+	if out.StopReason == StopReasonError {
+		return fmt.Errorf("%s", out.ErrorMessage)
+	}
+	if !hasFinish {
+		return fmt.Errorf("openai-completions: stream ended without finish_reason")
+	}
+	out.Timestamp = time.Now()
+	s.Push(AssistantMessageEvent{Type: EventDone, Reason: out.StopReason, Message: out})
+	return nil
+}
+
+func snapshot(out *AssistantMessage) *AssistantMessage {
+	cp := *out
+	cp.Content = append([]AssistantContent(nil), out.Content...)
+	return &cp
+}
+
+func parseOpenAIUsage(raw oaUsage, model Model) Usage {
+	cacheRead, cacheWrite := 0, 0
+	if raw.PromptTokensDetails != nil {
+		cacheRead = raw.PromptTokensDetails.CachedTokens
+		cacheWrite = raw.PromptTokensDetails.CacheWriteTokens
+	}
+	input := max(0, raw.PromptTokens-cacheRead-cacheWrite)
+	u := Usage{
+		Input:       input,
+		Output:      raw.CompletionTokens,
+		CacheRead:   cacheRead,
+		CacheWrite:  cacheWrite,
+		TotalTokens: input + raw.CompletionTokens + cacheRead + cacheWrite,
+	}
+	perTok := func(rate float64, tokens int) float64 { return rate * float64(tokens) / 1e6 }
+	u.Cost = Cost{
+		Input:      perTok(model.Cost.Input, u.Input),
+		Output:     perTok(model.Cost.Output, u.Output),
+		CacheRead:  perTok(model.Cost.CacheRead, u.CacheRead),
+		CacheWrite: perTok(model.Cost.CacheWrite, u.CacheWrite),
+	}
+	u.Cost.Total = u.Cost.Input + u.Cost.Output + u.Cost.CacheRead + u.Cost.CacheWrite
+	return u
+}
+
+func mapOpenAIStopReason(reason string) (StopReason, string) {
+	switch reason {
+	case "stop", "end":
+		return StopReasonStop, ""
+	case "length":
+		return StopReasonLength, ""
+	case "tool_calls", "function_call":
+		return StopReasonToolUse, ""
+	default:
+		return StopReasonError, "provider finish_reason: " + reason
+	}
+}

--- a/internal/piai/openai_test.go
+++ b/internal/piai/openai_test.go
@@ -1,0 +1,358 @@
+package piai_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/p-n-ai/pai-bot/internal/piai"
+)
+
+type capturedRequest struct {
+	body    map[string]any
+	headers http.Header
+}
+
+func sseServer(t *testing.T, lines []string) (*httptest.Server, *capturedRequest) {
+	t.Helper()
+	captured := &capturedRequest{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.headers = r.Header.Clone()
+		if err := json.NewDecoder(r.Body).Decode(&captured.body); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		for _, line := range lines {
+			_, _ = w.Write([]byte(line + "\n\n"))
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv, captured
+}
+
+func openAIModel(baseURL string) piai.Model {
+	return piai.Model{
+		ID:       "gpt-test",
+		Name:     "GPT Test",
+		API:      piai.APIOpenAICompletions,
+		Provider: "openai",
+		BaseURL:  baseURL + "/v1",
+		Cost:     piai.Cost{Input: 1, Output: 2, CacheRead: 0.5, CacheWrite: 1.5},
+	}
+}
+
+func chunk(s string) string { return "data: " + s }
+
+func TestOpenAIStreamsTextAndUsage(t *testing.T) {
+	srv, captured := sseServer(t, []string{
+		chunk(`{"id":"chatcmpl-1","choices":[{"delta":{"content":"Hel"}}]}`),
+		chunk(`{"id":"chatcmpl-1","choices":[{"delta":{"content":"lo"}}]}`),
+		chunk(`{"id":"chatcmpl-1","choices":[{"delta":{},"finish_reason":"stop"}]}`),
+		chunk(`{"id":"chatcmpl-1","choices":[],"usage":{"prompt_tokens":100,"completion_tokens":10,"prompt_tokens_details":{"cached_tokens":40}}}`),
+		"data: [DONE]",
+	})
+
+	temp := 0.3
+	msg, err := piai.StreamOpenAICompletions(context.Background(), openAIModel(srv.URL),
+		piai.Context{SystemPrompt: "Be brief.", Messages: []piai.Message{piai.UserText("hi")}},
+		&piai.StreamOptions{APIKey: "sk-test", Temperature: &temp, MaxTokens: 128},
+	).Result()
+	if err != nil {
+		t.Fatalf("Result: %v", err)
+	}
+
+	if got := textOf(t, msg); got != "Hello" {
+		t.Fatalf("text = %q", got)
+	}
+	if msg.ResponseID != "chatcmpl-1" || msg.StopReason != piai.StopReasonStop {
+		t.Fatalf("responseID=%q stopReason=%q", msg.ResponseID, msg.StopReason)
+	}
+
+	if msg.Usage.Input != 60 || msg.Usage.CacheRead != 40 || msg.Usage.Output != 10 {
+		t.Fatalf("usage = %+v", msg.Usage)
+	}
+	requireTotalTokensEqualsComponents(t, msg.Usage)
+
+	if msg.Usage.Cost.Total == 0 || msg.Usage.Cost.Input != 60.0/1e6 {
+		t.Fatalf("cost = %+v", msg.Usage.Cost)
+	}
+
+	if captured.headers.Get("Authorization") != "Bearer sk-test" {
+		t.Fatalf("auth header = %q", captured.headers.Get("Authorization"))
+	}
+	if captured.body["model"] != "gpt-test" || captured.body["stream"] != true {
+		t.Fatalf("body = %+v", captured.body)
+	}
+	if captured.body["temperature"] != 0.3 || captured.body["max_completion_tokens"] != float64(128) {
+		t.Fatalf("params = %+v", captured.body)
+	}
+	if _, hasStore := captured.body["store"]; hasStore {
+		t.Fatal("store must only be sent to api.openai.com")
+	}
+	msgs := captured.body["messages"].([]any)
+	first := msgs[0].(map[string]any)
+	if first["role"] != "system" || first["content"] != "Be brief." {
+		t.Fatalf("system message = %+v", first)
+	}
+}
+
+func TestOpenAIStreamsToolCallDeltas(t *testing.T) {
+	srv, captured := sseServer(t, []string{
+		chunk(`{"id":"c","choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"echo","arguments":""}}]}}]}`),
+		chunk(`{"id":"c","choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"text\":"}}]}}]}`),
+		chunk(`{"id":"c","choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"hi\"}"}}]}}]}`),
+		chunk(`{"id":"c","choices":[{"delta":{},"finish_reason":"tool_calls"}]}`),
+		"data: [DONE]",
+	})
+
+	tool := piai.Tool{Name: "echo", Description: "Echo", Parameters: json.RawMessage(`{"type":"object"}`)}
+	stream := piai.StreamOpenAICompletions(context.Background(), openAIModel(srv.URL),
+		piai.Context{Messages: []piai.Message{piai.UserText("hi")}, Tools: []piai.Tool{tool}},
+		&piai.StreamOptions{APIKey: "sk-test"},
+	)
+	events := collectEvents(stream)
+	msg, err := stream.Result()
+	if err != nil {
+		t.Fatalf("Result: %v", err)
+	}
+
+	if msg.StopReason != piai.StopReasonToolUse {
+		t.Fatalf("stopReason = %q", msg.StopReason)
+	}
+	tc, ok := msg.Content[0].(piai.ToolCall)
+	if !ok || tc.ID != "call_1" || tc.Name != "echo" || tc.Arguments["text"] != "hi" {
+		t.Fatalf("toolCall = %#v", msg.Content[0])
+	}
+	for _, want := range []piai.EventType{piai.EventToolCallStart, piai.EventToolCallDelta, piai.EventToolCallEnd, piai.EventDone} {
+		if !containsType(events, want) {
+			t.Fatalf("missing %q in %v", want, eventTypes(events))
+		}
+	}
+
+	tools := captured.body["tools"].([]any)
+	fn := tools[0].(map[string]any)["function"].(map[string]any)
+	if fn["name"] != "echo" {
+		t.Fatalf("tools = %+v", tools)
+	}
+}
+
+func TestOpenAIStreamsMultipleToolCallsByIndex(t *testing.T) {
+	srv, _ := sseServer(t, []string{
+		chunk(`{"id":"c","choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"a","arguments":"{}"}}]}}]}`),
+		chunk(`{"id":"c","choices":[{"delta":{"tool_calls":[{"index":1,"id":"call_2","function":{"name":"b","arguments":"{}"}}]}}]}`),
+		chunk(`{"id":"c","choices":[{"delta":{},"finish_reason":"tool_calls"}]}`),
+		"data: [DONE]",
+	})
+
+	msg, err := piai.StreamOpenAICompletions(context.Background(), openAIModel(srv.URL),
+		piai.Context{Messages: []piai.Message{piai.UserText("hi")}},
+		&piai.StreamOptions{APIKey: "sk-test"},
+	).Result()
+	if err != nil {
+		t.Fatalf("Result: %v", err)
+	}
+	if len(msg.Content) != 2 {
+		t.Fatalf("content blocks = %d", len(msg.Content))
+	}
+	a, b := msg.Content[0].(piai.ToolCall), msg.Content[1].(piai.ToolCall)
+	if a.ID != "call_1" || b.ID != "call_2" {
+		t.Fatalf("ids = %q, %q", a.ID, b.ID)
+	}
+}
+
+func TestOpenAIFinishReasonMapping(t *testing.T) {
+	cases := []struct {
+		finish  string
+		want    piai.StopReason
+		wantErr bool
+	}{
+		{"length", piai.StopReasonLength, false},
+		{"content_filter", piai.StopReasonError, true},
+	}
+	for _, tc := range cases {
+		srv, _ := sseServer(t, []string{
+			chunk(`{"id":"c","choices":[{"delta":{"content":"x"},"finish_reason":"` + tc.finish + `"}]}`),
+			"data: [DONE]",
+		})
+		msg, err := piai.StreamOpenAICompletions(context.Background(), openAIModel(srv.URL),
+			piai.Context{Messages: []piai.Message{piai.UserText("hi")}},
+			&piai.StreamOptions{APIKey: "sk-test"},
+		).Result()
+		if tc.wantErr {
+			if err == nil || msg.StopReason != piai.StopReasonError {
+				t.Fatalf("%s: expected error terminal, got %+v", tc.finish, msg)
+			}
+			if !strings.Contains(msg.ErrorMessage, tc.finish) {
+				t.Fatalf("%s: errorMessage = %q", tc.finish, msg.ErrorMessage)
+			}
+		} else {
+			if err != nil || msg.StopReason != tc.want {
+				t.Fatalf("%s: stopReason = %q err=%v", tc.finish, msg.StopReason, err)
+			}
+		}
+	}
+}
+
+func TestOpenAIStreamWithoutFinishReasonIsError(t *testing.T) {
+	srv, _ := sseServer(t, []string{
+		chunk(`{"id":"c","choices":[{"delta":{"content":"x"}}]}`),
+		"data: [DONE]",
+	})
+	msg, err := piai.StreamOpenAICompletions(context.Background(), openAIModel(srv.URL),
+		piai.Context{Messages: []piai.Message{piai.UserText("hi")}},
+		&piai.StreamOptions{APIKey: "sk-test"},
+	).Result()
+	if err == nil || !strings.Contains(msg.ErrorMessage, "finish_reason") {
+		t.Fatalf("expected finish_reason error, got %+v err=%v", msg, err)
+	}
+}
+
+func TestOpenAIHTTPErrorBecomesTerminalErrorEvent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":{"message":"bad model"}}`, http.StatusBadRequest)
+	}))
+	t.Cleanup(srv.Close)
+
+	msg, err := piai.StreamOpenAICompletions(context.Background(), openAIModel(srv.URL),
+		piai.Context{Messages: []piai.Message{piai.UserText("hi")}},
+		&piai.StreamOptions{APIKey: "sk-test"},
+	).Result()
+	var streamErr *piai.StreamError
+	if !errors.As(err, &streamErr) || streamErr.Reason != piai.StopReasonError {
+		t.Fatalf("expected StreamError, got %v", err)
+	}
+	if !strings.Contains(msg.ErrorMessage, "HTTP 400") || !strings.Contains(msg.ErrorMessage, "bad model") {
+		t.Fatalf("errorMessage = %q", msg.ErrorMessage)
+	}
+}
+
+func TestOpenAIMissingAPIKeyIsError(t *testing.T) {
+	msg, err := piai.StreamOpenAICompletions(context.Background(), openAIModel("http://localhost:0"),
+		piai.Context{Messages: []piai.Message{piai.UserText("hi")}}, nil,
+	).Result()
+	if err == nil || !strings.Contains(msg.ErrorMessage, "no API key") {
+		t.Fatalf("expected missing-key error, got %+v err=%v", msg, err)
+	}
+}
+
+func TestOpenAIAbortMidStream(t *testing.T) {
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(chunk(`{"id":"c","choices":[{"delta":{"content":"x"}}]}`) + "\n\n"))
+		w.(http.Flusher).Flush()
+		<-release
+	}))
+	t.Cleanup(func() { close(release); srv.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stream := piai.StreamOpenAICompletions(ctx, openAIModel(srv.URL),
+		piai.Context{Messages: []piai.Message{piai.UserText("hi")}},
+		&piai.StreamOptions{APIKey: "sk-test"},
+	)
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+	msg, err := stream.Result()
+	var streamErr *piai.StreamError
+	if !errors.As(err, &streamErr) || streamErr.Reason != piai.StopReasonAborted {
+		t.Fatalf("expected aborted, got %v (msg=%+v)", err, msg)
+	}
+}
+
+func TestOpenAIMessageConversion(t *testing.T) {
+	srv, captured := sseServer(t, []string{
+		chunk(`{"id":"c","choices":[{"delta":{"content":"ok"},"finish_reason":"stop"}]}`),
+		"data: [DONE]",
+	})
+
+	prior := piai.FauxAssistantMessage(
+		piai.FauxText("calling"),
+		piai.ToolCall{ID: "call_1", Name: "echo", Arguments: map[string]any{"text": "hi"}},
+	)
+	aborted := piai.FauxAssistantMessage()
+	c := piai.Context{
+		Messages: []piai.Message{
+			piai.UserMessage{Content: []piai.UserContent{
+				piai.TextContent{Text: "look"},
+				piai.ImageContent{MimeType: "image/png", Data: "abcd"},
+			}},
+			prior,
+			piai.ToolResultMessage{ToolCallID: "call_1", ToolName: "echo",
+				Content: []piai.UserContent{piai.TextContent{Text: "echoed"}}},
+			aborted,
+			piai.UserText("next"),
+		},
+	}
+	if _, err := piai.StreamOpenAICompletions(context.Background(), openAIModel(srv.URL), c,
+		&piai.StreamOptions{APIKey: "sk-test"}).Result(); err != nil {
+		t.Fatalf("Result: %v", err)
+	}
+
+	msgs := captured.body["messages"].([]any)
+	if len(msgs) != 4 {
+		t.Fatalf("messages = %d: %+v", len(msgs), msgs)
+	}
+	userParts := msgs[0].(map[string]any)["content"].([]any)
+	img := userParts[1].(map[string]any)["image_url"].(map[string]any)
+	if !strings.HasPrefix(img["url"].(string), "data:image/png;base64,") {
+		t.Fatalf("image part = %+v", userParts[1])
+	}
+	assistant := msgs[1].(map[string]any)
+	toolCalls := assistant["tool_calls"].([]any)
+	fn := toolCalls[0].(map[string]any)["function"].(map[string]any)
+	if fn["name"] != "echo" || !strings.Contains(fn["arguments"].(string), `"text":"hi"`) {
+		t.Fatalf("tool_calls = %+v", toolCalls)
+	}
+	toolMsg := msgs[2].(map[string]any)
+	if toolMsg["role"] != "tool" || toolMsg["tool_call_id"] != "call_1" || toolMsg["content"] != "echoed" {
+		t.Fatalf("tool message = %+v", toolMsg)
+	}
+
+	if tools, ok := captured.body["tools"].([]any); !ok || len(tools) != 0 {
+		t.Fatalf("tools = %+v", captured.body["tools"])
+	}
+}
+
+func TestOpenAIDeveloperRoleForReasoningModels(t *testing.T) {
+	srv, captured := sseServer(t, []string{
+		chunk(`{"id":"c","choices":[{"delta":{"content":"ok"},"finish_reason":"stop"}]}`),
+		"data: [DONE]",
+	})
+	model := openAIModel(srv.URL)
+	model.Reasoning = true
+
+	if _, err := piai.StreamOpenAICompletions(context.Background(), model,
+		piai.Context{SystemPrompt: "sys", Messages: []piai.Message{piai.UserText("hi")}},
+		&piai.StreamOptions{APIKey: "sk-test"}).Result(); err != nil {
+		t.Fatalf("Result: %v", err)
+	}
+	first := captured.body["messages"].([]any)[0].(map[string]any)
+	if first["role"] != "developer" {
+		t.Fatalf("system role = %q, want developer", first["role"])
+	}
+}
+
+func TestOpenAIRegistersInRegistry(t *testing.T) {
+	srv, _ := sseServer(t, []string{
+		chunk(`{"id":"c","choices":[{"delta":{"content":"via registry"},"finish_reason":"stop"}]}`),
+		"data: [DONE]",
+	})
+	piai.RegisterOpenAICompletions()
+
+	msg, err := piai.Complete(context.Background(), openAIModel(srv.URL),
+		piai.Context{Messages: []piai.Message{piai.UserText("hi")}},
+		&piai.StreamOptions{APIKey: "sk-test"})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if got := textOf(t, msg); got != "via registry" {
+		t.Fatalf("text = %q", got)
+	}
+}

--- a/internal/piai/registry.go
+++ b/internal/piai/registry.go
@@ -7,8 +7,6 @@ import (
 	"time"
 )
 
-// StreamFunction is the provider contract: all failures surface as a terminal error
-// event on the stream (never a Go error or panic); ctx cancel ends with stopReason "aborted".
 type StreamFunction func(ctx context.Context, model Model, c Context, opts *StreamOptions) *EventStream
 
 type registeredProvider struct {
@@ -21,14 +19,12 @@ var (
 	registry   = map[string]registeredProvider{}
 )
 
-// RegisterProvider registers a StreamFunction for an API shape; sourceID groups registrations for UnregisterProviders.
 func RegisterProvider(api string, stream StreamFunction, sourceID string) {
 	registryMu.Lock()
 	defer registryMu.Unlock()
 	registry[api] = registeredProvider{stream: stream, sourceID: sourceID}
 }
 
-// UnregisterProviders removes all providers registered under sourceID.
 func UnregisterProviders(sourceID string) {
 	registryMu.Lock()
 	defer registryMu.Unlock()
@@ -39,8 +35,6 @@ func UnregisterProviders(sourceID string) {
 	}
 }
 
-// Stream starts a completion against model.API's registered provider; a missing
-// provider is reported as a terminal error event, keeping one failure path for callers.
 func Stream(ctx context.Context, model Model, c Context, opts *StreamOptions) *EventStream {
 	registryMu.RLock()
 	entry, ok := registry[model.API]
@@ -60,7 +54,6 @@ func Stream(ctx context.Context, model Model, c Context, opts *StreamOptions) *E
 	return entry.stream(ctx, model, c, opts)
 }
 
-// Complete runs Stream to completion and returns the final message.
 func Complete(ctx context.Context, model Model, c Context, opts *StreamOptions) (AssistantMessage, error) {
 	return Stream(ctx, model, c, opts).Result()
 }

--- a/internal/piai/stream.go
+++ b/internal/piai/stream.go
@@ -6,8 +6,6 @@ import (
 	"sync"
 )
 
-// EventType tags AssistantMessageEvent. Streams emit start, then per-block
-// start/delta/end triples, and terminate with exactly one done or error event.
 type EventType string
 
 const (
@@ -25,9 +23,6 @@ const (
 	EventError         EventType = "error"
 )
 
-// AssistantMessageEvent is one streaming event. Fields set depend on Type:
-// deltas carry Delta, *_end carries Content or ToolCall, done/error carry
-// Reason and the final Message. Partial is the message assembled so far.
 type AssistantMessageEvent struct {
 	Type         EventType
 	ContentIndex int
@@ -39,9 +34,6 @@ type AssistantMessageEvent struct {
 	Message      *AssistantMessage
 }
 
-// EventStream carries AssistantMessageEvents from provider to consumer. The
-// queue is unbounded so Push never blocks and Result can be awaited without
-// draining events; a terminal event completes the stream, later pushes drop.
 type EventStream struct {
 	mu     sync.Mutex
 	cond   *sync.Cond
@@ -57,7 +49,6 @@ func NewEventStream() *EventStream {
 	return s
 }
 
-// Push appends an event; a done or error event must carry Message and completes the stream.
 func (s *EventStream) Push(ev AssistantMessageEvent) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -73,7 +64,6 @@ func (s *EventStream) Push(ev AssistantMessageEvent) {
 	s.cond.Broadcast()
 }
 
-// Events iterates all events in order, ending after the terminal event.
 func (s *EventStream) Events() iter.Seq[AssistantMessageEvent] {
 	return func(yield func(AssistantMessageEvent) bool) {
 		i := 0
@@ -96,17 +86,13 @@ func (s *EventStream) Events() iter.Seq[AssistantMessageEvent] {
 	}
 }
 
-// StreamError is Result's typed failure for stopReason "error" or "aborted";
-// Reason distinguishes cancellation from provider failure without string matching.
 type StreamError struct {
-	Reason  StopReason // StopReasonError or StopReasonAborted
+	Reason  StopReason
 	Message string
 }
 
 func (e *StreamError) Error() string { return fmt.Sprintf("piai: %s: %s", e.Reason, e.Message) }
 
-// Result blocks until the stream completes and returns the final message.
-// On stopReason "error"/"aborted" it also returns a *StreamError.
 func (s *EventStream) Result() (AssistantMessage, error) {
 	<-s.done
 	if s.final.StopReason == StopReasonError || s.final.StopReason == StopReasonAborted {

--- a/internal/piai/stream_test.go
+++ b/internal/piai/stream_test.go
@@ -66,7 +66,6 @@ func TestEventStreamResultWithoutDraining(t *testing.T) {
 		s.Push(piai.AssistantMessageEvent{Type: piai.EventDone, Reason: piai.StopReasonStop, Message: &final})
 	}()
 
-	// No consumer drains events; Result must still return.
 	msg, err := s.Result()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -75,7 +74,6 @@ func TestEventStreamResultWithoutDraining(t *testing.T) {
 		t.Fatalf("stopReason = %q, want stop", msg.StopReason)
 	}
 
-	// A late consumer still sees every event.
 	if got := eventTypes(collectEvents(s)); !equalTypes(got, piai.EventStart, piai.EventTextDelta, piai.EventDone) {
 		t.Fatalf("late consumer events: %v", got)
 	}

--- a/internal/piai/types.go
+++ b/internal/piai/types.go
@@ -1,6 +1,3 @@
-// Package piai is a Go port of pi-ai (@earendil-works/pi-ai), a unified
-// multi-provider LLM API: Stream(model, context) → event stream →
-// AssistantMessage. See NOTICE for attribution.
 package piai
 
 import (
@@ -8,8 +5,6 @@ import (
 	"time"
 )
 
-// StopReason mirrors pi-ai's stop reasons. "error" and "aborted" terminate a
-// stream via an error event; the others via a done event.
 type StopReason string
 
 const (
@@ -20,7 +15,6 @@ const (
 	StopReasonAborted StopReason = "aborted"
 )
 
-// Cost is USD cost per usage component.
 type Cost struct {
 	Input      float64 `json:"input"`
 	Output     float64 `json:"output"`
@@ -29,9 +23,6 @@ type Cost struct {
 	Total      float64 `json:"total"`
 }
 
-// Usage is token usage for one assistant response. TotalTokens is the total
-// processed by the LLM — input (with cache) plus output — and must equal
-// Input + Output + CacheRead + CacheWrite.
 type Usage struct {
 	Input       int  `json:"input"`
 	Output      int  `json:"output"`
@@ -46,13 +37,13 @@ type TextContent struct {
 }
 
 type ImageContent struct {
-	Data     string `json:"data"` // base64
+	Data     string `json:"data"`
 	MimeType string `json:"mimeType"`
 }
 
 type ThinkingContent struct {
 	Thinking string `json:"thinking"`
-	// Signature: opaque provider payload replayed for multi-turn continuity.
+
 	Signature string `json:"thinkingSignature,omitempty"`
 	Redacted  bool   `json:"redacted,omitempty"`
 }
@@ -63,10 +54,8 @@ type ToolCall struct {
 	Arguments map[string]any `json:"arguments"`
 }
 
-// UserContent is TextContent or ImageContent.
 type UserContent interface{ isUserContent() }
 
-// AssistantContent is TextContent, ThinkingContent, or ToolCall.
 type AssistantContent interface{ isAssistantContent() }
 
 func (TextContent) isUserContent()          {}
@@ -75,7 +64,6 @@ func (TextContent) isAssistantContent()     {}
 func (ThinkingContent) isAssistantContent() {}
 func (ToolCall) isAssistantContent()        {}
 
-// Message is UserMessage, AssistantMessage, or ToolResultMessage.
 type Message interface{ isMessage() }
 
 type UserMessage struct {
@@ -107,27 +95,22 @@ func (UserMessage) isMessage()       {}
 func (AssistantMessage) isMessage()  {}
 func (ToolResultMessage) isMessage() {}
 
-// UserText builds a plain-text user message.
 func UserText(text string) UserMessage {
 	return UserMessage{Content: []UserContent{TextContent{Text: text}}, Timestamp: time.Now()}
 }
 
-// Tool describes a callable tool. Parameters is a JSON Schema document.
 type Tool struct {
 	Name        string          `json:"name"`
 	Description string          `json:"description"`
 	Parameters  json.RawMessage `json:"parameters"`
 }
 
-// Context is the full request context for one completion.
 type Context struct {
 	SystemPrompt string
 	Messages     []Message
 	Tools        []Tool
 }
 
-// CacheRetention is the prompt-cache retention preference. Zero value means
-// the provider default ("short"); "none" disables caching.
 type CacheRetention string
 
 const (
@@ -136,9 +119,6 @@ const (
 	CacheRetentionLong  CacheRetention = "long"
 )
 
-// StreamOptions are per-request options shared by all providers. Cancellation
-// rides the context.Context passed to StreamFunction, not an option. Fields
-// grow as adapters need them.
 type StreamOptions struct {
 	Temperature    *float64
 	MaxTokens      int
@@ -148,15 +128,14 @@ type StreamOptions struct {
 	Headers        map[string]string
 }
 
-// Model identifies a concrete model behind an API shape.
 type Model struct {
 	ID            string
 	Name          string
-	API           string // API wire shape, e.g. "openai-completions"
-	Provider      string // provider slug, e.g. "openai"
+	API           string
+	Provider      string
 	BaseURL       string
 	Reasoning     bool
-	Cost          Cost // $/million tokens per component
+	Cost          Cost
 	ContextWindow int
 	MaxTokens     int
 }


### PR DESCRIPTION
## What

PR2 of the pi-ai port ([plan](.humanlayer — local): dead-code-first, flag-gated cut-over later). Adds the **openai-completions adapter** to `internal/piai` — still **zero callers**; registration is explicit via `RegisterOpenAICompletions()`, which nothing invokes yet. Merge + deploy is a no-op.

Also strips all comments from the package per repo style (attribution lives in `NOTICE`).

## How

`net/http` + hand-rolled SSE — no SDK dependency. Scoped to OpenAI proper + generic OpenAI-compatible endpoints; pi's 40-vendor compat matrix is deliberately not ported.

- **Request mapping**: system (or `developer` for reasoning models), user text+image parts, assistant `tool_calls` replay with empty-turn skipping, tool results, `tools` (+ empty `tools: []` when history has tool calls but context doesn't — proxy compat), temperature, `max_completion_tokens`, `stream_options.include_usage`, `store: false` on api.openai.com only.
- **SSE consumption**: text delta coalescing, index-keyed tool-call assembly with argument accumulation parsed at `toolcall_end`, finish_reason mapping (`stop`/`length`/`tool_calls`/other→`error`), usage with cached-token split (`input = prompt − cacheRead − cacheWrite`, totalTokens invariant holds) and `Model.Cost` pricing.
- **Failure contract**: everything is a terminal `error` event on the stream — missing API key, HTTP non-200 (body captured), malformed chunks, missing finish_reason; ctx cancellation classified as `aborted`.

## Not in this PR

Reasoning-effort mapping, prompt_cache_key, session-affinity headers, thinking-block replay — each lands when a pai-bot model needs it. Live parity tests are PR3 (`//go:build integration`).

## Verify

```bash
go test ./internal/piai/ -count=1 -race   # 35 tests
just lint                                  # 0 issues
rg -l "RegisterOpenAICompletions" --glob '!internal/piai/**'   # no callers
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)