### PR TITLE
feat(llm): support OpenRouter JSON schema responses

### DIFF
--- a/internal/llm/openrouter.go
+++ b/internal/llm/openrouter.go
@@ -31,6 +31,7 @@ const (
 var openRouterHTTPClient = &http.Client{}
 
 var openRouterSSEBoundary = regexp.MustCompile(`\r\n\r\n|\r\n\r|\r\n\n|\r\r\n|\n\r\n|\r\r|\n\r|\n\n`)
+var openRouterStructuredOutputName = regexp.MustCompile(`^[A-Za-z0-9_-]{1,64}$`)
 
 func RegisterOpenRouterChat() {
 	RegisterProvider(APIOpenRouterChat, StreamOpenRouterChat, "builtin:openrouter-chat")
@@ -183,14 +184,19 @@ func buildOpenRouterRequest(model Model, c Context, opts *StreamOptions) (compon
 	if err != nil {
 		return components.ChatRequest{}, err
 	}
+	responseFormat, err := openRouterJSONSchemaResponseFormat(opts.StructuredOutput)
+	if err != nil {
+		return components.ChatRequest{}, err
+	}
 
 	streamOptions := components.ChatStreamOptions{IncludeUsage: openrouter.Pointer(true)}
 	req := components.ChatRequest{
-		Messages:      messages,
-		Model:         openrouter.Pointer(model.ID),
-		Stream:        openrouter.Pointer(true),
-		StreamOptions: optionalnullable.From(&streamOptions),
-		Tools:         tools,
+		Messages:       messages,
+		Model:          openrouter.Pointer(model.ID),
+		ResponseFormat: responseFormat,
+		Stream:         openrouter.Pointer(true),
+		StreamOptions:  optionalnullable.From(&streamOptions),
+		Tools:          tools,
 	}
 	if opts.Temperature != nil {
 		req.Temperature = optionalnullable.From(opts.Temperature)
@@ -218,6 +224,46 @@ func buildOpenRouterRequest(model Model, c Context, opts *StreamOptions) (compon
 		}
 	}
 	return req, nil
+}
+
+func openRouterJSONSchemaResponseFormat(spec *StructuredOutputSpec) (*components.ResponseFormat, error) {
+	if spec == nil {
+		return nil, nil
+	}
+	if spec.Name == "" {
+		return nil, fmt.Errorf("openrouter-chat: structured output name is required")
+	}
+	if !openRouterStructuredOutputName.MatchString(spec.Name) {
+		return nil, fmt.Errorf("openrouter-chat: structured output name must match [A-Za-z0-9_-]{1,64}")
+	}
+
+	rawSchema := bytes.TrimSpace(spec.JSONSchema)
+	if len(rawSchema) == 0 {
+		return nil, fmt.Errorf("openrouter-chat: structured output JSON schema is required")
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(rawSchema))
+	decoder.UseNumber()
+	var decoded any
+	if err := decoder.Decode(&decoded); err != nil || len(bytes.TrimSpace(rawSchema[decoder.InputOffset():])) != 0 {
+		return nil, fmt.Errorf("openrouter-chat: structured output JSON schema must contain valid JSON")
+	}
+	schema, ok := decoded.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("openrouter-chat: structured output JSON schema must be a JSON object")
+	}
+
+	jsonSchema := components.ChatJSONSchemaConfig{
+		Name:   spec.Name,
+		Schema: schema,
+	}
+	if spec.Strict {
+		jsonSchema.Strict = optionalnullable.From(openrouter.Pointer(true))
+	}
+	responseFormat := components.CreateResponseFormatJSONSchema(components.ChatFormatJSONSchemaConfig{
+		JSONSchema: jsonSchema,
+	})
+	return &responseFormat, nil
 }
 
 func openRouterSupportsCacheControl(model Model) bool {

--- a/internal/llm/openrouter_test.go
+++ b/internal/llm/openrouter_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/OpenRouterTeam/go-sdk/models/sdkerrors"
@@ -130,6 +131,9 @@ func TestOpenRouterStreamsNativeTextReasoningUsageAndRequest(t *testing.T) {
 	if _, ok := captured.body["tools"]; ok {
 		t.Fatalf("tools must be omitted when no tools are configured: %+v", captured.body["tools"])
 	}
+	if _, ok := captured.body["response_format"]; ok {
+		t.Fatalf("response_format must be omitted when structured output is not configured: %+v", captured.body["response_format"])
+	}
 	cache := captured.body["cache_control"].(map[string]any)
 	if cache["type"] != "ephemeral" || cache["ttl"] != "1h" {
 		t.Fatalf("cache_control = %+v", cache)
@@ -142,6 +146,94 @@ func TestOpenRouterStreamsNativeTextReasoningUsageAndRequest(t *testing.T) {
 	first := messages[0].(map[string]any)
 	if first["role"] != "developer" || first["content"] != "Be brief." {
 		t.Fatalf("developer message = %+v", first)
+	}
+}
+
+func TestOpenRouterSendsStructuredOutputResponseFormat(t *testing.T) {
+	srv, captured := sseServer(t, []string{
+		openRouterChunk(`{"id":"or-structured","model":"openai/gpt-test","object":"chat.completion.chunk","created":1,"choices":[{"index":0,"delta":{"content":"{\"answer\":\"ok\"}"},"finish_reason":"stop"}]}`),
+		"data: [DONE]",
+	})
+	schema := json.RawMessage(`{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"],"additionalProperties":false}`)
+
+	_, err := llm.StreamOpenRouterChat(
+		context.Background(),
+		openRouterModel(srv.URL),
+		llm.Context{Messages: []llm.Message{llm.UserText("return JSON")}},
+		&llm.StreamOptions{
+			APIKey: "sk-or-test",
+			StructuredOutput: &llm.StructuredOutputSpec{
+				Name:       "tutor_response",
+				JSONSchema: schema,
+				Strict:     true,
+			},
+		},
+	).Result()
+	if err != nil {
+		t.Fatalf("Result: %v", err)
+	}
+
+	var decodedSchema map[string]any
+	if err := json.Unmarshal(schema, &decodedSchema); err != nil {
+		t.Fatalf("decode expected schema: %v", err)
+	}
+	want := map[string]any{
+		"type": "json_schema",
+		"json_schema": map[string]any{
+			"name":   "tutor_response",
+			"schema": decodedSchema,
+			"strict": true,
+		},
+	}
+	if got := captured.body["response_format"]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("response_format = %#v, want %#v", got, want)
+	}
+}
+
+func TestOpenRouterRejectsInvalidStructuredOutputBeforeRequest(t *testing.T) {
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, openRouterChunk(`{"id":"unexpected","choices":[{"delta":{"content":"unexpected"},"finish_reason":"stop"}]}`)+"\n\n")
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	t.Cleanup(srv.Close)
+
+	tests := []struct {
+		name string
+		spec llm.StructuredOutputSpec
+		want string
+	}{
+		{name: "missing name", spec: llm.StructuredOutputSpec{JSONSchema: json.RawMessage(`{}`)}, want: "name is required"},
+		{name: "invalid name", spec: llm.StructuredOutputSpec{Name: "invalid name", JSONSchema: json.RawMessage(`{}`)}, want: "name must match"},
+		{name: "name too long", spec: llm.StructuredOutputSpec{Name: strings.Repeat("a", 65), JSONSchema: json.RawMessage(`{}`)}, want: "name must match"},
+		{name: "missing schema", spec: llm.StructuredOutputSpec{Name: "reply"}, want: "JSON schema is required"},
+		{name: "malformed schema", spec: llm.StructuredOutputSpec{Name: "reply", JSONSchema: json.RawMessage(`{"schema-secret-marker":`)}, want: "must contain valid JSON"},
+		{name: "multiple schemas", spec: llm.StructuredOutputSpec{Name: "reply", JSONSchema: json.RawMessage(`{} {}`)}, want: "must contain valid JSON"},
+		{name: "array schema", spec: llm.StructuredOutputSpec{Name: "reply", JSONSchema: json.RawMessage(`[]`)}, want: "must be a JSON object"},
+		{name: "null schema", spec: llm.StructuredOutputSpec{Name: "reply", JSONSchema: json.RawMessage(`null`)}, want: "must be a JSON object"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := requests.Load()
+			msg, err := llm.StreamOpenRouterChat(
+				context.Background(),
+				openRouterModel(srv.URL),
+				llm.Context{Messages: []llm.Message{llm.UserText("return JSON")}},
+				&llm.StreamOptions{APIKey: "sk-secret-that-must-not-leak", StructuredOutput: &tt.spec},
+			).Result()
+			if err == nil || !strings.Contains(msg.ErrorMessage, tt.want) {
+				t.Fatalf("expected %q error, got message=%+v err=%v", tt.want, msg, err)
+			}
+			if strings.Contains(msg.ErrorMessage, "schema-secret-marker") || strings.Contains(msg.ErrorMessage, "sk-secret-that-must-not-leak") {
+				t.Fatalf("error leaks request data: %q", msg.ErrorMessage)
+			}
+			if got := requests.Load(); got != before {
+				t.Fatalf("requests = %d, want %d", got, before)
+			}
+		})
 	}
 }
 

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -168,13 +168,20 @@ const (
 	CacheRetentionLong  CacheRetention = "long"
 )
 
+type StructuredOutputSpec struct {
+	Name       string
+	JSONSchema json.RawMessage
+	Strict     bool
+}
+
 type StreamOptions struct {
-	Temperature    *float64
-	MaxTokens      int
-	APIKey         string
-	SessionID      string
-	CacheRetention CacheRetention
-	Headers        map[string]string
+	Temperature      *float64
+	MaxTokens        int
+	APIKey           string
+	SessionID        string
+	CacheRetention   CacheRetention
+	Headers          map[string]string
+	StructuredOutput *StructuredOutputSpec
 }
 
 type Model struct {


### PR DESCRIPTION
## Summary

- add an internal/llm structured-output request value without exposing OpenRouter SDK DTOs
- validate schema names and JSON objects before network I/O, then project the exact OpenRouter response_format
- cover exact wire shape, omission when absent, safe invalid-input failures, and no pre-validation requests

## Verification

- go test ./internal/llm -run TestOpenRouter(SendsStructuredOutputResponseFormat|RejectsInvalidStructuredOutputBeforeRequest|StreamsNativeTextReasoningUsageAndRequest)$ -count=1
- go test ./internal/llm -count=1
- go test ./internal/ai ./internal/platform/airouter ./internal/agent -count=1
- git diff --check origin/main...HEAD