### PR TITLE
feat(ai): use minimal reasoning for GPT-5.4 mini

### DIFF
--- a/internal/ai/provider_openrouter_llm_adapter.go
+++ b/internal/ai/provider_openrouter_llm_adapter.go
@@ -15,8 +15,9 @@ import (
 )
 
 const (
-	openRouterLLMDefaultBaseURL = "https://openrouter.ai/api/v1"
-	openRouterLLMDefaultModel   = "qwen/qwen3-max"
+	openRouterLLMDefaultBaseURL        = "https://openrouter.ai/api/v1"
+	openRouterLLMDefaultModel          = "qwen/qwen3-max"
+	openRouterLLMMinimalReasoningModel = "openai/gpt-5.4-mini"
 )
 
 var errOpenRouterLLMCompletion = errors.New("openrouter completion failed")
@@ -47,7 +48,7 @@ func (p *openRouterLLMAdapter) Complete(ctx context.Context, req CompletionReque
 	if err != nil {
 		return CompletionResponse{}, err
 	}
-	options := projectOpenRouterLLMOptions(p.apiKey, req)
+	options := projectOpenRouterLLMOptions(p.apiKey, modelID, req)
 	message, err := llm.StreamOpenRouterChat(ctx, llm.Model{
 		ID:       modelID,
 		API:      llm.APIOpenRouterChat,
@@ -137,10 +138,13 @@ func projectOpenRouterLLMImage(raw string) (llm.UserContent, error) {
 	}, nil
 }
 
-func projectOpenRouterLLMOptions(apiKey string, req CompletionRequest) llm.StreamOptions {
+func projectOpenRouterLLMOptions(apiKey, modelID string, req CompletionRequest) llm.StreamOptions {
 	options := llm.StreamOptions{
 		APIKey:    apiKey,
 		MaxTokens: req.MaxTokens,
+	}
+	if modelID == openRouterLLMMinimalReasoningModel {
+		options.ReasoningEffort = llm.ReasoningEffortMinimal
 	}
 	if req.Temperature > 0 {
 		temperature := req.Temperature

--- a/internal/ai/provider_openrouter_llm_adapter_test.go
+++ b/internal/ai/provider_openrouter_llm_adapter_test.go
@@ -166,6 +166,30 @@ func TestOpenRouterLLMAdapterCompleteProjectsStructuredOutputAndCallerModel(t *t
 	}
 }
 
+func TestOpenRouterLLMAdapterUsesMinimalReasoningForGPT54Mini(t *testing.T) {
+	captured := make(chan map[string]any, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		captured <- body
+		writeOpenRouterLLMStream(w, `{"id":"or-gpt","model":"openai/gpt-5.4-mini","choices":[{"delta":{"content":"ok"},"finish_reason":"stop"}]}`)
+	}))
+	t.Cleanup(server.Close)
+	var provider Provider = newOpenRouterLLMAdapter("test-key", server.URL)
+
+	_, err := provider.Complete(context.Background(), CompletionRequest{
+		Messages: []Message{{Role: "user", Content: "help"}},
+		Model:    "openai/gpt-5.4-mini",
+	})
+	if err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	body := <-captured
+	if body["reasoning_effort"] != "minimal" {
+		t.Fatalf("reasoning_effort = %#v, want minimal", body["reasoning_effort"])
+	}
+}
+
 func TestOpenRouterLLMAdapterCompleteOmitsZeroOptions(t *testing.T) {
 	captured := make(chan map[string]any, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -187,6 +211,9 @@ func TestOpenRouterLLMAdapterCompleteOmitsZeroOptions(t *testing.T) {
 	}
 	if _, ok := body["temperature"]; ok {
 		t.Fatalf("zero temperature must be omitted: %#v", body)
+	}
+	if _, ok := body["reasoning_effort"]; ok {
+		t.Fatalf("reasoning effort must be omitted for other models: %#v", body)
 	}
 }
 

--- a/internal/llm/openrouter.go
+++ b/internal/llm/openrouter.go
@@ -205,6 +205,10 @@ func buildOpenRouterRequest(model Model, c Context, opts *StreamOptions) (compon
 	if opts.MaxTokens > 0 {
 		req.MaxCompletionTokens = optionalnullable.From(openrouter.Pointer(int64(opts.MaxTokens)))
 	}
+	if opts.ReasoningEffort != "" {
+		effort := components.ChatRequestReasoningEffort(opts.ReasoningEffort)
+		req.ReasoningEffort = optionalnullable.From(&effort)
+	}
 	if opts.SessionID != "" {
 		req.SessionID = openrouter.Pointer(opts.SessionID)
 	}

--- a/internal/llm/openrouter_integration_test.go
+++ b/internal/llm/openrouter_integration_test.go
@@ -67,6 +67,31 @@ func TestOpenRouterLiveStreaming(t *testing.T) {
 	})
 }
 
+func TestOpenRouterLiveGPT54MiniMinimalReasoning(t *testing.T) {
+	key := liveOpenRouterKey(t)
+	model := liveOpenRouterModel()
+	model.ID = "openai/gpt-5.4-mini"
+	retryLive(t, func(ctx context.Context) error {
+		message, err := llm.StreamOpenRouterChat(
+			ctx,
+			model,
+			llm.Context{Messages: []llm.Message{llm.UserText("Reply with exactly: OR_GPT_MINIMAL_OK")}},
+			&llm.StreamOptions{
+				APIKey:          key,
+				MaxTokens:       32,
+				ReasoningEffort: llm.ReasoningEffortMinimal,
+			},
+		).Result()
+		if err != nil {
+			return err
+		}
+		if !strings.Contains(joinedText(message), "OR_GPT_MINIMAL_OK") {
+			return fmt.Errorf("response text = %q", joinedText(message))
+		}
+		return nil
+	})
+}
+
 func TestOpenRouterLiveMultiTurn(t *testing.T) {
 	key := liveOpenRouterKey(t)
 	model := liveOpenRouterModel()

--- a/internal/llm/openrouter_test.go
+++ b/internal/llm/openrouter_test.go
@@ -48,11 +48,12 @@ func TestOpenRouterStreamsNativeTextReasoningUsageAndRequest(t *testing.T) {
 		model,
 		llm.Context{SystemPrompt: "Be brief.", Messages: []llm.Message{llm.UserText("hi")}},
 		&llm.StreamOptions{
-			APIKey:         "sk-or-test",
-			Temperature:    &temperature,
-			MaxTokens:      128,
-			SessionID:      "session-1",
-			CacheRetention: llm.CacheRetentionLong,
+			APIKey:          "sk-or-test",
+			Temperature:     &temperature,
+			MaxTokens:       128,
+			SessionID:       "session-1",
+			CacheRetention:  llm.CacheRetentionLong,
+			ReasoningEffort: llm.ReasoningEffortMinimal,
 			Headers: map[string]string{
 				"http-referer": "https://review.example",
 				"x-title":      "Review Bot",
@@ -124,6 +125,9 @@ func TestOpenRouterStreamsNativeTextReasoningUsageAndRequest(t *testing.T) {
 	}
 	if captured.body["temperature"] != 0.3 || captured.body["max_completion_tokens"] != float64(128) {
 		t.Fatalf("params = %+v", captured.body)
+	}
+	if captured.body["reasoning_effort"] != "minimal" {
+		t.Fatalf("reasoning_effort = %#v", captured.body["reasoning_effort"])
 	}
 	if captured.body["session_id"] != "session-1" {
 		t.Fatalf("session_id = %+v", captured.body["session_id"])

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -184,12 +184,17 @@ type StructuredOutputSpec struct {
 	Strict     bool
 }
 
+type ReasoningEffort string
+
+const ReasoningEffortMinimal ReasoningEffort = "minimal"
+
 type StreamOptions struct {
 	Temperature      *float64
 	MaxTokens        int
 	APIKey           string
 	SessionID        string
 	CacheRetention   CacheRetention
+	ReasoningEffort  ReasoningEffort
 	Headers          map[string]string
 	StructuredOutput *StructuredOutputSpec
 }


### PR DESCRIPTION
Summary
- Add an explicit native OpenRouter reasoning-effort option.
- Select minimal reasoning when the compatibility adapter routes to openai/gpt-5.4-mini.
- Keep reasoning effort absent for other models.

Testing
- go test ./internal/llm ./internal/ai -count=1
- go test ./... -short -count=1
- go vet ./...
- live TestOpenRouterLiveGPT54MiniMinimalReasoning against OpenRouter