### PR TITLE
Route production OpenRouter through native LLM adapter

### DIFF
--- a/internal/platform/airouter/setup.go
+++ b/internal/platform/airouter/setup.go
@@ -87,7 +87,7 @@ func buildProvider(name string, cfg config.AIConfig) (ai.ProviderRegistration, b
 		if cfg.OpenRouter.APIKey == "" {
 			return ai.ProviderRegistration{}, false
 		}
-		return ai.ProviderRegistration{Name: name, Provider: ai.NewOpenRouterProvider(cfg.OpenRouter.APIKey), DefaultModel: cfg.OpenRouter.Model}, true
+		return ai.ProviderRegistration{Name: name, Provider: ai.NewOpenRouterLLMAdapter(cfg.OpenRouter.APIKey), DefaultModel: cfg.OpenRouter.Model}, true
 	}
 	return ai.ProviderRegistration{}, false
 }

--- a/internal/platform/airouter/setup_test.go
+++ b/internal/platform/airouter/setup_test.go
@@ -5,12 +5,33 @@ package airouter
 
 import (
 	"context"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/p-n-ai/pai-bot/internal/ai"
 	"github.com/p-n-ai/pai-bot/internal/platform/config"
 )
+
+func TestBuildProviderUsesOpenRouterLLMAdapter(t *testing.T) {
+	cfg := config.AIConfig{}
+	cfg.OpenRouter.APIKey = "test-openrouter-key"
+	cfg.OpenRouter.Model = "test-openrouter-model"
+
+	reg, ok := buildProvider("openrouter", cfg)
+	if !ok {
+		t.Fatal("buildProvider(openrouter) = not registered with key set")
+	}
+	if got, want := reflect.TypeOf(reg.Provider), reflect.TypeOf(ai.NewOpenRouterLLMAdapter("")); got != want {
+		t.Fatalf("OpenRouter provider type = %v, want %v", got, want)
+	}
+	if reg.Name != "openrouter" {
+		t.Fatalf("OpenRouter registration name = %q, want openrouter", reg.Name)
+	}
+	if reg.DefaultModel != cfg.OpenRouter.Model {
+		t.Fatalf("OpenRouter default model = %q, want %q", reg.DefaultModel, cfg.OpenRouter.Model)
+	}
+}
 
 func TestProviderOrderSkipsMockByDefault(t *testing.T) {
 	for _, provider := range providerOrder("") {


### PR DESCRIPTION
## Summary

- register OpenRouter with the internal LLM compatibility adapter at the production router assembly boundary
- preserve provider registration name, conditions, ordering, and configured default model
- add a regression test that pins the selected adapter type

## Testing

- `GOCACHE=/private/tmp/pai-bot-go-build go test ./internal/platform/airouter -count=1`
- `GOCACHE=/private/tmp/pai-bot-go-build go test ./internal/platform/airouter ./internal/ai ./internal/llm ./internal/agent -count=1`
- `git diff --check`
- mutation check: switching the constructor back to `ai.NewOpenRouterProvider` fails `TestBuildProviderUsesOpenRouterLLMAdapter`