### PR TITLE
ci: run only affected checks in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,26 +6,26 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  test:
+  admin:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
 
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.26.2
+
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version: "1.25"
-
-      - name: Install pnpm
-        working-directory: admin
-        run: |
-          corepack enable
-          corepack prepare pnpm@10.26.2 --activate
+          cache: pnpm
+          cache-dependency-path: admin/pnpm-lock.yaml
 
       - name: Validate admin lockfile
         working-directory: admin
@@ -39,27 +39,15 @@ jobs:
         working-directory: admin
         run: pnpm test
 
-      - name: Install Playwright browsers
-        if: github.event_name != 'pull_request'
-        timeout-minutes: 10
-        working-directory: admin
-        run: pnpm exec playwright install --with-deps chromium
+  go:
+    runs-on: ubuntu-latest
 
-      - name: Admin E2E (smoke only)
-        if: github.event_name != 'pull_request'
-        timeout-minutes: 15
-        working-directory: admin
-        run: pnpm test:e2e
+    steps:
+      - uses: actions/checkout@v4
 
-      - name: Upload Playwright report
-        if: failure()
-        uses: actions/upload-artifact@v4
+      - uses: actions/setup-go@v5
         with:
-          name: playwright-report
-          path: |
-            admin/playwright-report
-            admin/test-results
-          if-no-files-found: ignore
+          go-version: "1.25"
 
       - name: Download dependencies
         run: go mod download
@@ -70,7 +58,7 @@ jobs:
       - name: Test
         run: go test ./... -count=1
 
-      - name: Install golangci-lint
+      - name: Lint
         uses: golangci/golangci-lint-action@v7
         with:
           version: v2.4.0
@@ -109,9 +97,15 @@ jobs:
         with:
           submodules: true
 
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.26.2
+
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
+          cache: pnpm
+          cache-dependency-path: admin/pnpm-lock.yaml
 
       - uses: actions/setup-go@v5
         with:
@@ -153,12 +147,6 @@ jobs:
           PAI_AUTH_BOOTSTRAP_ADMIN_EMAIL: admin@example.com
           PAI_AUTH_BOOTSTRAP_ADMIN_PASSWORD: demo-password
 
-      - name: Install pnpm
-        working-directory: admin
-        run: |
-          corepack enable
-          corepack prepare pnpm@10.26.2 --activate
-
       - name: Install admin dependencies
         working-directory: admin
         run: pnpm install --frozen-lockfile --ignore-scripts
@@ -196,10 +184,19 @@ jobs:
 
   docker:
     runs-on: ubuntu-latest
-    needs: test
+    if: github.event_name == 'pull_request'
 
     steps:
       - uses: actions/checkout@v4
 
+      - uses: docker/setup-buildx-action@v3
+
       - name: Build Docker image
-        run: docker build -f deploy/docker/Dockerfile -t pai-bot:ci .
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/docker/Dockerfile
+          push: false
+          tags: pai-bot:ci
+          cache-from: type=gha,scope=ci-app
+          cache-to: type=gha,mode=max,scope=ci-app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,54 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  admin:
+  changes:
     runs-on: ubuntu-latest
+    outputs:
+      admin: ${{ steps.filter.outputs.admin }}
+      backend: ${{ steps.filter.outputs.backend }}
+      docker: ${{ steps.filter.outputs.docker }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            admin:
+              - 'admin/**'
+              - '.github/workflows/ci.yml'
+            backend:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - '.golangci.yml'
+              - 'migrations/**'
+              - 'oss/**'
+              - '.github/workflows/ci.yml'
+            docker:
+              - 'cmd/**'
+              - 'internal/**'
+              - 'go.mod'
+              - 'go.sum'
+              - 'migrations/**'
+              - 'oss/**'
+              - 'deploy/docker/Dockerfile'
+              - '.dockerignore'
+              - '.github/workflows/ci.yml'
+
+  admin:
+    name: Admin ${{ matrix.check }}
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.admin == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - check: lint
+            command: lint
+          - check: test
+            command: test
 
     steps:
       - uses: actions/checkout@v4
@@ -31,16 +77,23 @@ jobs:
         working-directory: admin
         run: pnpm install --frozen-lockfile --ignore-scripts
 
-      - name: Admin lint
+      - name: Run ${{ matrix.check }}
         working-directory: admin
-        run: pnpm lint
-
-      - name: Admin test
-        working-directory: admin
-        run: pnpm test
+        run: pnpm ${{ matrix.command }}
 
   go:
+    name: Go ${{ matrix.check }}
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - check: vet
+            command: go vet ./...
+          - check: test
+            command: go test ./... -count=1
 
     steps:
       - uses: actions/checkout@v4
@@ -52,11 +105,20 @@ jobs:
       - name: Download dependencies
         run: go mod download
 
-      - name: Vet
-        run: go vet ./...
+      - name: Run ${{ matrix.check }}
+        run: ${{ matrix.command }}
 
-      - name: Test
-        run: go test ./... -count=1
+  go-lint:
+    name: Go lint
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
 
       - name: Lint
         uses: golangci/golangci-lint-action@v7
@@ -65,7 +127,11 @@ jobs:
 
   e2e-backend:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
+    needs: changes
+    if: >-
+      github.event_name != 'pull_request' &&
+      (needs.changes.outputs.admin == 'true' ||
+      needs.changes.outputs.backend == 'true')
 
     services:
       postgres:
@@ -184,7 +250,10 @@ jobs:
 
   docker:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    needs: changes
+    if: >-
+      github.event_name == 'pull_request' &&
+      needs.changes.outputs.docker == 'true'
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- run admin and Go checks concurrently instead of serially
- skip unaffected admin, backend, and Docker checks using changed paths
- cache pnpm dependencies and Docker build layers
- cancel superseded CI runs and avoid duplicate main-branch builds

## Testing

- actionlint .github/workflows/ci.yml
- yamllint .github/workflows/ci.yml
- YAML parse validation
- git diff --check