### PR TITLE
test: characterize OpenRouter provider contract

### DIFF
--- a/internal/ai/provider_openrouter_test.go
+++ b/internal/ai/provider_openrouter_test.go
@@ -8,16 +8,33 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 )
 
-func TestOpenRouterProvider_Complete(t *testing.T) {
+func TestOpenRouterProvider_Complete_MapsTeachingRequestAndResponse(t *testing.T) {
+	type observedRequest struct {
+		method        string
+		path          string
+		authorization string
+		contentType   string
+		body          map[string]any
+	}
+	observed := make(chan observedRequest, 1)
+	decodeErrors := make(chan error, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/chat/completions" {
-			t.Errorf("unexpected path: %s", r.URL.Path)
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			decodeErrors <- err
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
 		}
-		if r.Header.Get("Authorization") != "Bearer test-or-key" {
-			t.Errorf("unexpected auth header: %s", r.Header.Get("Authorization"))
+		observed <- observedRequest{
+			method:        r.Method,
+			path:          r.URL.Path,
+			authorization: r.Header.Get("Authorization"),
+			contentType:   r.Header.Get("Content-Type"),
+			body:          body,
 		}
 
 		writeOpenAITextResponse(t, w, "OpenRouter response", "qwen/qwen3-max", 7, 15)
@@ -27,17 +44,62 @@ func TestOpenRouterProvider_Complete(t *testing.T) {
 	provider := NewOpenRouterProvider("test-or-key", WithOpenRouterBaseURL(server.URL))
 
 	resp, err := provider.Complete(context.Background(), CompletionRequest{
-		Messages: []Message{{Role: "user", Content: "hello"}},
+		Messages: []Message{
+			{Role: "system", Content: "Teach with hints before answers."},
+			{Role: "user", Content: "How do I solve 2x + 3 = 11?"},
+			{Role: "assistant", Content: "What could you subtract first?"},
+			{Role: "user", Content: "Is my working correct?", ImageURLs: []string{"data:image/png;base64,AAEC"}},
+		},
+		MaxTokens:   1024,
+		Temperature: 0.3,
 	})
 
+	select {
+	case decodeErr := <-decodeErrors:
+		t.Fatalf("decode request: %v", decodeErr)
+	default:
+	}
 	if err != nil {
 		t.Fatalf("Complete() error = %v", err)
+	}
+	got := <-observed
+	if got.method != http.MethodPost || got.path != "/chat/completions" {
+		t.Errorf("request = %s %s, want POST /chat/completions", got.method, got.path)
+	}
+	if got.authorization != "Bearer test-or-key" {
+		t.Errorf("authorization = %q, want Bearer test-or-key", got.authorization)
+	}
+	if got.contentType != "application/json" {
+		t.Errorf("content type = %q, want application/json", got.contentType)
+	}
+	wantBody := map[string]any{
+		"model":       "qwen/qwen3-max",
+		"max_tokens":  float64(1024),
+		"temperature": 0.3,
+		"messages": []any{
+			map[string]any{"role": "system", "content": "Teach with hints before answers."},
+			map[string]any{"role": "user", "content": "How do I solve 2x + 3 = 11?"},
+			map[string]any{"role": "assistant", "content": "What could you subtract first?"},
+			map[string]any{"role": "user", "content": []any{
+				map[string]any{"type": "text", "text": "Is my working correct?"},
+				map[string]any{"type": "image_url", "image_url": map[string]any{"url": "data:image/png;base64,AAEC"}},
+			}},
+		},
+	}
+	if !reflect.DeepEqual(got.body, wantBody) {
+		t.Errorf("request body = %#v, want %#v", got.body, wantBody)
 	}
 	if resp.Content != "OpenRouter response" {
 		t.Errorf("content = %q, want %q", resp.Content, "OpenRouter response")
 	}
 	if resp.InputTokens != 7 {
 		t.Errorf("input_tokens = %d, want 7", resp.InputTokens)
+	}
+	if resp.OutputTokens != 15 {
+		t.Errorf("output_tokens = %d, want 15", resp.OutputTokens)
+	}
+	if resp.Model != "qwen/qwen3-max" {
+		t.Errorf("model = %q, want qwen/qwen3-max", resp.Model)
 	}
 }
 
@@ -96,6 +158,82 @@ func TestOpenRouterProvider_ExtraHeaders(t *testing.T) {
 	}
 	if gotTitle != "P&AI Bot" {
 		t.Errorf("X-Title = %q, want %q", gotTitle, "P&AI Bot")
+	}
+}
+
+func TestOpenRouterProvider_Complete_OmitsZeroMaxTokensAndTemperature(t *testing.T) {
+	requestBodies := make(chan map[string]any, 1)
+	decodeErrors := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			decodeErrors <- err
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+		requestBodies <- body
+		writeOpenAITextResponse(t, w, "ok", "qwen/qwen3-max", 0, 0)
+	}))
+	defer server.Close()
+	provider := NewOpenRouterProvider("test-key", WithOpenRouterBaseURL(server.URL))
+
+	_, err := provider.Complete(context.Background(), CompletionRequest{
+		Messages: []Message{{Role: "user", Content: "hi"}},
+	})
+
+	select {
+	case decodeErr := <-decodeErrors:
+		t.Fatalf("decode request: %v", decodeErr)
+	default:
+	}
+	if err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	body := <-requestBodies
+	if _, ok := body["max_tokens"]; ok {
+		t.Errorf("zero max_tokens should be omitted, request = %#v", body)
+	}
+	if _, ok := body["temperature"]; ok {
+		t.Errorf("zero temperature should be omitted, request = %#v", body)
+	}
+}
+
+func TestOpenRouterProvider_Complete_UsesCallerModel(t *testing.T) {
+	models := make(chan string, 1)
+	decodeErrors := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Model string `json:"model"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			decodeErrors <- err
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+		models <- body.Model
+		writeOpenAITextResponse(t, w, "ok", body.Model, 0, 0)
+	}))
+	defer server.Close()
+	provider := NewOpenRouterProvider("test-key", WithOpenRouterBaseURL(server.URL))
+
+	resp, err := provider.Complete(context.Background(), CompletionRequest{
+		Messages: []Message{{Role: "user", Content: "hi"}},
+		Model:    "anthropic/claude-sonnet-4",
+	})
+
+	select {
+	case decodeErr := <-decodeErrors:
+		t.Fatalf("decode request: %v", decodeErr)
+	default:
+	}
+	if err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	if got := <-models; got != "anthropic/claude-sonnet-4" {
+		t.Errorf("request model = %q, want anthropic/claude-sonnet-4", got)
+	}
+	if resp.Model != "anthropic/claude-sonnet-4" {
+		t.Errorf("response model = %q, want anthropic/claude-sonnet-4", resp.Model)
 	}
 }
 


### PR DESCRIPTION
## Summary

- characterize OpenRouter teaching request projection and completion response mapping through a local HTTP server
- pin default and caller-supplied model propagation, token and temperature serialization, multimodal messages, and required headers
- preserve existing structured-output, API-error, health-check, and model-list coverage

## Testing

- `go test ./internal/ai -run '^TestOpenRouterProvider_(Complete_MapsTeachingRequestAndResponse|Complete_OmitsZeroMaxTokensAndTemperature|Complete_UsesCallerModel|ExtraHeaders)$' -count=1`\n- `go test ./internal/ai ./internal/platform/airouter ./internal/agent -count=1`\n- `git diff --check aafa79371e54b53307490a6a9b8317b707128b9e`