### PR TITLE
feat(auth): discover Google login at runtime

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,8 @@ PAI_AUTH_GOOGLE_ALLOWED_DOMAIN=
 # Override for local emulation; leave blank in production.
 PAI_AUTH_GOOGLE_DISCOVERY_URL=
 PAI_AUTH_GOOGLE_EMULATOR_SIGNING_SECRET=
+# Legacy Next.js admin only. The active admin SPA discovers Google availability
+# from the backend at runtime.
 NEXT_PUBLIC_PAI_AUTH_GOOGLE_LOGIN_ENABLED=false
 
 # Admin container API routing

--- a/admin-spa/src/components/auth/login-form.test.tsx
+++ b/admin-spa/src/components/auth/login-form.test.tsx
@@ -15,13 +15,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { LoginForm } from './login-form'
 import type { AuthSession } from '@/lib/auth-types'
 import type * as AuthClient from '@/lib/auth-client'
-import type * as LoginSettings from '@/lib/login-settings'
 
 const loginWithPassword = vi.hoisted(() => vi.fn())
+const readAuthCapabilities = vi.hoisted(() => vi.fn())
 const buildGoogleLoginURL = vi.hoisted(() =>
   vi.fn(() => '/api/auth/google/start?next=%2Fdashboard'),
 )
-const isGoogleLoginEnabled = vi.hoisted(() => vi.fn(() => false))
 
 vi.mock('@/lib/auth-client', async (importOriginal) => {
   const actual = await importOriginal<typeof AuthClient>()
@@ -30,15 +29,7 @@ vi.mock('@/lib/auth-client', async (importOriginal) => {
     ...actual,
     buildGoogleLoginURL,
     loginWithPassword,
-  }
-})
-
-vi.mock('@/lib/login-settings', async (importOriginal) => {
-  const actual = await importOriginal<typeof LoginSettings>()
-
-  return {
-    ...actual,
-    isGoogleLoginEnabled,
+    readAuthCapabilities,
   }
 })
 
@@ -52,7 +43,8 @@ const adminSession: AuthSession = {
 
 describe('LoginForm', () => {
   beforeEach(() => {
-    isGoogleLoginEnabled.mockReturnValue(false)
+    readAuthCapabilities.mockReset()
+    readAuthCapabilities.mockResolvedValue({ google_login: false })
     loginWithPassword.mockReset()
     window.HTMLElement.prototype.scrollIntoView = vi.fn()
   })
@@ -98,27 +90,41 @@ describe('LoginForm', () => {
     )
   })
 
-  it('shows the source-admin email divider when Google sign-in is enabled', () => {
-    isGoogleLoginEnabled.mockReturnValue(true)
+  it('shows the source-admin email divider when the server enables Google sign-in', async () => {
+    readAuthCapabilities.mockResolvedValue({ google_login: true })
 
     render(<LoginForm onAuthenticated={vi.fn()} />)
 
     expect(
-      screen.getByRole('button', { name: 'Continue with Google' }),
+      await screen.findByRole('button', { name: 'Continue with Google' }),
     ).toBeInTheDocument()
     expect(screen.getByText('G')).toHaveAttribute('aria-hidden', 'true')
     expect(screen.getByText('or use email')).toBeInTheDocument()
   })
 
-  it('shows Google redirect progress and disables email submit while redirecting', () => {
-    isGoogleLoginEnabled.mockReturnValue(true)
+  it('keeps password sign-in available when capabilities cannot be loaded', async () => {
+    readAuthCapabilities.mockRejectedValue(new Error('network unavailable'))
+
+    render(<LoginForm onAuthenticated={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(readAuthCapabilities).toHaveBeenCalledOnce()
+    })
+    expect(
+      screen.queryByRole('button', { name: 'Continue with Google' }),
+    ).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Sign in' })).toBeEnabled()
+  })
+
+  it('shows Google redirect progress and disables email submit while redirecting', async () => {
+    readAuthCapabilities.mockResolvedValue({ google_login: true })
     const assign = vi.fn()
     vi.stubGlobal('location', { assign })
 
     render(<LoginForm onAuthenticated={vi.fn()} nextPath='/dashboard' />)
 
     fireEvent.click(
-      screen.getByRole('button', { name: 'Continue with Google' }),
+      await screen.findByRole('button', { name: 'Continue with Google' }),
     )
 
     expect(buildGoogleLoginURL).toHaveBeenCalledWith('/dashboard')

--- a/admin-spa/src/components/auth/login-form.tsx
+++ b/admin-spa/src/components/auth/login-form.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useId, useState } from 'react'
+import { useCallback, useEffect, useId, useState } from 'react'
 import { Building2Icon, LockKeyholeIcon } from 'lucide-react'
 import type { FormEvent } from 'react'
 
@@ -17,9 +17,12 @@ import {
 import { readAuthDisplayError } from '@/lib/auth-errors'
 import { useInputValue } from '@/hooks/use-input-value'
 import { useSubmitStatus } from '@/hooks/use-submit-status'
-import { buildGoogleLoginURL, loginWithPassword } from '@/lib/auth-client'
+import {
+  buildGoogleLoginURL,
+  loginWithPassword,
+  readAuthCapabilities,
+} from '@/lib/auth-client'
 import { getAuthErrorMessage } from '@/lib/auth-feedback'
-import { isGoogleLoginEnabled } from '@/lib/login-settings'
 
 interface LoginFormProps {
   authError?: string
@@ -38,8 +41,29 @@ export function LoginForm({
   const [tenantID, setTenantID] = useState('')
   const [tenantChoices, setTenantChoices] = useState<Array<SchoolChoice>>([])
   const [isGooglePending, setGooglePending] = useState(false)
+  const [showGoogleLogin, setShowGoogleLogin] = useState(false)
   const { beginSubmit, error, finishSubmit, isPending, setError } =
     useSubmitStatus(getAuthErrorMessage(authError))
+
+  useEffect(() => {
+    let active = true
+
+    readAuthCapabilities()
+      .then((capabilities) => {
+        if (active) {
+          setShowGoogleLogin(capabilities.google_login)
+        }
+      })
+      .catch(() => {
+        if (active) {
+          setShowGoogleLogin(false)
+        }
+      })
+
+    return () => {
+      active = false
+    }
+  }, [])
 
   const submit = useCallback(
     (event: FormEvent<HTMLFormElement>) => {
@@ -92,8 +116,6 @@ export function LoginForm({
     setGooglePending(true)
     window.location.assign(buildGoogleLoginURL(nextPath))
   }, [isGooglePending, isPending, nextPath])
-
-  const showGoogleLogin = isGoogleLoginEnabled()
 
   return (
     <form

--- a/admin-spa/src/lib/auth-client.test.ts
+++ b/admin-spa/src/lib/auth-client.test.ts
@@ -5,8 +5,39 @@ import {
   buildGoogleLoginURL,
   loginWithPassword,
   logout,
+  readAuthCapabilities,
   readAuthSession,
 } from './auth-client'
+
+describe('readAuthCapabilities', () => {
+  it('reads server-owned Google login availability', async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ google_login: true }), { status: 200 }),
+      )
+
+    await expect(readAuthCapabilities(fetcher)).resolves.toEqual({
+      google_login: true,
+    })
+    expect(fetcher).toHaveBeenCalledWith('/api/auth/capabilities', {
+      credentials: 'include',
+      cache: 'no-store',
+    })
+  })
+
+  it('rejects malformed capability responses', async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ google_login: 'yes' }), { status: 200 }),
+      )
+
+    await expect(readAuthCapabilities(fetcher)).rejects.toMatchObject({
+      name: 'AuthContractError',
+    })
+  })
+})
 
 describe('readAuthSession', () => {
   it('reads the cookie-backed admin session', async () => {

--- a/admin-spa/src/lib/auth-client.ts
+++ b/admin-spa/src/lib/auth-client.ts
@@ -40,6 +40,33 @@ export type LoginResult =
     }
   | TenantRequiredResult
 
+/** Auth methods that the running backend is ready to serve. */
+export interface AuthCapabilities {
+  google_login: boolean
+}
+
+/** Reads runtime auth availability without exposing provider credentials. */
+export async function readAuthCapabilities(
+  fetcher: typeof fetch = fetch,
+): Promise<AuthCapabilities> {
+  const response = await fetcher('/api/auth/capabilities', {
+    credentials: 'include',
+    cache: 'no-store',
+  })
+
+  if (!response.ok) {
+    throw new Error(`Auth capabilities request failed: ${response.status}`)
+  }
+
+  const payload: unknown = await response.json()
+
+  if (!isAuthCapabilities(payload)) {
+    throw new AuthContractError('Invalid auth capabilities response')
+  }
+
+  return payload
+}
+
 export async function readAuthSession(
   fetcher: typeof fetch = fetch,
 ): Promise<AuthSession | null> {
@@ -224,4 +251,8 @@ function readPayloadError(payload: unknown): string | undefined {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null
+}
+
+function isAuthCapabilities(value: unknown): value is AuthCapabilities {
+  return isRecord(value) && typeof value.google_login === 'boolean'
 }

--- a/admin-spa/src/lib/login-settings.ts
+++ b/admin-spa/src/lib/login-settings.ts
@@ -1,9 +1,0 @@
-interface LoginEnv {
-  VITE_PAI_AUTH_GOOGLE_LOGIN_ENABLED?: string
-}
-
-export function isGoogleLoginEnabled(env?: LoginEnv): boolean {
-  const source = env ?? (import.meta.env as LoginEnv)
-
-  return source.VITE_PAI_AUTH_GOOGLE_LOGIN_ENABLED === 'true'
-}

--- a/internal/auth/google_oidc_test.go
+++ b/internal/auth/google_oidc_test.go
@@ -12,7 +12,29 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 )
+
+func TestPostgresServiceCapabilitiesRequireCompleteGoogleConfig(t *testing.T) {
+	svc := newPostgresService(nil, time.Hour, nil)
+
+	svc.ConfigureGoogleOAuth(GoogleOAuthProviderConfig{
+		ClientID:     "google-client",
+		DiscoveryURL: "https://accounts.google.com/.well-known/openid-configuration",
+	})
+	if svc.Capabilities().GoogleLogin {
+		t.Fatal("GoogleLogin = true without client secret")
+	}
+
+	svc.ConfigureGoogleOAuth(GoogleOAuthProviderConfig{
+		ClientID:     "google-client",
+		ClientSecret: "google-secret",
+		DiscoveryURL: "https://accounts.google.com/.well-known/openid-configuration",
+	})
+	if !svc.Capabilities().GoogleLogin {
+		t.Fatal("GoogleLogin = false with complete provider config")
+	}
+}
 
 func TestRewriteLocalOIDCTransportEndpoints(t *testing.T) {
 	doc := googleDiscoveryDocument{

--- a/internal/auth/postgres.go
+++ b/internal/auth/postgres.go
@@ -55,6 +55,13 @@ func (s *PostgresService) ConfigureGoogleOAuth(cfg GoogleOAuthProviderConfig) {
 	s.google = NewGoogleOAuthProvider(cfg, s.httpClient, s.now)
 }
 
+// Capabilities reports auth flows backed by complete runtime configuration.
+func (s *PostgresService) Capabilities() Capabilities {
+	return Capabilities{
+		GoogleLogin: s.google != nil && s.google.Configured(),
+	}
+}
+
 func (s *PostgresService) ConfigureInviteEmail(sender mailer.Sender) {
 	s.inviteMailSender = sender
 }

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -142,8 +142,14 @@ type GoogleCallbackResult struct {
 	Session      *Session
 }
 
+// Capabilities describes auth flows currently configured by the server.
+type Capabilities struct {
+	GoogleLogin bool `json:"google_login"`
+}
+
 // Service defines the auth flows needed by the HTTP layer.
 type Service interface {
+	Capabilities() Capabilities
 	Login(ctx context.Context, req LoginRequest) (Session, error)
 	AcceptInvite(ctx context.Context, req AcceptInviteRequest) (Session, error)
 	IssueInvite(ctx context.Context, req IssueInviteRequest) (InviteRecord, error)
@@ -163,6 +169,10 @@ type noopService struct{}
 // NewNoopService returns a placeholder auth service until the DB-backed auth flow lands.
 func NewNoopService() Service {
 	return noopService{}
+}
+
+func (noopService) Capabilities() Capabilities {
+	return Capabilities{}
 }
 
 func (noopService) Login(_ context.Context, _ LoginRequest) (Session, error) {

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -29,6 +29,10 @@ func TestTenantRequiredErrorWrapsSentinel(t *testing.T) {
 func TestNoopServiceReturnsNotImplemented(t *testing.T) {
 	svc := NewNoopService()
 
+	if capabilities := svc.Capabilities(); capabilities.GoogleLogin {
+		t.Fatal("Capabilities().GoogleLogin = true, want false")
+	}
+
 	_, err := svc.Login(context.Background(), LoginRequest{})
 	if !errors.Is(err, ErrNotImplemented) {
 		t.Fatalf("Login() error = %v, want ErrNotImplemented", err)

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -227,6 +227,7 @@ func (p tenantAdminDataSourceProvider) ForRequest(r *http.Request) (adminDataSou
 }
 
 type authService interface {
+	Capabilities() auth.Capabilities
 	Login(ctx context.Context, req auth.LoginRequest) (auth.Session, error)
 	AcceptInvite(ctx context.Context, req auth.AcceptInviteRequest) (auth.Session, error)
 	IssueInvite(ctx context.Context, req auth.IssueInviteRequest) (auth.InviteRecord, error)
@@ -387,6 +388,7 @@ func newHandlerWithAdminProvider(adminProvider adminDataSourceProvider, joinSour
 		authenticated,
 		auth.RequireRoles(auth.RoleAdmin),
 	)
+	mux.Handle("GET /api/auth/capabilities", handleAuthCapabilities(authSvc))
 	mux.Handle("POST /api/auth/login", handleAuthLogin(authSvc, canManageAISettings))
 	mux.Handle("GET /api/auth/google/start", handleAuthGoogleStart(authSvc))
 	mux.Handle("GET /api/auth/google/callback", handleAuthGoogleCallback(authSvc))
@@ -1587,6 +1589,12 @@ func handleAuthLogin(authSvc authService, canManageAISettings func(auth.Role) bo
 		}
 
 		writeAuthSessionResponse(w, r, http.StatusOK, resp, canManageAISettings)
+	}
+}
+
+func handleAuthCapabilities(authSvc authService) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusOK, authSvc.Capabilities())
 	}
 }
 

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -1083,6 +1083,27 @@ func TestAuthLogoutEndpointRejectsGET(t *testing.T) {
 	}
 }
 
+func TestAuthCapabilitiesReflectConfiguredProviders(t *testing.T) {
+	authSvc := &stubAuthService{
+		capabilities: auth.Capabilities{GoogleLogin: true},
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/capabilities", nil)
+	rec := httptest.NewRecorder()
+
+	newHandlerWithServices(stubAdminAPI{}, &chatGatewayStub{}, authSvc, "change-me-in-production", time.Hour).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	var payload auth.Capabilities
+	if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode capabilities: %v", err)
+	}
+	if !payload.GoogleLogin {
+		t.Fatal("google_login = false, want true")
+	}
+}
+
 func TestAuthGoogleStartEndpointRedirectsToProvider(t *testing.T) {
 	authSvc := &stubAuthService{
 		googleStartURL: "https://accounts.google.com/o/oauth2/v2/auth?state=abc",
@@ -1930,6 +1951,7 @@ func (c *chatGatewayStub) Send(_ context.Context, msg outboundMessage) error {
 }
 
 type stubAuthService struct {
+	capabilities      auth.Capabilities
 	loginReq          auth.LoginRequest
 	loginResp         auth.Session
 	loginErr          error
@@ -1968,6 +1990,10 @@ type stubAuthService struct {
 	identitiesErr     error
 	logoutToken       string
 	logoutErr         error
+}
+
+func (s *stubAuthService) Capabilities() auth.Capabilities {
+	return s.capabilities
 }
 
 func (s *stubAuthService) Login(_ context.Context, req auth.LoginRequest) (auth.Session, error) {

--- a/internal/server/security.go
+++ b/internal/server/security.go
@@ -86,7 +86,9 @@ func withAPIRateLimit(next http.Handler, now func() time.Time, apiLimiter, authL
 
 		limiter := apiLimiter
 		keyPrefix := "api"
-		if strings.HasPrefix(r.URL.Path, "/api/auth/") {
+		authRequest := strings.HasPrefix(r.URL.Path, "/api/auth/")
+		capabilitiesRead := r.Method == http.MethodGet && r.URL.Path == "/api/auth/capabilities"
+		if authRequest && !capabilitiesRead {
 			limiter = authLimiter
 			keyPrefix = "auth"
 		}

--- a/internal/server/security_test.go
+++ b/internal/server/security_test.go
@@ -70,6 +70,40 @@ func TestWithAPIRateLimit_AuthEndpointReturns429(t *testing.T) {
 	}
 }
 
+func TestWithAPIRateLimit_CapabilitiesDoNotConsumeAuthBudget(t *testing.T) {
+	apiLimiter := newFixedWindowLimiter(100, time.Minute)
+	authLimiter := newFixedWindowLimiter(1, time.Minute)
+	now := time.Date(2026, 4, 9, 10, 0, 0, 0, time.UTC)
+
+	handler := withAPIRateLimit(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}), func() time.Time { return now }, apiLimiter, authLimiter)
+
+	capabilitiesReq := httptest.NewRequest(http.MethodGet, "/api/auth/capabilities", nil)
+	capabilitiesReq.RemoteAddr = "203.0.113.10:43123"
+	capabilitiesRec := httptest.NewRecorder()
+	handler.ServeHTTP(capabilitiesRec, capabilitiesReq)
+	if capabilitiesRec.Code != http.StatusOK {
+		t.Fatalf("capabilities status = %d, want %d", capabilitiesRec.Code, http.StatusOK)
+	}
+
+	loginReq := httptest.NewRequest(http.MethodPost, "/api/auth/login", nil)
+	loginReq.RemoteAddr = "203.0.113.10:43123"
+	loginRec := httptest.NewRecorder()
+	handler.ServeHTTP(loginRec, loginReq)
+	if loginRec.Code != http.StatusOK {
+		t.Fatalf("first login status = %d, want %d", loginRec.Code, http.StatusOK)
+	}
+
+	secondLoginReq := httptest.NewRequest(http.MethodPost, "/api/auth/login", nil)
+	secondLoginReq.RemoteAddr = "203.0.113.10:43123"
+	secondLoginRec := httptest.NewRecorder()
+	handler.ServeHTTP(secondLoginRec, secondLoginReq)
+	if secondLoginRec.Code != http.StatusTooManyRequests {
+		t.Fatalf("second login status = %d, want %d", secondLoginRec.Code, http.StatusTooManyRequests)
+	}
+}
+
 func TestWithSecurityHeaders(t *testing.T) {
 	handler := withSecurityHeaders(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)

--- a/site/src/content/docs/getting-started/configuration.md
+++ b/site/src/content/docs/getting-started/configuration.md
@@ -56,6 +56,10 @@ Set `LEARN_AI_DEFAULT_PROVIDER` to choose which provider handles requests by def
 | `PAI_AUTH_GOOGLE_CLIENT_ID` | Google OAuth client ID (admin panel) |
 | `PAI_AUTH_GOOGLE_CLIENT_SECRET` | Google OAuth client secret |
 
+The admin SPA shows Google sign-in automatically when both Google credentials
+are configured. Register `/api/auth/google/callback` on the public admin origin
+as an authorized redirect URI in Google Cloud.
+
 ## Feature Flags
 
 | Variable | Default | Description |


### PR DESCRIPTION
## Summary
- expose runtime auth capabilities from the backend so Google availability has one source of truth
- show Google sign-in in the admin SPA only when the running server is fully configured, while preserving password sign-in on capability failures
- remove the stale SPA build-time flag and document Google credential and callback setup

## Testing
- `go test ./internal/auth ./internal/server`
- `go vet ./internal/auth ./internal/server`
- `pnpm typecheck`
- `pnpm exec vitest run src/lib/auth-client.test.ts src/components/auth/login-form.test.tsx`
- focused ESLint and Prettier checks
- `pnpm build`
- `git diff --check`