### PR TITLE
feat(llm): support remote image URL content

### DIFF
--- a/internal/llm/faux.go
+++ b/internal/llm/faux.go
@@ -403,6 +403,8 @@ func userContentToText(content []UserContent) string {
 			parts = append(parts, b.Text)
 		case ImageContent:
 			parts = append(parts, fmt.Sprintf("[image:%s:%d]", b.MimeType, len(b.Data)))
+		case ImageURLContent:
+			parts = append(parts, "[image-url:"+b.URL+"]")
 		}
 	}
 	return strings.Join(parts, "\n")

--- a/internal/llm/faux_test.go
+++ b/internal/llm/faux_test.go
@@ -269,6 +269,7 @@ func TestFauxEstimatesTokensFromSerializedContext(t *testing.T) {
 				Content: []llm.UserContent{
 					llm.TextContent{Text: "hello"},
 					llm.ImageContent{MimeType: "image/png", Data: "abcd"},
+					llm.ImageURLContent{URL: "https://images.example/cat.png"},
 				},
 			},
 			llm.SystemMessage{Content: "ordered"},
@@ -290,7 +291,7 @@ func TestFauxEstimatesTokensFromSerializedContext(t *testing.T) {
 	toolsJSON, _ := json.Marshal([]llm.Tool{tool})
 	promptText := strings.Join([]string{
 		"system:sys",
-		"user:hello\n[image:image/png:4]",
+		"user:hello\n[image:image/png:4]\n[image-url:https://images.example/cat.png]",
 		"system:ordered",
 		"assistant:prior",
 		"toolResult:echo\ntool out",

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -191,7 +191,11 @@ func convertOpenAIMessages(model Model, c Context) ([]oaMessage, error) {
 		case SystemMessage:
 			return nil, fmt.Errorf("openai-completions: ordered system messages are unsupported")
 		case UserMessage:
-			params = append(params, convertOpenAIUserMessage(msg)...)
+			converted, err := convertOpenAIUserMessage(msg)
+			if err != nil {
+				return nil, err
+			}
+			params = append(params, converted...)
 		case AssistantMessage:
 			var texts []string
 			var toolCalls []oaToolCall
@@ -226,6 +230,9 @@ func convertOpenAIMessages(model Model, c Context) ([]oaMessage, error) {
 		case ToolResultMessage:
 			var texts []string
 			for _, b := range msg.Content {
+				if _, ok := b.(ImageURLContent); ok {
+					return nil, fmt.Errorf("openai-completions: remote image URL content is unsupported")
+				}
 				if t, ok := b.(TextContent); ok {
 					texts = append(texts, t.Text)
 				}
@@ -240,7 +247,7 @@ func convertOpenAIMessages(model Model, c Context) ([]oaMessage, error) {
 	return params, nil
 }
 
-func convertOpenAIUserMessage(msg UserMessage) []oaMessage {
+func convertOpenAIUserMessage(msg UserMessage) ([]oaMessage, error) {
 	onlyText := true
 	for _, b := range msg.Content {
 		if _, ok := b.(TextContent); !ok {
@@ -253,7 +260,7 @@ func convertOpenAIUserMessage(msg UserMessage) []oaMessage {
 		for _, b := range msg.Content {
 			texts = append(texts, b.(TextContent).Text)
 		}
-		return []oaMessage{{Role: "user", Content: strings.Join(texts, "\n")}}
+		return []oaMessage{{Role: "user", Content: strings.Join(texts, "\n")}}, nil
 	}
 	var parts []any
 	for _, b := range msg.Content {
@@ -264,12 +271,14 @@ func convertOpenAIUserMessage(msg UserMessage) []oaMessage {
 			p := oaImagePart{Type: "image_url"}
 			p.ImageURL.URL = "data:" + block.MimeType + ";base64," + block.Data
 			parts = append(parts, p)
+		case ImageURLContent:
+			return nil, fmt.Errorf("openai-completions: remote image URL content is unsupported")
 		}
 	}
 	if len(parts) == 0 {
-		return nil
+		return nil, nil
 	}
-	return []oaMessage{{Role: "user", Content: parts}}
+	return []oaMessage{{Role: "user", Content: parts}}, nil
 }
 
 type oaChunk struct {

--- a/internal/llm/openai_test.go
+++ b/internal/llm/openai_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -435,6 +436,39 @@ func TestOpenAIMessageConversion(t *testing.T) {
 
 	if tools, ok := captured.body["tools"].([]any); !ok || len(tools) != 0 {
 		t.Fatalf("tools = %+v", captured.body["tools"])
+	}
+}
+
+func TestOpenAIRejectsRemoteImageURLBeforeRequest(t *testing.T) {
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests.Add(1)
+	}))
+	t.Cleanup(srv.Close)
+
+	contexts := map[string]llm.Context{
+		"user message": {Messages: []llm.Message{llm.UserMessage{Content: []llm.UserContent{
+			llm.ImageURLContent{URL: "https://images.example/cat.png"},
+		}}}},
+		"tool result": {Messages: []llm.Message{llm.ToolResultMessage{ToolCallID: "call-1", Content: []llm.UserContent{
+			llm.ImageURLContent{URL: "https://images.example/result.png"},
+		}}}},
+	}
+	for name, testContext := range contexts {
+		t.Run(name, func(t *testing.T) {
+			msg, err := llm.StreamOpenAICompletions(
+				context.Background(),
+				openAIModel(srv.URL),
+				testContext,
+				&llm.StreamOptions{APIKey: "sk-test"},
+			).Result()
+			if err == nil || msg.ErrorMessage != "openai-completions: remote image URL content is unsupported" {
+				t.Fatalf("expected unsupported content error, got %+v err=%v", msg, err)
+			}
+		})
+	}
+	if requests.Load() != 0 {
+		t.Fatalf("requests = %d, want 0", requests.Load())
 	}
 }
 

--- a/internal/llm/openrouter.go
+++ b/internal/llm/openrouter.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"mime"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -281,8 +282,12 @@ func convertOpenRouterMessages(model Model, c Context) ([]components.ChatMessage
 		case SystemMessage:
 			messages = append(messages, openRouterSystemMessage(model, msg.Content))
 		case UserMessage:
+			content, err := openRouterUserContent(msg.Content)
+			if err != nil {
+				return nil, err
+			}
 			messages = append(messages, components.CreateChatMessagesUser(components.ChatUserMessage{
-				Content: openRouterUserContent(msg.Content),
+				Content: content,
 			}))
 		case AssistantMessage:
 			assistant, ok, err := openRouterAssistantMessage(msg)
@@ -293,8 +298,12 @@ func convertOpenRouterMessages(model Model, c Context) ([]components.ChatMessage
 				messages = append(messages, components.CreateChatMessagesAssistant(assistant))
 			}
 		case ToolResultMessage:
+			content, err := openRouterToolContent(msg.Content)
+			if err != nil {
+				return nil, err
+			}
 			messages = append(messages, components.CreateChatMessagesTool(components.ChatToolMessage{
-				Content:    openRouterToolContent(msg.Content),
+				Content:    content,
 				ToolCallID: msg.ToolCallID,
 			}))
 		}
@@ -318,24 +327,32 @@ func openRouterUsesDeveloperRole(model Model) bool {
 	return model.Reasoning && (strings.HasPrefix(modelID, "openai/") || strings.HasPrefix(modelID, "anthropic/"))
 }
 
-func openRouterUserContent(content []UserContent) components.ChatUserMessageContent {
+func openRouterUserContent(content []UserContent) (components.ChatUserMessageContent, error) {
 	if text, ok := openRouterTextOnly(content); ok {
-		return components.CreateChatUserMessageContentStr(text)
+		return components.CreateChatUserMessageContentStr(text), nil
 	}
-	return components.CreateChatUserMessageContentArrayOfChatContentItems(openRouterContentItems(content))
+	items, err := openRouterContentItems(content)
+	if err != nil {
+		return components.ChatUserMessageContent{}, err
+	}
+	return components.CreateChatUserMessageContentArrayOfChatContentItems(items), nil
 }
 
-func openRouterToolContent(content []UserContent) components.ChatToolMessageContent {
+func openRouterToolContent(content []UserContent) (components.ChatToolMessageContent, error) {
 	if len(content) == 0 {
-		return components.CreateChatToolMessageContentStr("(no text result)")
+		return components.CreateChatToolMessageContentStr("(no text result)"), nil
 	}
 	if text, ok := openRouterTextOnly(content); ok {
 		if text == "" {
 			text = "(no text result)"
 		}
-		return components.CreateChatToolMessageContentStr(text)
+		return components.CreateChatToolMessageContentStr(text), nil
 	}
-	return components.CreateChatToolMessageContentArrayOfChatContentItems(openRouterContentItems(content))
+	items, err := openRouterContentItems(content)
+	if err != nil {
+		return components.ChatToolMessageContent{}, err
+	}
+	return components.CreateChatToolMessageContentArrayOfChatContentItems(items), nil
 }
 
 func openRouterTextOnly(content []UserContent) (string, bool) {
@@ -350,7 +367,7 @@ func openRouterTextOnly(content []UserContent) (string, bool) {
 	return strings.Join(texts, "\n"), true
 }
 
-func openRouterContentItems(content []UserContent) []components.ChatContentItems {
+func openRouterContentItems(content []UserContent) ([]components.ChatContentItems, error) {
 	items := make([]components.ChatContentItems, 0, len(content))
 	for _, item := range content {
 		switch block := item.(type) {
@@ -362,9 +379,25 @@ func openRouterContentItems(content []UserContent) []components.ChatContentItems
 					URL: "data:" + block.MimeType + ";base64," + block.Data,
 				},
 			}))
+		case ImageURLContent:
+			if err := validateOpenRouterImageURL(block.URL); err != nil {
+				return nil, err
+			}
+			items = append(items, components.CreateChatContentItemsImageURL(components.ChatContentImage{
+				ImageURL: components.ChatContentImageImageURL{URL: block.URL},
+			}))
 		}
 	}
-	return items
+	return items, nil
+}
+
+func validateOpenRouterImageURL(raw string) error {
+	parsed, err := url.Parse(raw)
+	if err != nil || raw == "" || !parsed.IsAbs() || parsed.Hostname() == "" || parsed.User != nil ||
+		(!strings.EqualFold(parsed.Scheme, "http") && !strings.EqualFold(parsed.Scheme, "https")) {
+		return fmt.Errorf("openrouter-chat: image URL must be an absolute HTTP(S) URL without credentials")
+	}
+	return nil
 }
 
 func openRouterAssistantMessage(msg AssistantMessage) (components.ChatAssistantMessage, bool, error) {

--- a/internal/llm/openrouter_test.go
+++ b/internal/llm/openrouter_test.go
@@ -560,11 +560,13 @@ func TestOpenRouterConvertsMessagesToolsAndImages(t *testing.T) {
 			llm.UserMessage{Content: []llm.UserContent{
 				llm.TextContent{Text: "look"},
 				llm.ImageContent{MimeType: "image/png", Data: "abcd"},
+				llm.ImageURLContent{URL: "HTTPS://images.example/cat.png?size=large#view"},
 			}},
 			prior,
 			llm.ToolResultMessage{ToolCallID: "call-1", ToolName: "inspect", Content: []llm.UserContent{
 				llm.TextContent{Text: "found"},
 				llm.ImageContent{MimeType: "image/jpeg", Data: "efgh"},
+				llm.ImageURLContent{URL: "http://images.example/result.jpg"},
 			}},
 		},
 		Tools: []llm.Tool{tool},
@@ -589,6 +591,10 @@ func TestOpenRouterConvertsMessagesToolsAndImages(t *testing.T) {
 	if !strings.HasPrefix(userImage["url"].(string), "data:image/png;base64,") {
 		t.Fatalf("user image = %+v", userImage)
 	}
+	userRemoteImage := userParts[2].(map[string]any)["image_url"].(map[string]any)
+	if userRemoteImage["url"] != "HTTPS://images.example/cat.png?size=large#view" {
+		t.Fatalf("remote user image = %+v", userRemoteImage)
+	}
 	assistant := messages[2].(map[string]any)
 	if assistant["content"] != "calling" || assistant["reasoning"] != "planning" {
 		t.Fatalf("assistant = %+v", assistant)
@@ -603,12 +609,55 @@ func TestOpenRouterConvertsMessagesToolsAndImages(t *testing.T) {
 	if !strings.HasPrefix(toolImage["url"].(string), "data:image/jpeg;base64,") {
 		t.Fatalf("tool image = %+v", toolImage)
 	}
+	toolRemoteImage := toolResultParts[2].(map[string]any)["image_url"].(map[string]any)
+	if toolRemoteImage["url"] != "http://images.example/result.jpg" {
+		t.Fatalf("remote tool image = %+v", toolRemoteImage)
+	}
 
 	tools := captured.body["tools"].([]any)
 	toolFunction := tools[0].(map[string]any)["function"].(map[string]any)
 	parameters := toolFunction["parameters"].(map[string]any)
 	if toolFunction["name"] != "inspect" || parameters["type"] != "object" {
 		t.Fatalf("tools = %+v", tools)
+	}
+}
+
+func TestOpenRouterRejectsInvalidImageURLsBeforeRequest(t *testing.T) {
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests.Add(1)
+	}))
+	t.Cleanup(srv.Close)
+
+	invalid := []string{
+		"",
+		"images.example/cat.png",
+		"data:image/png;base64,abcd",
+		"ftp://images.example/cat.png",
+		"https://user:secret@images.example/cat.png",
+		"https://:443/cat.png",
+		"://malformed",
+	}
+	for _, imageURL := range invalid {
+		t.Run(imageURL, func(t *testing.T) {
+			msg, err := llm.StreamOpenRouterChat(
+				context.Background(),
+				openRouterModel(srv.URL),
+				llm.Context{Messages: []llm.Message{llm.UserMessage{Content: []llm.UserContent{
+					llm.ImageURLContent{URL: imageURL},
+				}}}},
+				&llm.StreamOptions{APIKey: "sk-or-test"},
+			).Result()
+			if err == nil || msg.ErrorMessage != "openrouter-chat: image URL must be an absolute HTTP(S) URL without credentials" {
+				t.Fatalf("expected safe image URL error, got %+v err=%v", msg, err)
+			}
+			if strings.Contains(msg.ErrorMessage, "secret") {
+				t.Fatalf("error leaks URL credentials: %q", msg.ErrorMessage)
+			}
+		})
+	}
+	if requests.Load() != 0 {
+		t.Fatalf("requests = %d, want 0", requests.Load())
 	}
 }
 

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -43,6 +43,10 @@ type ImageContent struct {
 	MimeType string `json:"mimeType"`
 }
 
+type ImageURLContent struct {
+	URL string `json:"url"`
+}
+
 type ThinkingContent struct {
 	Thinking string `json:"thinking"`
 
@@ -107,6 +111,7 @@ type AssistantContent interface{ isAssistantContent() }
 
 func (TextContent) isUserContent()          {}
 func (ImageContent) isUserContent()         {}
+func (ImageURLContent) isUserContent()      {}
 func (TextContent) isAssistantContent()     {}
 func (ThinkingContent) isAssistantContent() {}
 func (ToolCall) isAssistantContent()        {}


### PR DESCRIPTION
## Summary

- add an explicit `ImageURLContent` variant for remote user images
- serialize valid absolute HTTP(S) image URLs natively at the OpenRouter boundary without rewriting the URL
- reject malformed, credential-bearing, and unsupported URLs before transport; make legacy OpenAI fail explicitly and Faux serialize deterministically

## Tests

- `go test ./internal/llm -run 'TestOpenRouterConvertsMessagesToolsAndImages|TestOpenRouterRejectsInvalidImageURLsBeforeRequest|TestOpenAIRejectsRemoteImageURLBeforeRequest|TestFauxEstimatesTokensFromSerializedContext' -count=1`\n- `go test ./internal/llm -count=1`\n- `go test ./internal/... -count=1`\n- `git diff --check`\n- mutation checks confirmed request-shape assertions catch URL rewriting and validation assertions catch unsupported schemes reaching transport