### PR TITLE
feat(terminal-chat): deliver focused pages

### DIFF
--- a/cmd/server/focused_page_policy_test.go
+++ b/cmd/server/focused_page_policy_test.go
@@ -1,0 +1,32 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"testing"
+
+	"github.com/p-n-ai/pai-bot/internal/chat"
+)
+
+func TestFocusedPageChannelPolicy(t *testing.T) {
+	tests := []struct {
+		name    string
+		devMode bool
+		channel string
+		want    bool
+	}{
+		{name: "telegram production", channel: "telegram", want: true},
+		{name: "terminal websocket in dev", devMode: true, channel: "websocket", want: true},
+		{name: "embed websocket in production", channel: "websocket", want: false},
+		{name: "whatsapp", devMode: true, channel: "whatsapp", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := focusedPageChannelEnabled(tt.devMode, chat.InboundMessage{Channel: tt.channel}); got != tt.want {
+				t.Fatalf("focusedPageChannelEnabled(%t, %q) = %t, want %t", tt.devMode, tt.channel, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -34,6 +34,10 @@ import (
 	"github.com/p-n-ai/pai-bot/internal/tenant"
 )
 
+func focusedPageChannelEnabled(devMode bool, msg chat.InboundMessage) bool {
+	return msg.Channel == "telegram" || (devMode && msg.Channel == "websocket")
+}
+
 func main() {
 	cfg, err := config.Load()
 	if err != nil {
@@ -192,7 +196,7 @@ func main() {
 				FeatureFlags:         flagsProvider,
 				FocusedPages:         focusedPageService,
 				FocusedPageEnabled: func(msg chat.InboundMessage) bool {
-					return msg.Channel == "telegram"
+					return focusedPageChannelEnabled(cfg.Runtime.DevMode, msg)
 				},
 			})
 

--- a/cmd/terminal-chat/main.go
+++ b/cmd/terminal-chat/main.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"strings"
@@ -21,6 +22,7 @@ import (
 	"github.com/p-n-ai/pai-bot/internal/ai"
 	"github.com/p-n-ai/pai-bot/internal/chat"
 	"github.com/p-n-ai/pai-bot/internal/curriculum"
+	"github.com/p-n-ai/pai-bot/internal/focusedpage"
 	"github.com/p-n-ai/pai-bot/internal/platform/airouter"
 	"github.com/p-n-ai/pai-bot/internal/platform/config"
 	"github.com/p-n-ai/pai-bot/internal/platform/featureflags"
@@ -45,7 +47,7 @@ func main() {
 
 	flag.StringVar(&userID, "user-id", "terminal-user", "stable user id for the terminal session")
 	flag.StringVar(&language, "lang", "", "preferred language override (en, ms, zh)")
-	flag.StringVar(&channel, "channel", "terminal", "channel name for store scoping (use 'telegram' to share state with the live bot)")
+	flag.StringVar(&channel, "channel", "terminal", "channel name for store scoping (use 'telegram' to share live bot state and focused-page behavior)")
 	flag.BoolVar(&memory, "memory", false, "use in-memory session state instead of PostgreSQL")
 	flag.BoolVar(&multi, "multi", false, "multi-user mode: prefix lines with N: to switch users (e.g., 1:hello, 2:/challenge ABC)")
 	flag.IntVar(&userCount, "users", 2, "number of simulated users in multi-user mode")
@@ -114,6 +116,17 @@ func main() {
 	}
 	defer cleanup()
 
+	var focusedPageService *focusedpage.Service
+	if strings.TrimSpace(cfg.FocusedPage.BaseURL) != "" && state.DB != nil {
+		focusedPageService, err = focusedpage.NewService(
+			focusedpage.NewPostgresStore(state.DB.Pool), cfg.FocusedPage.BaseURL, []byte(cfg.Auth.JWTSecret), time.Now,
+		)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "initialize focused pages: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
 	if lang := strings.TrimSpace(language); lang != "" {
 		if err := state.Store.SetUserPreferredLanguage(userID, lang); err != nil {
 			fmt.Fprintf(os.Stderr, "set preferred language: %v\n", err)
@@ -138,8 +151,13 @@ func main() {
 		DisableMultiLanguage: cfg.Runtime.DisableMultiLanguage,
 		Goals:                goalStore,
 		Challenges:           challengeStore,
+		TenantID:             state.TenantID,
 		DevMode:              cfg.Runtime.DevMode,
 		FeatureFlags:         func() featureflags.Features { return cfg.FeatureFlags },
+		FocusedPages:         focusedPageService,
+		FocusedPageEnabled: func(msg chat.InboundMessage) bool {
+			return msg.Channel == "telegram"
+		},
 	}
 	if cfg.Runtime.DevMode {
 		engineCfg.TurnHookNotice = func(notice agent.TurnHookCallNotice) {
@@ -255,15 +273,15 @@ func newConversationHistory(userID, channel string) *conversationHistory {
 	}
 }
 
-func (p *historyProcessor) ProcessMessage(ctx context.Context, msg chat.InboundMessage) (string, error) {
+func (p *historyProcessor) ProcessTurn(ctx context.Context, msg chat.InboundMessage) (agent.TurnResult, error) {
 	p.append(msg.UserID, msg.Channel, "student", msg.Text)
-	resp, err := p.inner.ProcessMessage(ctx, msg)
+	result, err := p.inner.ProcessTurn(ctx, msg)
 	if err != nil {
 		p.append(msg.UserID, msg.Channel, "error", err.Error())
-		return resp, err
+		return result, err
 	}
-	p.append(msg.UserID, msg.Channel, "assistant", strings.TrimSpace(resp))
-	return resp, nil
+	p.append(msg.UserID, msg.Channel, "assistant", strings.TrimSpace(result.Text))
+	return result, nil
 }
 
 func (p *historyProcessor) append(userID, channel, role, text string) {
@@ -365,8 +383,13 @@ type wsInboundMsg struct {
 
 // wsOutboundMsg mirrors the WebSocket protocol envelope for incoming server messages.
 type wsOutboundMsg struct {
-	Type string `json:"type"`
-	Text string `json:"text,omitempty"`
+	Type        string         `json:"type"`
+	Text        string         `json:"text,omitempty"`
+	FocusedPage *wsFocusedPage `json:"focused_page,omitempty"`
+}
+
+type wsFocusedPage struct {
+	URL string `json:"url"`
 }
 
 // runWSClient connects to a pai-bot WebSocket server and runs an interactive
@@ -424,7 +447,13 @@ func runWSClient(serverURL, userID string) error {
 
 			switch msg.Type {
 			case "response":
-				fmt.Printf("\nBot: %s\n\nYou: ", msg.Text)
+				fmt.Println()
+				if err := writeWSResponse(os.Stdout, "Bot: ", msg); err != nil {
+					fmt.Fprintf(os.Stderr, "\nwrite response: %v\n", err)
+					cancel()
+					return
+				}
+				fmt.Print("\nYou: ")
 			case "notification":
 				fmt.Printf("\n[notification] %s\n\nYou: ", msg.Text)
 			case "typing":
@@ -455,6 +484,10 @@ func runWSClient(serverURL, userID string) error {
 }
 
 func runWSClientOnce(serverURL, userID, text string) error {
+	return runWSClientOnceTo(serverURL, userID, text, os.Stdout)
+}
+
+func runWSClientOnceTo(serverURL, userID, text string, out io.Writer) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
@@ -489,9 +522,19 @@ func runWSClientOnce(serverURL, userID, text string) error {
 		if resp.Type == "typing" {
 			continue
 		}
-		fmt.Printf("%s\n", resp.Text)
+		return writeWSResponse(out, "", resp)
+	}
+}
+
+func writeWSResponse(out io.Writer, prefix string, response wsOutboundMsg) error {
+	if _, err := fmt.Fprintf(out, "%s%s\n", prefix, response.Text); err != nil {
+		return err
+	}
+	if response.FocusedPage == nil || strings.TrimSpace(response.FocusedPage.URL) == "" {
 		return nil
 	}
+	_, err := fmt.Fprintf(out, "Focused page: %s\n", strings.TrimSpace(response.FocusedPage.URL))
+	return err
 }
 
 func readExpectedWSMessage(ctx context.Context, conn *websocket.Conn, want string) error {

--- a/cmd/terminal-chat/main_test.go
+++ b/cmd/terminal-chat/main_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/p-n-ai/pai-bot/internal/agent"
 	"github.com/p-n-ai/pai-bot/internal/chat"
 	"github.com/p-n-ai/pai-bot/internal/focusedpage"
+	"github.com/p-n-ai/pai-bot/internal/server"
 )
 
 type turnProcessorStub struct {
@@ -107,20 +108,22 @@ func TestWriteWSResponseWithoutFocusedPagePreservesPlainText(t *testing.T) {
 
 func TestWSClientOnceRendersTurnWithAndWithoutFocusedPage(t *testing.T) {
 	tests := []struct {
-		name     string
-		response chat.OutboundMessage
-		want     string
+		name   string
+		result agent.TurnResult
+		want   string
 	}{
 		{
-			name:     "plain text",
-			response: chat.OutboundMessage{Text: "Plain tutor reply"},
-			want:     "Plain tutor reply\n",
+			name:   "plain text",
+			result: agent.TurnResult{Text: "Plain tutor reply"},
+			want:   "Plain tutor reply\n",
 		},
 		{
 			name: "focused page",
-			response: chat.OutboundMessage{
-				Text:           "Your report is ready.",
-				FocusedPageURL: "https://pages.example/a/page-1#private-capability",
+			result: agent.TurnResult{
+				Text: "Your report is ready.",
+				FocusedPage: &focusedpage.Artifact{
+					URL: "https://pages.example/a/page-1#private-capability",
+				},
 			},
 			want: "Your report is ready.\nFocused page: https://pages.example/a/page-1#private-capability\n",
 		},
@@ -129,8 +132,11 @@ func TestWSClientOnceRendersTurnWithAndWithoutFocusedPage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			channel := chat.NewWSChannel()
+			gateway := chat.NewGateway()
+			gateway.Register("websocket", channel)
+			deliverer := server.NewGatewayTurnDeliverer(gateway, agent.NewMemoryStore())
 			if err := channel.Start(context.Background(), func(msg chat.InboundMessage) {
-				_ = channel.SendMessage(context.Background(), msg.UserID, tt.response)
+				_ = deliverer.DeliverTurn(context.Background(), msg, tt.result)
 			}); err != nil {
 				t.Fatalf("Start() error = %v", err)
 			}

--- a/cmd/terminal-chat/main_test.go
+++ b/cmd/terminal-chat/main_test.go
@@ -4,9 +4,24 @@
 package main
 
 import (
+	"context"
+	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
+
+	"github.com/p-n-ai/pai-bot/internal/agent"
+	"github.com/p-n-ai/pai-bot/internal/chat"
+	"github.com/p-n-ai/pai-bot/internal/focusedpage"
 )
+
+type turnProcessorStub struct {
+	result agent.TurnResult
+}
+
+func (s turnProcessorStub) ProcessTurn(context.Context, chat.InboundMessage) (agent.TurnResult, error) {
+	return s.result, nil
+}
 
 func TestWriteConversationHistoryTightensExistingFilePermissions(t *testing.T) {
 	path := t.TempDir() + "/history.json"
@@ -31,5 +46,108 @@ func TestWriteConversationHistoryTightensExistingFilePermissions(t *testing.T) {
 	}
 	if got := info.Mode().Perm(); got != 0o600 {
 		t.Fatalf("history permissions = %v, want 0600", got)
+	}
+}
+
+func TestHistoryProcessorPreservesArtifactWithoutRecordingCapabilityURL(t *testing.T) {
+	artifact := &focusedpage.Artifact{URL: "https://pages.example/a/page-1#private-capability"}
+	history := newConversationHistory("u1", "telegram")
+	processor := &historyProcessor{
+		inner:   turnProcessorStub{result: agent.TurnResult{Text: "Your report is ready.", FocusedPage: artifact}},
+		history: history,
+	}
+
+	result, err := processor.ProcessTurn(context.Background(), chat.InboundMessage{
+		Channel: "telegram",
+		UserID:  "u1",
+		Text:    "make my report",
+	})
+	if err != nil {
+		t.Fatalf("ProcessTurn() error = %v", err)
+	}
+	if result.FocusedPage != artifact {
+		t.Fatal("ProcessTurn() did not preserve the focused-page artifact")
+	}
+
+	snapshot := history.snapshot(0)
+	if len(snapshot.Turns) != 2 || snapshot.Turns[1].Text != "Your report is ready." {
+		t.Fatalf("history turns = %#v, want student and assistant text", snapshot.Turns)
+	}
+	for _, turn := range snapshot.Turns {
+		if strings.Contains(turn.Text, "private-capability") || strings.Contains(turn.Text, artifact.URL) {
+			t.Fatalf("history leaked focused-page capability in %#v", turn)
+		}
+	}
+}
+
+func TestWriteWSResponseWithFocusedPage(t *testing.T) {
+	var output strings.Builder
+	err := writeWSResponse(&output, "", wsOutboundMsg{
+		Type:        "response",
+		Text:        "Your report is ready.",
+		FocusedPage: &wsFocusedPage{URL: "https://pages.example/a/page-1#private-capability"},
+	})
+	if err != nil {
+		t.Fatalf("writeWSResponse() error = %v", err)
+	}
+	if got, want := output.String(), "Your report is ready.\nFocused page: https://pages.example/a/page-1#private-capability\n"; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestWriteWSResponseWithoutFocusedPagePreservesPlainText(t *testing.T) {
+	var output strings.Builder
+	if err := writeWSResponse(&output, "", wsOutboundMsg{Type: "response", Text: "Plain tutor reply"}); err != nil {
+		t.Fatalf("writeWSResponse() error = %v", err)
+	}
+	if got, want := output.String(), "Plain tutor reply\n"; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestWSClientOnceRendersTurnWithAndWithoutFocusedPage(t *testing.T) {
+	tests := []struct {
+		name     string
+		response chat.OutboundMessage
+		want     string
+	}{
+		{
+			name:     "plain text",
+			response: chat.OutboundMessage{Text: "Plain tutor reply"},
+			want:     "Plain tutor reply\n",
+		},
+		{
+			name: "focused page",
+			response: chat.OutboundMessage{
+				Text:           "Your report is ready.",
+				FocusedPageURL: "https://pages.example/a/page-1#private-capability",
+			},
+			want: "Your report is ready.\nFocused page: https://pages.example/a/page-1#private-capability\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			channel := chat.NewWSChannel()
+			if err := channel.Start(context.Background(), func(msg chat.InboundMessage) {
+				_ = channel.SendMessage(context.Background(), msg.UserID, tt.response)
+			}); err != nil {
+				t.Fatalf("Start() error = %v", err)
+			}
+			server := httptest.NewServer(channel.Handler())
+			t.Cleanup(func() {
+				_ = channel.Stop()
+				server.Close()
+			})
+
+			var output strings.Builder
+			serverURL := "ws" + strings.TrimPrefix(server.URL, "http")
+			if err := runWSClientOnceTo(serverURL, "terminal-user", "make my report", &output); err != nil {
+				t.Fatalf("runWSClientOnceTo() error = %v", err)
+			}
+			if got := output.String(); got != tt.want {
+				t.Fatalf("output = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/agent/focused_page_tool.go
+++ b/internal/agent/focused_page_tool.go
@@ -81,7 +81,7 @@ type createFocusedPageTool struct {
 func (t *createFocusedPageTool) Definition() llm.Tool {
 	return llm.Tool{
 		Name:        createFocusedPageToolName,
-		Description: "Create one private, read-only focused message page for a goal or report. Use at most once in a turn. The server owns its recipient, layout, action, lifetime, capability, URL, and Telegram delivery.",
+		Description: "Create one private, read-only focused message page for a goal or report. Use at most once in a turn. The server owns its recipient, layout, action, lifetime, capability, URL, and channel delivery.",
 		Parameters:  json.RawMessage(`{"type":"object","additionalProperties":false,"properties":{"message":{"type":"string","minLength":1,"maxLength":4000}},"required":["message"]}`),
 	}
 }

--- a/internal/chat/gateway.go
+++ b/internal/chat/gateway.go
@@ -40,10 +40,11 @@ type InlineButton struct {
 
 // OutboundMessage is a message to send via any channel.
 type OutboundMessage struct {
-	Channel   string
-	UserID    string
-	Text      string
-	ParseMode string // "Markdown", "HTML", or ""
+	Channel        string
+	UserID         string
+	Text           string
+	FocusedPageURL string
+	ParseMode      string // "Markdown", "HTML", or ""
 	// ReplyKeyboard is Telegram-style keyboard rows. Other channels may ignore it.
 	ReplyKeyboard [][]string
 	// InlineKeyboard is Telegram inline keyboard rows. Other channels may ignore it.

--- a/internal/chat/turn_render.go
+++ b/internal/chat/turn_render.go
@@ -7,7 +7,12 @@ import "strings"
 
 // RenderTurn projects semantic tutor text and an optional artifact into channel-owned formatting.
 func RenderTurn(in InboundMessage, text, focusedPageURL string, telegramContext TelegramInlineKeyboardContext) (OutboundMessage, bool) {
-	out := OutboundMessage{Channel: in.Channel, UserID: in.UserID, Text: StripReviewActionCodes(text)}
+	out := OutboundMessage{
+		Channel:        in.Channel,
+		UserID:         in.UserID,
+		Text:           StripReviewActionCodes(text),
+		FocusedPageURL: strings.TrimSpace(focusedPageURL),
+	}
 	if in.Channel == "telegram" {
 		out.Text = ConvertLaTeXToUnicode(text)
 		out.Text = NormalizeTelegramMarkdown(out.Text)

--- a/internal/chat/turn_render_artifact_test.go
+++ b/internal/chat/turn_render_artifact_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package chat
+
+import "testing"
+
+func TestRenderTurnPreservesFocusedPageForChannelDelivery(t *testing.T) {
+	pageURL := "https://pages.example/a/page-1#private-capability"
+	out, ok := RenderTurn(
+		InboundMessage{Channel: "websocket", UserID: "learner-1"},
+		"Your report is ready.",
+		pageURL,
+		TelegramInlineKeyboardContext{},
+	)
+	if !ok {
+		t.Fatal("RenderTurn() dropped a non-empty tutor response")
+	}
+	if out.Text != "Your report is ready." || out.FocusedPageURL != pageURL {
+		t.Fatalf("text = %q, focused page = %q", out.Text, out.FocusedPageURL)
+	}
+}
+
+func TestRenderTurnPlainTextHasNoFocusedPage(t *testing.T) {
+	out, ok := RenderTurn(
+		InboundMessage{Channel: "websocket", UserID: "learner-1"},
+		"Plain tutor reply",
+		"",
+		TelegramInlineKeyboardContext{},
+	)
+	if !ok {
+		t.Fatal("RenderTurn() dropped a non-empty tutor response")
+	}
+	if out.Text != "Plain tutor reply" || out.FocusedPageURL != "" {
+		t.Fatalf("text = %q, focused page = %q", out.Text, out.FocusedPageURL)
+	}
+}

--- a/internal/chat/websocket.go
+++ b/internal/chat/websocket.go
@@ -27,8 +27,13 @@ type wsInboundMsg struct {
 
 // wsOutboundMsg is the JSON envelope the server sends over the WebSocket.
 type wsOutboundMsg struct {
-	Type string `json:"type"`
-	Text string `json:"text,omitempty"`
+	Type        string         `json:"type"`
+	Text        string         `json:"text,omitempty"`
+	FocusedPage *wsFocusedPage `json:"focused_page,omitempty"`
+}
+
+type wsFocusedPage struct {
+	URL string `json:"url"`
 }
 
 // WSChannel implements the Channel interface for WebSocket connections.
@@ -334,10 +339,14 @@ func (ws *WSChannel) SendMessage(ctx context.Context, userID string, msg Outboun
 		return fmt.Errorf("websocket: user %q not connected", userID)
 	}
 
-	return ws.writeJSON(ctx, conn, wsOutboundMsg{
+	response := wsOutboundMsg{
 		Type: "response",
 		Text: msg.Text,
-	})
+	}
+	if pageURL := strings.TrimSpace(msg.FocusedPageURL); pageURL != "" {
+		response.FocusedPage = &wsFocusedPage{URL: pageURL}
+	}
+	return ws.writeJSON(ctx, conn, response)
 }
 
 // SendTyping sends a typing indicator to the connected user.

--- a/internal/chat/websocket_test.go
+++ b/internal/chat/websocket_test.go
@@ -110,7 +110,8 @@ func TestWSChannel_SendMessageToCorrectUser(t *testing.T) {
 
 	// Send a message to user-a.
 	ctx := context.Background()
-	err := ws.SendMessage(ctx, "user-a", OutboundMessage{Text: "for user-a"})
+	pageURL := "https://pages.example/a/page-1#private-capability"
+	err := ws.SendMessage(ctx, "user-a", OutboundMessage{Text: "for user-a", FocusedPageURL: pageURL})
 	if err != nil {
 		t.Fatalf("SendMessage: %v", err)
 	}
@@ -133,6 +134,32 @@ func TestWSChannel_SendMessageToCorrectUser(t *testing.T) {
 	}
 	if resp.Text != "for user-a" {
 		t.Errorf("expected text 'for user-a', got %q", resp.Text)
+	}
+	if resp.FocusedPage == nil || resp.FocusedPage.URL != pageURL {
+		t.Fatalf("focused page = %#v, want URL %q", resp.FocusedPage, pageURL)
+	}
+}
+
+func TestWSChannel_PlainTextResponseOmitsFocusedPage(t *testing.T) {
+	ws := NewWSChannel()
+	_ = ws.Start(context.Background(), func(InboundMessage) {})
+
+	srv := httptest.NewServer(ws.Handler())
+	defer srv.Close()
+	conn := dialAndAuth(t, "ws"+strings.TrimPrefix(srv.URL, "http"), "plain-user")
+	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "") }()
+
+	if err := ws.SendMessage(context.Background(), "plain-user", OutboundMessage{Text: "plain reply"}); err != nil {
+		t.Fatalf("SendMessage() error = %v", err)
+	}
+	readCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, data, err := conn.Read(readCtx)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if strings.Contains(string(data), "focused_page") {
+		t.Fatalf("plain response exposed focused_page field: %s", data)
 	}
 }
 
@@ -636,4 +663,3 @@ func TestWSChannel_EmbedRejectsUnlistedOrigin(t *testing.T) {
 		t.Fatal("expected dial error for unlisted origin, got nil")
 	}
 }
-

--- a/internal/terminalchat/runner.go
+++ b/internal/terminalchat/runner.go
@@ -10,12 +10,13 @@ import (
 	"io"
 	"strings"
 
+	"github.com/p-n-ai/pai-bot/internal/agent"
 	"github.com/p-n-ai/pai-bot/internal/chat"
 )
 
 // Processor handles inbound messages and returns assistant responses.
 type Processor interface {
-	ProcessMessage(ctx context.Context, msg chat.InboundMessage) (string, error)
+	ProcessTurn(ctx context.Context, msg chat.InboundMessage) (agent.TurnResult, error)
 }
 
 // Config controls the terminal chat session.
@@ -67,7 +68,7 @@ func Run(ctx context.Context, in io.Reader, out io.Writer, processor Processor, 
 			return nil
 		}
 
-		resp, err := processor.ProcessMessage(ctx, chat.InboundMessage{
+		result, err := processor.ProcessTurn(ctx, chat.InboundMessage{
 			Channel: channel,
 			UserID:  userID,
 			Text:    text,
@@ -79,8 +80,19 @@ func Run(ctx context.Context, in io.Reader, out io.Writer, processor Processor, 
 			continue
 		}
 
-		if _, err := fmt.Fprintf(out, "P&AI> %s\n", strings.TrimSpace(resp)); err != nil {
+		if err := writeTurn(out, "", result); err != nil {
 			return err
 		}
 	}
+}
+
+func writeTurn(out io.Writer, prefix string, result agent.TurnResult) error {
+	if _, err := fmt.Fprintf(out, "%sP&AI> %s\n", prefix, strings.TrimSpace(result.Text)); err != nil {
+		return err
+	}
+	if result.FocusedPage == nil || strings.TrimSpace(result.FocusedPage.URL) == "" {
+		return nil
+	}
+	_, err := fmt.Fprintf(out, "%sFocused page> %s\n", prefix, strings.TrimSpace(result.FocusedPage.URL))
+	return err
 }

--- a/internal/terminalchat/runner_multi.go
+++ b/internal/terminalchat/runner_multi.go
@@ -99,7 +99,7 @@ func RunMulti(ctx context.Context, in io.Reader, out io.Writer, processor Proces
 		userIdx, text := parseMultiInput(raw, userCount)
 		userID := userIDs[userIdx]
 
-		resp, err := processor.ProcessMessage(ctx, chat.InboundMessage{
+		result, err := processor.ProcessTurn(ctx, chat.InboundMessage{
 			Channel: channel,
 			UserID:  userID,
 			Text:    text,
@@ -111,7 +111,7 @@ func RunMulti(ctx context.Context, in io.Reader, out io.Writer, processor Proces
 			continue
 		}
 
-		if _, err := fmt.Fprintf(out, "[%s] P&AI> %s\n", userID, strings.TrimSpace(resp)); err != nil {
+		if err := writeTurn(out, "["+userID+"] ", result); err != nil {
 			return err
 		}
 	}

--- a/internal/terminalchat/runner_multi_test.go
+++ b/internal/terminalchat/runner_multi_test.go
@@ -7,13 +7,16 @@ import (
 	"context"
 	"strings"
 	"testing"
+
+	"github.com/p-n-ai/pai-bot/internal/agent"
+	"github.com/p-n-ai/pai-bot/internal/focusedpage"
 )
 
 func TestRunMulti_RoutesMessagesToDifferentUsers(t *testing.T) {
 	var output strings.Builder
 	input := strings.NewReader("1:hello from user 1\n2:hello from user 2\n/exit\n")
 	processor := &stubProcessor{
-		responses: []string{"reply to 1", "reply to 2"},
+		responses: []agent.TurnResult{{Text: "reply to 1"}, {Text: "reply to 2"}},
 	}
 
 	err := RunMulti(context.Background(), input, &output, processor, MultiConfig{
@@ -53,9 +56,7 @@ func TestRunMulti_RoutesMessagesToDifferentUsers(t *testing.T) {
 func TestRunMulti_DefaultsToUser1WhenNoPrefix(t *testing.T) {
 	var output strings.Builder
 	input := strings.NewReader("no prefix message\n/exit\n")
-	processor := &stubProcessor{
-		responses: []string{"ok"},
-	}
+	processor := &stubProcessor{responses: []agent.TurnResult{{Text: "ok"}}}
 
 	err := RunMulti(context.Background(), input, &output, processor, MultiConfig{UserCount: 2})
 	if err != nil {
@@ -76,9 +77,7 @@ func TestRunMulti_DefaultsToUser1WhenNoPrefix(t *testing.T) {
 func TestRunMulti_InvalidPrefixDefaultsToUser1(t *testing.T) {
 	var output strings.Builder
 	input := strings.NewReader("9:out of range\n/exit\n")
-	processor := &stubProcessor{
-		responses: []string{"ok"},
-	}
+	processor := &stubProcessor{responses: []agent.TurnResult{{Text: "ok"}}}
 
 	err := RunMulti(context.Background(), input, &output, processor, MultiConfig{UserCount: 2})
 	if err != nil {
@@ -119,7 +118,7 @@ func TestRunMulti_ShowsWelcomeWithUserList(t *testing.T) {
 func TestRunMulti_EOFEndsSession(t *testing.T) {
 	var output strings.Builder
 	input := strings.NewReader("1:hello\n")
-	processor := &stubProcessor{responses: []string{"hi"}}
+	processor := &stubProcessor{responses: []agent.TurnResult{{Text: "hi"}}}
 
 	err := RunMulti(context.Background(), input, &output, processor, MultiConfig{UserCount: 2})
 	if err != nil {
@@ -128,6 +127,26 @@ func TestRunMulti_EOFEndsSession(t *testing.T) {
 
 	if !strings.Contains(output.String(), "Session ended.") {
 		t.Errorf("output missing 'Session ended.', got: %s", output.String())
+	}
+}
+
+func TestRunMulti_PrintsFocusedPageForTheCorrectUser(t *testing.T) {
+	var output strings.Builder
+	processor := &stubProcessor{responses: []agent.TurnResult{{
+		Text:        "Your report is ready.",
+		FocusedPage: &focusedpage.Artifact{URL: "https://pages.example/a/page-2#private-capability"},
+	}}}
+
+	err := RunMulti(context.Background(), strings.NewReader("2:make my report\n/exit\n"), &output, processor, MultiConfig{
+		UserCount: 2,
+	})
+	if err != nil {
+		t.Fatalf("RunMulti() error = %v", err)
+	}
+
+	rendered := output.String()
+	if !strings.Contains(rendered, "[terminal-user-2] P&AI> Your report is ready.\n[terminal-user-2] Focused page> https://pages.example/a/page-2#private-capability\n") {
+		t.Fatalf("output = %q, want user-scoped tutor text and focused-page URL", rendered)
 	}
 }
 

--- a/internal/terminalchat/runner_test.go
+++ b/internal/terminalchat/runner_test.go
@@ -9,22 +9,24 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/p-n-ai/pai-bot/internal/agent"
 	"github.com/p-n-ai/pai-bot/internal/chat"
+	"github.com/p-n-ai/pai-bot/internal/focusedpage"
 )
 
 type stubProcessor struct {
-	responses []string
+	responses []agent.TurnResult
 	err       error
 	messages  []chat.InboundMessage
 }
 
-func (s *stubProcessor) ProcessMessage(_ context.Context, msg chat.InboundMessage) (string, error) {
+func (s *stubProcessor) ProcessTurn(_ context.Context, msg chat.InboundMessage) (agent.TurnResult, error) {
 	s.messages = append(s.messages, msg)
 	if s.err != nil {
-		return "", s.err
+		return agent.TurnResult{}, s.err
 	}
 	if len(s.responses) == 0 {
-		return "", nil
+		return agent.TurnResult{}, nil
 	}
 	resp := s.responses[0]
 	s.responses = s.responses[1:]
@@ -35,9 +37,9 @@ func TestRun_ForwardsConversationAndPrintsReplies(t *testing.T) {
 	var output strings.Builder
 	input := strings.NewReader("hello bot\nhow are you?\n/exit\n")
 	processor := &stubProcessor{
-		responses: []string{
-			"Hi there",
-			"I'm ready to help",
+		responses: []agent.TurnResult{
+			{Text: "Hi there"},
+			{Text: "I'm ready to help"},
 		},
 	}
 
@@ -74,6 +76,24 @@ func TestRun_ForwardsConversationAndPrintsReplies(t *testing.T) {
 	}
 	if !strings.Contains(rendered, "Session ended.") {
 		t.Fatalf("output = %q, want session end text", rendered)
+	}
+}
+
+func TestRun_PrintsFocusedPageAfterTutorText(t *testing.T) {
+	var output strings.Builder
+	processor := &stubProcessor{responses: []agent.TurnResult{{
+		Text:        "Your report is ready.",
+		FocusedPage: &focusedpage.Artifact{URL: "https://pages.example/a/page-1#private-capability"},
+	}}}
+
+	err := Run(context.Background(), strings.NewReader("make my report\n/exit\n"), &output, processor, Config{})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	rendered := output.String()
+	if !strings.Contains(rendered, "P&AI> Your report is ready.\nFocused page> https://pages.example/a/page-1#private-capability\n") {
+		t.Fatalf("output = %q, want tutor text followed by focused-page URL", rendered)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Preserve the semantic tutor turn in local terminal-chat and render one focused-page URL after the final text.
- Carry an optional focused-page object through WebSocket responses and render it in interactive and one-shot terminal clients.
- Enable focused pages for the dev terminal WebSocket surface while leaving production embed WebSockets and existing plain-text responses unchanged.
- Keep focused-page capability URLs out of terminal history exports.

## Verification

- `go test ./...`
- `go vet ./...`
- `go test ./cmd/terminal-chat -run TestWSClientOnceRendersTurnWithAndWithoutFocusedPage -count=1 -v`

Closes #184