### PR TITLE
feat(llm): preserve ordered system messages

### DIFF
--- a/internal/llm/faux.go
+++ b/internal/llm/faux.go
@@ -429,6 +429,8 @@ func assistantContentToText(content []AssistantContent) (string, error) {
 
 func messageToText(m Message) (role, text string, err error) {
 	switch msg := m.(type) {
+	case SystemMessage:
+		return "system", msg.Content, nil
 	case UserMessage:
 		return "user", userContentToText(msg.Content), nil
 	case AssistantMessage:

--- a/internal/llm/faux_test.go
+++ b/internal/llm/faux_test.go
@@ -271,6 +271,7 @@ func TestFauxEstimatesTokensFromSerializedContext(t *testing.T) {
 					llm.ImageContent{MimeType: "image/png", Data: "abcd"},
 				},
 			},
+			llm.SystemMessage{Content: "ordered"},
 			prior,
 			llm.ToolResultMessage{
 				ToolCallID: "tool-1",
@@ -290,6 +291,7 @@ func TestFauxEstimatesTokensFromSerializedContext(t *testing.T) {
 	promptText := strings.Join([]string{
 		"system:sys",
 		"user:hello\n[image:image/png:4]",
+		"system:ordered",
 		"assistant:prior",
 		"toolResult:echo\ntool out",
 		"tools:" + string(toolsJSON),

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -188,6 +188,8 @@ func convertOpenAIMessages(model Model, c Context) ([]oaMessage, error) {
 	}
 	for _, m := range c.Messages {
 		switch msg := m.(type) {
+		case SystemMessage:
+			return nil, fmt.Errorf("openai-completions: ordered system messages are unsupported")
 		case UserMessage:
 			params = append(params, convertOpenAIUserMessage(msg)...)
 		case AssistantMessage:

--- a/internal/llm/openai_test.go
+++ b/internal/llm/openai_test.go
@@ -105,6 +105,27 @@ func TestOpenAIStreamsTextAndUsage(t *testing.T) {
 	}
 }
 
+func TestOpenAIRejectsOrderedSystemMessagesBeforeRequest(t *testing.T) {
+	requested := false
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requested = true
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := llm.StreamOpenAICompletions(
+		context.Background(),
+		openAIModel(srv.URL),
+		llm.Context{Messages: []llm.Message{llm.SystemMessage{Content: "ordered"}}},
+		&llm.StreamOptions{APIKey: "sk-test"},
+	).Result()
+	if err == nil || !strings.Contains(err.Error(), "openai-completions: ordered system messages are unsupported") {
+		t.Fatalf("error = %v", err)
+	}
+	if requested {
+		t.Fatal("request was sent before rejecting ordered system message")
+	}
+}
+
 func TestOpenAIStreamsRefusalAsText(t *testing.T) {
 	srv, captured := sseServer(t, []string{
 		chunk(`{"id":"chatcmpl-refusal","choices":[{"delta":{"refusal":"I can"}}]}`),

--- a/internal/llm/openrouter.go
+++ b/internal/llm/openrouter.go
@@ -273,19 +273,13 @@ func openRouterSupportsCacheControl(model Model) bool {
 func convertOpenRouterMessages(model Model, c Context) ([]components.ChatMessages, error) {
 	messages := make([]components.ChatMessages, 0, len(c.Messages)+1)
 	if c.SystemPrompt != "" {
-		if openRouterUsesDeveloperRole(model) {
-			messages = append(messages, components.CreateChatMessagesDeveloper(components.ChatDeveloperMessage{
-				Content: components.CreateChatDeveloperMessageContentStr(c.SystemPrompt),
-			}))
-		} else {
-			messages = append(messages, components.CreateChatMessagesSystem(components.ChatSystemMessage{
-				Content: components.CreateChatSystemMessageContentStr(c.SystemPrompt),
-			}))
-		}
+		messages = append(messages, openRouterSystemMessage(model, c.SystemPrompt))
 	}
 
 	for _, m := range c.Messages {
 		switch msg := m.(type) {
+		case SystemMessage:
+			messages = append(messages, openRouterSystemMessage(model, msg.Content))
 		case UserMessage:
 			messages = append(messages, components.CreateChatMessagesUser(components.ChatUserMessage{
 				Content: openRouterUserContent(msg.Content),
@@ -306,6 +300,17 @@ func convertOpenRouterMessages(model Model, c Context) ([]components.ChatMessage
 		}
 	}
 	return messages, nil
+}
+
+func openRouterSystemMessage(model Model, content string) components.ChatMessages {
+	if openRouterUsesDeveloperRole(model) {
+		return components.CreateChatMessagesDeveloper(components.ChatDeveloperMessage{
+			Content: components.CreateChatDeveloperMessageContentStr(content),
+		})
+	}
+	return components.CreateChatMessagesSystem(components.ChatSystemMessage{
+		Content: components.CreateChatSystemMessageContentStr(content),
+	})
 }
 
 func openRouterUsesDeveloperRole(model Model) bool {

--- a/internal/llm/openrouter_test.go
+++ b/internal/llm/openrouter_test.go
@@ -149,6 +149,54 @@ func TestOpenRouterStreamsNativeTextReasoningUsageAndRequest(t *testing.T) {
 	}
 }
 
+func TestOpenRouterPreservesOrderedSystemMessages(t *testing.T) {
+	srv, captured := sseServer(t, []string{
+		openRouterChunk(`{"id":"or-ordered","model":"openai/gpt-test","object":"chat.completion.chunk","created":1,"choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":"stop"}]}`),
+		"data: [DONE]",
+	})
+
+	_, err := llm.StreamOpenRouterChat(
+		context.Background(),
+		openRouterModel(srv.URL),
+		llm.Context{
+			SystemPrompt: "leading",
+			Messages: []llm.Message{
+				llm.SystemMessage{Content: "before"},
+				llm.UserText("question"),
+				llm.SystemMessage{Content: "between"},
+				llm.AssistantMessage{Content: []llm.AssistantContent{llm.TextContent{Text: "answer"}}},
+				llm.SystemMessage{Content: "after"},
+			},
+		},
+		&llm.StreamOptions{APIKey: "sk-or-test"},
+	).Result()
+	if err != nil {
+		t.Fatalf("Result: %v", err)
+	}
+
+	messages := captured.body["messages"].([]any)
+	want := []struct {
+		role    string
+		content string
+	}{
+		{role: "developer", content: "leading"},
+		{role: "developer", content: "before"},
+		{role: "user", content: "question"},
+		{role: "developer", content: "between"},
+		{role: "assistant", content: "answer"},
+		{role: "developer", content: "after"},
+	}
+	if len(messages) != len(want) {
+		t.Fatalf("messages = %#v, want %d entries", messages, len(want))
+	}
+	for i, expected := range want {
+		message := messages[i].(map[string]any)
+		if message["role"] != expected.role || message["content"] != expected.content {
+			t.Fatalf("message %d = %#v, want role %q content %q", i, message, expected.role, expected.content)
+		}
+	}
+}
+
 func TestOpenRouterSendsStructuredOutputResponseFormat(t *testing.T) {
 	srv, captured := sseServer(t, []string{
 		openRouterChunk(`{"id":"or-structured","model":"openai/gpt-test","object":"chat.completion.chunk","created":1,"choices":[{"index":0,"delta":{"content":"{\"answer\":\"ok\"}"},"finish_reason":"stop"}]}`),

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -113,6 +113,10 @@ func (ToolCall) isAssistantContent()        {}
 
 type Message interface{ isMessage() }
 
+type SystemMessage struct {
+	Content string
+}
+
 type UserMessage struct {
 	Content   []UserContent
 	Timestamp time.Time
@@ -140,6 +144,7 @@ type ToolResultMessage struct {
 	Timestamp  time.Time
 }
 
+func (SystemMessage) isMessage()     {}
 func (UserMessage) isMessage()       {}
 func (AssistantMessage) isMessage()  {}
 func (ToolResultMessage) isMessage() {}


### PR DESCRIPTION
## Summary
- add an explicit `llm.SystemMessage` message variant
- preserve ordered system messages in native OpenRouter requests while retaining leading `Context.SystemPrompt` behavior
- reject ordered system messages explicitly in the legacy OpenAI transport and retain them in faux serialization

## Testing
- `go test ./internal/llm -count=1`
- `go test ./internal/... -count=1`
- `git diff --check`
- mutation check: changed the interleaved expected role from `developer` to `system`, confirmed the transport test failed, then restored it