### PR TITLE
fix(llm): omit absent OpenRouter assistant fields

### DIFF
--- a/internal/ai/provider_openrouter_llm_adapter_test.go
+++ b/internal/ai/provider_openrouter_llm_adapter_test.go
@@ -95,10 +95,8 @@ func TestOpenRouterLLMAdapterCompleteProjectsTeachingContractThroughNativeTransp
 		map[string]any{"role": "user", "content": "MODEL-GENERATED SUMMARY: The learner practiced balancing equations."},
 		map[string]any{"role": "user", "content": "How do I solve 2x + 3 = 11?"},
 		map[string]any{
-			"role":              "assistant",
-			"content":           "What could you subtract first?",
-			"reasoning_details": []any{},
-			"tool_calls":        []any{},
+			"role":    "assistant",
+			"content": "What could you subtract first?",
 		},
 		map[string]any{"role": "user", "content": "LEARNER-PROVIDED CONTEXT: I prefer visual explanations."},
 		map[string]any{"role": "system", "content": "Analyze the attached image directly."},

--- a/internal/llm/openrouter.go
+++ b/internal/llm/openrouter.go
@@ -403,8 +403,8 @@ func validateOpenRouterImageURL(raw string) error {
 func openRouterAssistantMessage(msg AssistantMessage) (components.ChatAssistantMessage, bool, error) {
 	texts := make([]string, 0, len(msg.Content))
 	thoughts := make([]string, 0, len(msg.Content))
-	toolCalls := make([]components.ChatToolCall, 0, len(msg.Content))
-	reasoningDetails := make([]components.ReasoningDetailUnion, 0, len(msg.ReasoningDetails))
+	var toolCalls []components.ChatToolCall
+	var reasoningDetails []components.ReasoningDetailUnion
 	for i, raw := range msg.ReasoningDetails {
 		encoded, err := json.Marshal(raw)
 		if err != nil {

--- a/internal/llm/openrouter_integration_test.go
+++ b/internal/llm/openrouter_integration_test.go
@@ -67,7 +67,7 @@ func TestOpenRouterLiveStreaming(t *testing.T) {
 	})
 }
 
-func TestOpenRouterLiveMultiTurn(t *testing.T) {
+func TestOpenRouterLiveTextOnlyAssistantHistory(t *testing.T) {
 	key := liveOpenRouterKey(t)
 	model := liveOpenRouterModel()
 	retryLive(t, func(ctx context.Context) error {
@@ -81,12 +81,15 @@ func TestOpenRouterLiveMultiTurn(t *testing.T) {
 		if err != nil {
 			return err
 		}
+		textOnlyHistory := llm.AssistantMessage{
+			Content: []llm.AssistantContent{llm.TextContent{Text: joinedText(first)}},
+		}
 		second, err := llm.StreamOpenRouterChat(
 			ctx,
 			model,
 			llm.Context{Messages: []llm.Message{
 				firstUser,
-				first,
+				textOnlyHistory,
 				llm.UserText("What code word did I ask you to remember? Reply only with the code word."),
 			}},
 			&llm.StreamOptions{APIKey: key, MaxTokens: 32},

--- a/internal/llm/openrouter_test.go
+++ b/internal/llm/openrouter_test.go
@@ -622,6 +622,35 @@ func TestOpenRouterConvertsMessagesToolsAndImages(t *testing.T) {
 	}
 }
 
+func TestOpenRouterOmitsAbsentAssistantToolCallsAndReasoningDetails(t *testing.T) {
+	srv, captured := sseServer(t, []string{
+		openRouterChunk(`{"id":"or-history","model":"qwen/qwen3-max","object":"chat.completion.chunk","created":1,"choices":[{"index":0,"delta":{"content":"COBALT"},"finish_reason":"stop"}]}`),
+		"data: [DONE]",
+	})
+
+	_, err := llm.StreamOpenRouterChat(
+		context.Background(),
+		openRouterModel(srv.URL),
+		llm.Context{Messages: []llm.Message{
+			llm.UserText("Remember COBALT."),
+			llm.AssistantMessage{Content: []llm.AssistantContent{llm.TextContent{Text: "ACK"}}},
+			llm.UserText("What was the word?"),
+		}},
+		&llm.StreamOptions{APIKey: "sk-or-test"},
+	).Result()
+	if err != nil {
+		t.Fatalf("Result: %v", err)
+	}
+
+	messages := captured.body["messages"].([]any)
+	assistant := messages[1].(map[string]any)
+	for _, field := range []string{"tool_calls", "reasoning_details"} {
+		if _, present := assistant[field]; present {
+			t.Fatalf("text-only assistant message contains absent field %q: %#v", field, assistant)
+		}
+	}
+}
+
 func TestOpenRouterRejectsInvalidImageURLsBeforeRequest(t *testing.T) {
 	var requests atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {


### PR DESCRIPTION
Summary
- Preserve absent assistant tool calls and reasoning details as omitted JSON fields.
- Cover text-only historical assistant turns at the native OpenRouter wire boundary.
- Exercise the same history shape against the live Qwen endpoint.

Why
- Alibaba rejects empty tool_calls arrays in historical assistant messages.

Testing
- go test ./internal/llm ./internal/ai -count=1
- go test ./... -short -count=1
- go vet ./...
- live TestOpenRouterLiveTextOnlyAssistantHistory against qwen/qwen3-max