### PR TITLE
docs(agent): refresh repository guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # P&AI BOT
 
-**Generated:** 2026-06-04T16:28:07Z
-**Commit:** bb3a740
+**Generated:** 2026-07-11
+**Commit:** bdd0c16
 
 K-12 proactive learning agent for Telegram, WhatsApp, WebSocket/embed chat, and admin dashboards. Go modular monolith with Vite/Next/Astro frontends; current primary scope is backend Go and `admin-spa/`.
 

--- a/admin-spa/src/components/AGENTS.md
+++ b/admin-spa/src/components/AGENTS.md
@@ -1,7 +1,7 @@
 # ADMIN SPA COMPONENTS
 
-**Generated:** 2026-06-04T16:28:07Z
-**Commit:** bb3a740
+**Generated:** 2026-07-11
+**Commit:** bdd0c16
 
 Feature, shared, and primitive React components for admin workflows and dashboards.
 
@@ -34,16 +34,18 @@ components/
 | Onboarding wizard | `onboarding/` |
 | Classes/users management | `classes/`, `users/` |
 | Retrieval lab UI | `retrieval/` |
+| Embed/AI/WhatsApp settings | `settings/` |
+| Export workflows | `export/` |
 
 ## CONVENTIONS
 
-- Feature components receive typed data/actions; parsing and calculations stay in `src/lib`.
+- Feature components may own API effects and loading state; response parsing and deterministic calculations stay in `src/lib`.
 - Tests cover visible behavior, form state, and loading/error branches.
 - Prefer shared admin surfaces before inventing new wrappers.
 - Component additions should use existing `ui/` primitives and shadcn project context.
 
 ## ANTI-PATTERNS
 
-- No API fetching hidden in leaf components when route/provider layer can pass data.
+- No duplicate API orchestration across a route and its feature component; make one owner explicit.
 - No one-off visual primitive that belongs in `shared/` or `ui/`.
 - No inaccessible form/control composition; labels and focus states are required.

--- a/admin/AGENTS.md
+++ b/admin/AGENTS.md
@@ -1,0 +1,44 @@
+# NEXT ADMIN APP
+
+**Generated:** 2026-07-11
+**Commit:** bdd0c16
+
+Standalone Next.js admin surface; distinct from the primary Vite app in `admin-spa/`.
+
+## STRUCTURE
+
+```
+admin/
+├── src/app/          # App Router pages, layouts, one proxy route
+├── src/components/   # feature and UI components
+├── src/lib/          # client/server API, auth, RBAC, view logic
+├── src/hooks/        # reusable client hooks
+├── src/stores/       # Zustand client state
+└── e2e/              # Playwright public and backend-auth suites
+```
+
+## WHERE TO LOOK
+
+| Task | Location |
+|------|----------|
+| Root/landing layout | `src/app/layout.tsx`, `src/app/page.tsx` |
+| Authenticated shell | `src/app/(app)/layout.tsx` |
+| Cookie-presence redirects | `src/proxy.ts` |
+| Browser API client | `src/lib/api.ts` |
+| Server API/session/RBAC | `src/lib/server-api.ts`, auth/RBAC helpers |
+| Backend proxying | `next.config.ts`, route handlers under `src/app/api` |
+
+## CONVENTIONS
+
+- Use `pnpm`; ignore package-manager suggestions in the scaffold README.
+- Proxy cookie checks are navigation hints, not authorization; server/session checks own access.
+- Keep browser same-origin API behavior distinct from server-side backend base URLs.
+- Dev-only Agentation wiring must not enter production bundles.
+- Unit aggregation, Vitest, and Playwright are separate gates; backend-tagged E2E needs explicit env enablement.
+
+## ANTI-PATTERNS
+
+- No shared implementation assumptions with `admin-spa/`; verify which app owns the requested surface.
+- No frontend token ownership or client-only authorization.
+- No casual removal of the misspelled retrieval route without proving compatibility callers.
+- No edits to generated/build output.

--- a/cmd/AGENTS.md
+++ b/cmd/AGENTS.md
@@ -1,7 +1,7 @@
 # COMMAND ENTRYPOINTS
 
-**Generated:** 2026-06-04T16:28:07Z
-**Commit:** bb3a740
+**Generated:** 2026-07-11
+**Commit:** bdd0c16
 
 Thin binaries for server, seed, local chat, nudges, quality harnesses, and analytics export.
 
@@ -21,9 +21,9 @@ cmd/
 
 | Task | Location |
 |------|----------|
-| Server startup/routes | `server/main.go` |
-| Admin asset embed | `server/embed_admin.go` |
-| Security headers/origins | `server/security.go` |
+| Server dependency wiring | `server/main.go` |
+| HTTP routes/admin embedding | `internal/server/handler.go` |
+| Security headers/origins | `internal/server/security.go` |
 | Demo/auth/budget seed flags | `seed/main.go` |
 | Local tutor session | `terminal-chat/main.go`, `internal/terminalchat` |
 | Nudge debug CLI | `terminal-nudge/main.go`, `internal/terminalnudge` |

--- a/cmd/server/AGENTS.md
+++ b/cmd/server/AGENTS.md
@@ -1,31 +1,30 @@
 # SERVER COMMAND
 
-**Generated:** 2026-06-04T16:28:07Z
-**Commit:** bb3a740
+**Generated:** 2026-07-11
+**Commit:** bdd0c16
 
-Production Go HTTP server: health bootstrap, API routes, admin embedding, chat channels, auth, retrieval, and graceful shutdown.
+Production composition root: config and dependency wiring for the HTTP server and chat channels.
 
 ## WHERE TO LOOK
 
 | Task | Location |
 |------|----------|
 | Startup dependency graph | `main.go` |
-| Route registration | `main.go` handler setup sections |
-| Admin SPA embedding | `embed_admin.go`, `embed_admin_test.go` |
-| Security headers/origins | `security.go`, `security_test.go` |
-| Route/wiring regressions | `main_test.go` |
+| HTTP lifecycle and handler swap | `internal/server/run.go` |
+| Routes and admin SPA embedding | `internal/server/handler.go` |
+| Security headers/origins | `internal/server/security.go` |
+| Route/lifecycle regressions | `internal/server/handler_test.go`, `internal/server/run_test.go` |
 | API shape docs | `internal/apidocs` |
 
 ## CONVENTIONS
 
-- Health-only handler comes up before full mux; keep long init after early healthz.
+- `internal/server` owns the health-first handler swap, HTTP lifecycle, and mux adapters.
 - DB/config failures are fatal; cache failures degrade where existing code does.
-- Route handlers parse/auth/encode; service packages own product decisions.
-- Admin asset path behavior needs embed tests.
+- Keep this package focused on dependency construction and channel registration.
 
 ## ANTI-PATTERNS
 
-- No long startup task before healthz availability.
+- No duplicate HTTP lifecycle or handler ownership outside `internal/server`.
 - No direct provider-specific AI setup here; use `internal/platform/airouter`.
-- No duplicating admin API logic from `internal/adminapi` in route closures.
-- No security header/origin change without route or browser smoke coverage.
+- No reusable server behavior that forces imports from `cmd/`.
+- No channel startup detached from the lifecycle owner that observes its failure.

--- a/internal/AGENTS.md
+++ b/internal/AGENTS.md
@@ -1,7 +1,7 @@
 # BACKEND INTERNAL PACKAGES
 
-**Generated:** 2026-06-04T16:28:07Z
-**Commit:** bb3a740
+**Generated:** 2026-07-11
+**Commit:** bdd0c16
 
 Runtime product code for the Go modular monolith. Commands wire these packages; packages own behavior.
 
@@ -11,6 +11,7 @@ Runtime product code for the Go modular monolith. Commands wire these packages; 
 internal/
 ├── agent/          # tutor engine, quizzes, nudges, challenges (AGENTS.md)
 ├── ai/             # provider gateway, router, budget, structured output (AGENTS.md)
+├── llm/            # provider protocol, registry, streaming adapters (AGENTS.md)
 ├── chat/           # Telegram/WhatsApp/WebSocket/embed adapters (AGENTS.md)
 ├── auth/           # JWT, cookies, Google OIDC, guest/password auth (AGENTS.md)
 ├── adminapi/       # admin service helpers (AGENTS.md)
@@ -19,6 +20,7 @@ internal/
 ├── retrieval/      # curriculum search/index facade (AGENTS.md)
 ├── tenant/         # tenant bootstrap
 ├── platform/       # config/db/cache/AI router/mailer/seed (AGENTS.md)
+├── server/         # HTTP lifecycle, mux, security, admin/chat mounts (AGENTS.md)
 └── terminal*/      # local CLI runtime helpers
 ```
 
@@ -28,8 +30,10 @@ internal/
 |------|----------|
 | Wire one learner turn | `agent/engine.go`, `agent/turn.go`, `chat/gateway.go` |
 | Add slash command | `chat/commands.go`, then `agent/*command*.go` |
-| Add AI provider/model | `ai/provider_*.go`, `ai/router.go`, `platform/config`, `platform/airouter` |
-| Add admin API behavior | `adminapi/service.go`, specific `adminapi/*.go`, then `cmd/server` route |
+| Add product AI provider/model | `ai/provider_*.go`, `ai/router.go`, `platform/config`, `platform/airouter` |
+| Change low-level OpenRouter/LLM protocol | `llm/` |
+| Add admin API behavior | `adminapi/service.go`, specific `adminapi/*.go`, then `server/handler.go` |
+| Change HTTP lifecycle/routes | `server/run.go`, `server/handler.go`, `server/security.go` |
 | Add persistence | nearest `*_postgres.go` plus integration test |
 | Add local/dev runtime behavior | `terminalchat/`, `terminalnudge/`, or `cmd/*` wrapper |
 | Add curriculum source behavior | `curriculum/`, `retrieval/`, `oss/` contract checks |

--- a/internal/adminapi/AGENTS.md
+++ b/internal/adminapi/AGENTS.md
@@ -1,7 +1,7 @@
 # ADMIN API SERVICE
 
-**Generated:** 2026-06-04T16:28:07Z
-**Commit:** bb3a740
+**Generated:** 2026-07-11
+**Commit:** bdd0c16
 
 Backend service helpers for admin app features: onboarding, classes, groups, users, and school setup.
 
@@ -12,12 +12,12 @@ Backend service helpers for admin app features: onboarding, classes, groups, use
 | Service construction | `service.go`, `service_test.go` |
 | Onboarding flow | `onboarding.go`, `onboarding_test.go` |
 | Classes/groups | `classes.go`, `groups.go` |
-| HTTP route wiring | `cmd/server/main.go` |
+| HTTP route wiring | `internal/server/handler.go` |
 | SPA shape mirror | `admin-spa/src/lib/admin-api.ts`, `admin-spa/src/lib/*-types.ts` |
 
 ## CONVENTIONS
 
-- HTTP parsing/encoding stays in `cmd/server`; product decisions live here.
+- HTTP parsing/encoding stays in `internal/server`; product decisions live here.
 - Return typed structs fit for API JSON responses.
 - Tenant-aware queries only; platform-admin/global behavior is explicit.
 - Class/group field changes inspect migrations, seed data, and SPA type guards.

--- a/internal/agent/AGENTS.md
+++ b/internal/agent/AGENTS.md
@@ -1,7 +1,7 @@
 # TUTOR AGENT ENGINE
 
-**Generated:** 2026-06-04T16:28:07Z
-**Commit:** bb3a740
+**Generated:** 2026-07-11
+**Commit:** bdd0c16
 
 Conversation state machine, pedagogy, quiz runtime, nudges, goals, group flows, and learner motivation.
 
@@ -9,7 +9,8 @@ Conversation state machine, pedagogy, quiz runtime, nudges, goals, group flows, 
 
 | Task | Location |
 |------|----------|
-| Main turn handling | `engine.go`, `turn.go`, `turn_hooks.go` |
+| Intake and route selection | `engine.go`, `turn.go` |
+| Generic teaching-turn lifecycle | `teaching_turn.go`, `turn_hooks.go` |
 | Prompt behavior | `prompt_builder.go`, `tutor_behavior.go`, `tutor_personality.go` |
 | Curriculum context | `context_loader.go`, `context_packets.go`, `context_resolver.go`, `curriculum_retriever.go` |
 | Quiz flow | `quiz.go`, `quiz_runtime.go`, `quiz_router.go`, `quiz_generate.go`, `quiz_progress.go` |

--- a/internal/ai/AGENTS.md
+++ b/internal/ai/AGENTS.md
@@ -1,7 +1,7 @@
 # AI GATEWAY
 
-**Generated:** 2026-06-04T16:28:07Z
-**Commit:** bb3a740
+**Generated:** 2026-07-11
+**Commit:** bdd0c16
 
 Provider-neutral completion gateway, model routing, token budget enforcement, image input, and structured output.
 
@@ -12,7 +12,7 @@ Provider-neutral completion gateway, model routing, token budget enforcement, im
 | Gateway contracts | `gateway.go`, `mock.go` |
 | Model routing/fallback | `router.go`, `router_test.go` |
 | Token budgets | `budget.go`, `budget_test.go` |
-| Structured JSON | `complete_json.go`, `structured_output*.go`, related tests |
+| Structured JSON | helpers in `gateway.go`, `complete_json_test.go`, `structured_output_test.go` |
 | OpenAI/DeepSeek-compatible | `provider_openai.go` |
 | Anthropic/Gemini/Ollama/OpenRouter | `provider_anthropic.go`, `provider_google.go`, `provider_ollama.go`, `provider_openrouter_llm_adapter.go` |
 | Image inputs | `image_input.go` |

--- a/internal/llm/AGENTS.md
+++ b/internal/llm/AGENTS.md
@@ -1,0 +1,35 @@
+# LLM PROVIDER PROTOCOL
+
+**Generated:** 2026-07-11
+**Commit:** bdd0c16
+
+Provider-neutral request/response types, concurrent registry, streaming protocol, and provider adapters.
+
+## WHERE TO LOOK
+
+| Task | Location |
+|------|----------|
+| Public protocol and content types | `types.go` |
+| Provider registry and lookup | `registry.go` |
+| OpenAI/OpenRouter adapters | `openai.go`, `openrouter.go` |
+| Streaming/SSE behavior | `stream.go`, provider tests |
+| Deterministic provider behavior | `faux.go` |
+
+## CONVENTIONS
+
+- Preserve provider-neutral typed content, reasoning, tool, and multimodal shapes.
+- Registry mutation and lookup remain concurrency-safe.
+- Expected provider/stream failures are typed or wrapped with safe operational context.
+- Adapter tests use fake HTTP servers; live-provider tests stay explicit integration tests.
+- Do not add comments here; attribution belongs in `NOTICE`.
+
+## ANTI-PATTERNS
+
+- No provider-specific decisions in `internal/agent` or `internal/chat`.
+- No text-only assumptions that discard images, tools, reasoning, or stream terminal state.
+- No silent fallback loop that hides every provider error.
+- No broad config, API-key, request, or response dumps.
+
+## NOTES
+
+- Product-level routing, budgets, and fallback policy remain in `internal/ai`.

--- a/internal/platform/AGENTS.md
+++ b/internal/platform/AGENTS.md
@@ -1,7 +1,7 @@
 # PLATFORM ADAPTERS
 
-**Generated:** 2026-06-04T16:28:07Z
-**Commit:** bb3a740
+**Generated:** 2026-07-11
+**Commit:** bdd0c16
 
 Infrastructure wrappers for config, DB, cache, AI router setup, mailer, feature flags, and seed data.
 
@@ -15,6 +15,8 @@ platform/
 ├── airouter/      # AI router setup from config
 ├── featureflags/  # runtime flags
 ├── mailer/        # outbound email adapter
+├── settings/      # encrypted persisted runtime settings (AGENTS.md)
+├── tenant/        # tenant context adapter
 └── seed/          # demo/token-budget seed routines
 ```
 
@@ -28,10 +30,12 @@ platform/
 | AI router from config | `airouter/` |
 | Demo/token-budget seed | `seed/`, `cmd/seed` |
 | Mail delivery | `mailer/` |
+| Runtime AI/auth settings | `settings/` |
+| Tenant context adapter | `tenant/` |
 
 ## CONVENTIONS
 
-- Adapters stay thin; product behavior belongs in domain packages.
+- Adapters stay thin where possible; `settings` owns persistence, encryption, and effective-value policy.
 - Config defaults and validation stay in lockstep with `.env.example`.
 - Connection constructors accept context and return closable clients/pools.
 - Seed routines prefer idempotent inserts/upserts.

--- a/internal/platform/settings/AGENTS.md
+++ b/internal/platform/settings/AGENTS.md
@@ -1,0 +1,35 @@
+# RUNTIME SETTINGS
+
+**Generated:** 2026-07-11
+**Commit:** bdd0c16
+
+Encrypted persisted runtime settings, effective-value resolution, and live apply coordination.
+
+## WHERE TO LOOK
+
+| Task | Location |
+|------|----------|
+| Effective settings model | `settings.go` |
+| Encryption helpers | `crypto.go` |
+| Encrypted persistence and in-memory state | `postgres.go` |
+| Admin update wiring | `internal/server/handler.go` |
+| Integration behavior | `*_integration_test.go` |
+
+## CONVENTIONS
+
+- Environment/config values and persisted values have one explicit precedence path.
+- Persisted API keys are encrypted using the auth secret and never serialized back to clients.
+- Preserve an undecryptable stored blob unless an authorized update replaces it.
+- Updates serialize persistence, current-state replacement, then the non-failing live apply callback.
+- Test transaction, degraded-read, corruption, and secret-redaction behavior at real seams.
+
+## ANTI-PATTERNS
+
+- No plaintext secrets in JSON, logs, fixtures, or error context.
+- No current-state or apply mutation after a persistence failure.
+- No fallback to insecure default auth secrets.
+- No config/persistence precedence duplicated in HTTP handlers.
+
+## NOTES
+
+- Runtime settings are platform-global; tenant-scoped fallback is not implicit.

--- a/internal/server/AGENTS.md
+++ b/internal/server/AGENTS.md
@@ -1,0 +1,36 @@
+# HTTP SERVER RUNTIME
+
+**Generated:** 2026-07-11
+**Commit:** bdd0c16
+
+HTTP lifecycle, mux composition, security middleware, and admin/chat HTTP adapters.
+
+## WHERE TO LOOK
+
+| Task | Location |
+|------|----------|
+| Health-first startup and shutdown | `run.go` |
+| Top-level mounts and API handler | `handler.go` |
+| Security headers and origin policy | `security.go` |
+| Runtime settings admin surface | `handler.go`, `internal/platform/settings` |
+| OpenAPI/docs routes | `handler.go`, `internal/apidocs` |
+
+## CONVENTIONS
+
+- `Run` exposes a health-only handler before dependency initialization, then atomically swaps in the full handler.
+- `NewTopMux` owns transport mounts; domain decisions stay in `internal/*` services.
+- Preserve explicit tenant and platform-admin authorization at route boundaries.
+- Parse, authenticate, and encode here; keep deterministic calculations in owning packages.
+- Exercise handler behavior through real HTTP requests/recorders.
+
+## ANTI-PATTERNS
+
+- No slow initialization before health availability.
+- No product authorization represented only by client/user-selected filters.
+- No duplicate route ownership in `cmd/server`.
+- No raw secrets, learner content, prompts, or image data in logs.
+- No security/origin change without focused handler tests and browser-facing verification.
+
+## NOTES
+
+- `handler.go` is intentionally the current route composition seam; split only with behavior-preserving tests.

--- a/migrations/AGENTS.md
+++ b/migrations/AGENTS.md
@@ -1,0 +1,32 @@
+# DATABASE MIGRATIONS
+
+**Generated:** 2026-07-11
+**Commit:** bdd0c16
+
+Timestamped Goose SQL migrations for product schema, constraints, and required data transitions.
+
+## CONVENTIONS
+
+- Create files with `just migration-create <name>`; keep Goose Up/Down markers valid.
+- Treat applied migrations as append-only; add a corrective migration instead of rewriting history.
+- Product tables carry `tenant_id` unless the global/platform exception is explicit in schema and code.
+- Cross-table relationships preserve tenant consistency with constraints or triggers where plain FKs cannot.
+- Data backfills are deterministic, bounded, and safe against partially populated databases.
+- Keep Down ordering dependency-safe; document deliberate irreversibility in the migration itself.
+- Use `StatementBegin`/`StatementEnd` for trigger/function bodies when Goose parsing requires it.
+
+## VERIFICATION
+
+- Never point `GOOSE_DSN` or `LEARN_DATABASE_URL` at a remote database for local validation.
+- Run the smallest owning integration tests after schema changes; auth and runtime-settings tests load named migrations.
+- Keep demo/product seed behavior in `cmd/seed` and `internal/platform/seed` unless schema bootstrap requires it.
+
+## ANTI-PATTERNS
+
+- No tenant-blind product schema or data rewrite.
+- No second migration runner against the same long-lived database.
+- No rename/removal of a migration referenced directly by integration tests without updating the contract.
+
+## NOTES
+
+- Runtime settings are a deliberate platform-global schema exception; keep exceptions explicit.

--- a/site/AGENTS.md
+++ b/site/AGENTS.md
@@ -1,0 +1,35 @@
+# SITE AND PUBLIC DOCS
+
+**Generated:** 2026-07-11
+**Commit:** bdd0c16
+
+Astro package combining a custom landing page with Starlight documentation.
+
+## WHERE TO LOOK
+
+| Task | Location |
+|------|----------|
+| Landing page | `src/pages/index.astro` |
+| Landing layout/components | `src/layouts`, `src/components` |
+| Starlight docs | `src/content/docs` |
+| Sidebar/base/site config | `astro.config.mjs`, `src/content.config.ts` |
+| Landing theme styles | `src/styles/globals.css` |
+| Starlight overrides | `src/styles/starlight.css` |
+
+## CONVENTIONS
+
+- Use `pnpm` in this package.
+- Route landing links/assets through `withBase()` or `import.meta.env.BASE_URL`.
+- Keep landing `.dark` state separate from Starlight's `data-theme` mechanism.
+- Docs pages carry Starlight frontmatter, including title, description, and sidebar order where relevant.
+- Verify runtime, command, version, and architecture claims against current code and `justfile`.
+
+## ANTI-PATTERNS
+
+- No assumption that landing and Starlight share routing or theme state.
+- No stale setup/deployment claim copied from old docs without code verification.
+- No committed generated output.
+
+## COMMANDS
+
+`pnpm dev`, `pnpm build`, and `pnpm preview` run from this directory.


### PR DESCRIPTION
## What changed

- refresh the root and scoped `AGENTS.md` maps against the current repository
- document the Next admin, Astro site, migrations, HTTP server, LLM, and runtime-settings boundaries
- correct stale ownership references after the server and teaching-turn extractions

## Why

The existing hierarchy predated several package extractions and contained plausible but incorrect file and ownership pointers. Scoped guidance now follows the current code boundaries and keeps local instructions close to the affected surfaces.

## Impact

Agent work should reach the correct implementation and test seams with fewer stale assumptions. This changes repository guidance only; application behavior is unchanged.

## Validation

- `git diff --check`
- verified referenced paths exist
- verified root and child `AGENTS.md` size gates
- five-lane post-generation review passed
