### PR TITLE
feat(focusedpage): clean up expired rows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,8 @@ jobs:
             command: go vet ./...
           - check: test
             command: go test ./... -count=1
+          - check: focused-page integration
+            command: go test -tags=integration ./internal/focusedpage -count=1
 
     steps:
       - uses: actions/checkout@v4

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -140,11 +140,16 @@ func main() {
 				slog.Error("failed to initialize conversation store", "error", err)
 				os.Exit(1)
 			}
+			focusedPageStore := focusedpage.NewPostgresStore(db.Pool)
+			focusedPageCleanup, err := server.NewFocusedPageCleanupWorker(focusedPageStore, nil)
+			if err != nil {
+				return nil, nil, fmt.Errorf("initialize focused page cleanup: %w", err)
+			}
 			var focusedPageService *focusedpage.Service
 			var focusedPageHandler http.Handler
 			if strings.TrimSpace(cfg.FocusedPage.BaseURL) != "" {
 				focusedPageService, err = focusedpage.NewService(
-					focusedpage.NewPostgresStore(db.Pool), cfg.FocusedPage.BaseURL, []byte(cfg.Auth.JWTSecret), time.Now,
+					focusedPageStore, cfg.FocusedPage.BaseURL, []byte(cfg.Auth.JWTSecret), time.Now,
 				)
 				if err != nil {
 					return nil, nil, fmt.Errorf("initialize focused pages: %w", err)
@@ -376,6 +381,12 @@ func main() {
 				if err := gw.StartAll(ctx, handleInbound); err != nil {
 					return err
 				}
+				focusedPageCleanupDone := make(chan struct{})
+				go func() {
+					defer close(focusedPageCleanupDone)
+					focusedPageCleanup.Run(ctx)
+				}()
+				cleanup = append(cleanup, func() { <-focusedPageCleanupDone })
 				slog.Info("P&AI Bot is running")
 				return nil
 			}, nil

--- a/internal/focusedpage/cleanup_postgres_integration_test.go
+++ b/internal/focusedpage/cleanup_postgres_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -18,6 +19,7 @@ func TestPostgresStoreCleanupExpiredBatchPolicy(t *testing.T) {
 	owners := seedCleanupOwners(t, ctx, pool)
 	store := NewPostgresStore(pool)
 	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	assertFocusedPageCleanupIndex(t, ctx, pool)
 
 	t.Run("zero rows", func(t *testing.T) {
 		truncateFocusedPages(t, ctx, pool)
@@ -120,6 +122,45 @@ func TestPostgresStoreCleanupExpiredBatchPolicy(t *testing.T) {
 			t.Fatalf("cleanup error = %v, want context cancellation", err)
 		}
 		assertFocusedPageCount(t, ctx, pool, 1)
+	})
+
+	t.Run("only one replica cleans at a time", func(t *testing.T) {
+		truncateFocusedPages(t, ctx, pool)
+		seedCleanupPage(t, ctx, pool, owners[0], 1, StatusActive, now)
+
+		lockHolder, err := pool.Acquire(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			if _, err := lockHolder.Exec(context.Background(), `SELECT pg_advisory_unlock($1)`, focusedPageCleanupLockID); err != nil {
+				t.Errorf("release cleanup lock: %v", err)
+			}
+			lockHolder.Release()
+		}()
+		if _, err := lockHolder.Exec(ctx, `SELECT pg_advisory_lock($1)`, focusedPageCleanupLockID); err != nil {
+			t.Fatal(err)
+		}
+
+		deleted, err := store.CleanupExpired(ctx, now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if deleted != 0 {
+			t.Fatalf("deleted rows while another replica held the cleanup lock = %d, want 0", deleted)
+		}
+		assertFocusedPageCount(t, ctx, pool, 1)
+
+		if _, err := lockHolder.Exec(ctx, `SELECT pg_advisory_unlock($1)`, focusedPageCleanupLockID); err != nil {
+			t.Fatal(err)
+		}
+		deleted, err = store.CleanupExpired(ctx, now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if deleted != 1 {
+			t.Fatalf("deleted rows after cleanup lock release = %d, want 1", deleted)
+		}
 	})
 }
 
@@ -256,4 +297,30 @@ func truncateFocusedPages(t *testing.T, ctx context.Context, pool *pgxpool.Pool)
 
 func cleanupPageID(index int) string {
 	return fmt.Sprintf("00000000-0000-0000-0000-%012d", index)
+}
+
+func assertFocusedPageCleanupIndex(t *testing.T, ctx context.Context, pool *pgxpool.Pool) {
+	t.Helper()
+	var definition string
+	if err := pool.QueryRow(ctx, `
+		SELECT indexdef
+		FROM pg_indexes
+		WHERE schemaname = current_schema() AND indexname = 'focused_pages_cleanup_idx'`,
+	).Scan(&definition); err != nil {
+		t.Fatalf("focused-page cleanup index: %v", err)
+	}
+	if !strings.Contains(definition, "(expires_at, id)") {
+		t.Fatalf("focused-page cleanup index definition = %q", definition)
+	}
+	var legacyIndexCount int
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*)
+		FROM pg_indexes
+		WHERE schemaname = current_schema() AND indexname = 'focused_pages_expiry_idx'`,
+	).Scan(&legacyIndexCount); err != nil {
+		t.Fatal(err)
+	}
+	if legacyIndexCount != 0 {
+		t.Fatalf("legacy focused-page expiry indexes = %d, want 0", legacyIndexCount)
+	}
 }

--- a/internal/focusedpage/cleanup_postgres_integration_test.go
+++ b/internal/focusedpage/cleanup_postgres_integration_test.go
@@ -1,0 +1,259 @@
+//go:build integration
+
+package focusedpage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestPostgresStoreCleanupExpiredBatchPolicy(t *testing.T) {
+	ctx := context.Background()
+	pool := startFocusedPagePostgres(t, ctx)
+	owners := seedCleanupOwners(t, ctx, pool)
+	store := NewPostgresStore(pool)
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+
+	t.Run("zero rows", func(t *testing.T) {
+		truncateFocusedPages(t, ctx, pool)
+		deleted, err := store.CleanupExpired(ctx, now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if deleted != 0 {
+			t.Fatalf("deleted rows = %d, want 0", deleted)
+		}
+	})
+
+	t.Run("exactly 100 rows", func(t *testing.T) {
+		truncateFocusedPages(t, ctx, pool)
+		for index := 1; index <= CleanupBatchSize; index++ {
+			seedCleanupPage(t, ctx, pool, owners[index%len(owners)], index, StatusActive, now)
+		}
+		deleted, err := store.CleanupExpired(ctx, now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if deleted != CleanupBatchSize {
+			t.Fatalf("deleted rows = %d, want %d", deleted, CleanupBatchSize)
+		}
+		assertFocusedPageCount(t, ctx, pool, 0)
+	})
+
+	t.Run("more than 100 equal-expiry rows drain deterministically across tenants", func(t *testing.T) {
+		truncateFocusedPages(t, ctx, pool)
+		const total = 205
+		for index := 1; index <= total; index++ {
+			seedCleanupPage(t, ctx, pool, owners[index%len(owners)], index, StatusActive, now)
+		}
+
+		assertCleanupProgress(t, ctx, store, pool, now, CleanupBatchSize, CleanupBatchSize+1, total-CleanupBatchSize)
+		assertCleanupProgress(t, ctx, store, pool, now, CleanupBatchSize, 2*CleanupBatchSize+1, total-2*CleanupBatchSize)
+		assertCleanupProgress(t, ctx, store, pool, now, total-2*CleanupBatchSize, 0, 0)
+
+		deleted, err := store.CleanupExpired(ctx, now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if deleted != 0 {
+			t.Fatalf("final deleted rows = %d, want 0", deleted)
+		}
+	})
+
+	t.Run("expires_at alone governs every lifecycle state", func(t *testing.T) {
+		truncateFocusedPages(t, ctx, pool)
+		statuses := []Status{StatusActive, StatusRevoked, StatusExpired}
+		for index, status := range statuses {
+			seedCleanupPage(t, ctx, pool, owners[index%len(owners)], index+1, status, now)
+			seedCleanupPage(t, ctx, pool, owners[(index+1)%len(owners)], index+4, status, now.Add(time.Second))
+		}
+
+		deleted, err := store.CleanupExpired(ctx, now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if deleted != int64(len(statuses)) {
+			t.Fatalf("deleted rows = %d, want %d", deleted, len(statuses))
+		}
+		assertFocusedPageCount(t, ctx, pool, int64(len(statuses)))
+		for _, status := range statuses {
+			var count int
+			if err := pool.QueryRow(ctx, `SELECT count(*) FROM focused_pages WHERE status = $1`, status).Scan(&count); err != nil {
+				t.Fatal(err)
+			}
+			if count != 1 {
+				t.Fatalf("%s rows after cleanup = %d, want one unexpired row", status, count)
+			}
+		}
+		for index := 4; index <= 6; index++ {
+			var tenantID string
+			if err := pool.QueryRow(ctx, `SELECT tenant_id::text FROM focused_pages WHERE id = $1::uuid`, cleanupPageID(index)).Scan(&tenantID); err != nil {
+				t.Fatalf("unexpired row %d was not preserved: %v", index, err)
+			}
+			wantOwner := owners[(index-3)%len(owners)]
+			if tenantID != wantOwner.tenantID {
+				t.Fatalf("unexpired row %d tenant = %s, want %s", index, tenantID, wantOwner.tenantID)
+			}
+		}
+
+		deleted, err = store.CleanupExpired(ctx, now.Add(time.Second))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if deleted != int64(len(statuses)) {
+			t.Fatalf("deleted rows at later expiry = %d, want %d", deleted, len(statuses))
+		}
+		assertFocusedPageCount(t, ctx, pool, 0)
+	})
+
+	t.Run("cancellation preserves eligible rows", func(t *testing.T) {
+		truncateFocusedPages(t, ctx, pool)
+		seedCleanupPage(t, ctx, pool, owners[0], 1, StatusActive, now)
+		cancelled, cancel := context.WithCancel(ctx)
+		cancel()
+		if _, err := store.CleanupExpired(cancelled, now); !errors.Is(err, context.Canceled) {
+			t.Fatalf("cleanup error = %v, want context cancellation", err)
+		}
+		assertFocusedPageCount(t, ctx, pool, 1)
+	})
+}
+
+func TestPostgresStoreCleanupExpiredReportsDatabaseFailure(t *testing.T) {
+	ctx := context.Background()
+	pool := startFocusedPagePostgres(t, ctx)
+	store := NewPostgresStore(pool)
+	pool.Close()
+	if _, err := store.CleanupExpired(ctx, time.Now()); err == nil {
+		t.Fatal("cleanup succeeded with a closed database pool")
+	}
+}
+
+type cleanupOwner struct {
+	tenantID       string
+	ownerID        string
+	conversationID string
+}
+
+func seedCleanupOwners(t *testing.T, ctx context.Context, pool *pgxpool.Pool) []cleanupOwner {
+	t.Helper()
+	owners := make([]cleanupOwner, 0, 2)
+	for index := 1; index <= 2; index++ {
+		var owner cleanupOwner
+		if err := pool.QueryRow(ctx,
+			`INSERT INTO tenants (name, slug) VALUES ($1, $2) RETURNING id::text`,
+			fmt.Sprintf("Cleanup tenant %d", index), fmt.Sprintf("cleanup-tenant-%d", index),
+		).Scan(&owner.tenantID); err != nil {
+			t.Fatal(err)
+		}
+		if err := pool.QueryRow(ctx, `
+			INSERT INTO users (tenant_id, role, name, external_id, channel)
+			VALUES ($1, 'student', $2, $3, 'telegram')
+			RETURNING id::text`,
+			owner.tenantID, fmt.Sprintf("Cleanup learner %d", index), fmt.Sprintf("cleanup-learner-%d", index),
+		).Scan(&owner.ownerID); err != nil {
+			t.Fatal(err)
+		}
+		if err := pool.QueryRow(ctx, `
+			INSERT INTO conversations (tenant_id, user_id, state)
+			VALUES ($1, $2, 'teaching')
+			RETURNING id::text`,
+			owner.tenantID, owner.ownerID,
+		).Scan(&owner.conversationID); err != nil {
+			t.Fatal(err)
+		}
+		owners = append(owners, owner)
+	}
+	return owners
+}
+
+func seedCleanupPage(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	owner cleanupOwner,
+	index int,
+	status Status,
+	expiresAt time.Time,
+) {
+	t.Helper()
+	var lifecycleAt any
+	if status != StatusActive {
+		lifecycleAt = expiresAt.Add(-time.Minute)
+	}
+	_, err := pool.Exec(ctx, `
+		INSERT INTO focused_pages (
+			id, public_id, tenant_id, owner_user_id, conversation_id, turn_id, recipient_name,
+			message, token_hash, status, created_at, expires_at, revoked_at, expired_at
+		)
+		VALUES (
+			$1::uuid, $2, $3::uuid, $4::uuid, $5::uuid, $6, 'Learner',
+			'Private report', $7, $8, $9, $10,
+			CASE WHEN $8 = 'revoked' THEN $11::timestamptz END,
+			CASE WHEN $8 = 'expired' THEN $11::timestamptz END
+		)`,
+		cleanupPageID(index), fmt.Sprintf("cleanup-public-%03d", index),
+		owner.tenantID, owner.ownerID, owner.conversationID, fmt.Sprintf("cleanup-turn-%03d", index),
+		make([]byte, 32), status, expiresAt.Add(-Lifetime), expiresAt, lifecycleAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertCleanupProgress(
+	t *testing.T,
+	ctx context.Context,
+	store *PostgresStore,
+	pool *pgxpool.Pool,
+	now time.Time,
+	wantDeleted int64,
+	wantFirstIndex int,
+	wantRemaining int64,
+) {
+	t.Helper()
+	deleted, err := store.CleanupExpired(ctx, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deleted != wantDeleted {
+		t.Fatalf("deleted rows = %d, want %d", deleted, wantDeleted)
+	}
+	assertFocusedPageCount(t, ctx, pool, wantRemaining)
+	if wantFirstIndex == 0 {
+		return
+	}
+	var firstID string
+	if err := pool.QueryRow(ctx, `SELECT id::text FROM focused_pages ORDER BY expires_at, id LIMIT 1`).Scan(&firstID); err != nil {
+		t.Fatal(err)
+	}
+	if want := cleanupPageID(wantFirstIndex); firstID != want {
+		t.Fatalf("first remaining id = %s, want %s", firstID, want)
+	}
+}
+
+func assertFocusedPageCount(t *testing.T, ctx context.Context, pool *pgxpool.Pool, want int64) {
+	t.Helper()
+	var count int64
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM focused_pages`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != want {
+		t.Fatalf("focused page rows = %d, want %d", count, want)
+	}
+}
+
+func truncateFocusedPages(t *testing.T, ctx context.Context, pool *pgxpool.Pool) {
+	t.Helper()
+	if _, err := pool.Exec(ctx, `TRUNCATE focused_pages`); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func cleanupPageID(index int) string {
+	return fmt.Sprintf("00000000-0000-0000-0000-%012d", index)
+}

--- a/internal/focusedpage/page.go
+++ b/internal/focusedpage/page.go
@@ -22,6 +22,9 @@ const (
 	MaxMessageLength = 4000
 	PageIndex        = 0
 	CleanupBatchSize = 100
+
+	// This stable database-wide key keeps cleanup singleton-safe across server replicas.
+	focusedPageCleanupLockID int64 = 0x7061696670636c6e
 )
 
 var (

--- a/internal/focusedpage/page.go
+++ b/internal/focusedpage/page.go
@@ -21,6 +21,7 @@ const (
 	Lifetime         = time.Hour
 	MaxMessageLength = 4000
 	PageIndex        = 0
+	CleanupBatchSize = 100
 )
 
 var (

--- a/internal/focusedpage/store_postgres.go
+++ b/internal/focusedpage/store_postgres.go
@@ -17,6 +17,34 @@ type PostgresStore struct{ pool *pgxpool.Pool }
 
 func NewPostgresStore(pool *pgxpool.Pool) *PostgresStore { return &PostgresStore{pool: pool} }
 
+func (s *PostgresStore) CleanupExpired(ctx context.Context, now time.Time) (int64, error) {
+	if s.pool == nil {
+		return 0, fmt.Errorf("focused page pool is nil")
+	}
+	var deleted int64
+	err := s.pool.QueryRow(ctx, `
+		WITH eligible AS (
+			SELECT id
+			FROM focused_pages
+			WHERE expires_at <= $1
+			ORDER BY expires_at, id
+			LIMIT $2
+			FOR UPDATE SKIP LOCKED
+		),
+		deleted AS (
+			DELETE FROM focused_pages AS page
+			USING eligible
+			WHERE page.id = eligible.id
+			RETURNING page.id
+		)
+		SELECT count(*) FROM deleted`,
+		now, CleanupBatchSize).Scan(&deleted)
+	if err != nil {
+		return 0, fmt.Errorf("cleanup focused pages: %w", err)
+	}
+	return deleted, nil
+}
+
 func (s *PostgresStore) CreateOrGet(ctx context.Context, record CreateRecord) (Page, error) {
 	if s.pool == nil {
 		return Page{}, fmt.Errorf("focused page pool is nil")

--- a/internal/focusedpage/store_postgres.go
+++ b/internal/focusedpage/store_postgres.go
@@ -23,13 +23,17 @@ func (s *PostgresStore) CleanupExpired(ctx context.Context, now time.Time) (int6
 	}
 	var deleted int64
 	err := s.pool.QueryRow(ctx, `
-		WITH eligible AS (
-			SELECT id
-			FROM focused_pages
-			WHERE expires_at <= $1
-			ORDER BY expires_at, id
+		WITH cleanup_lock AS MATERIALIZED (
+			SELECT pg_try_advisory_xact_lock($3) AS acquired
+		),
+		eligible AS (
+			SELECT page.id
+			FROM focused_pages AS page
+			JOIN cleanup_lock ON cleanup_lock.acquired
+			WHERE page.expires_at <= $1
+			ORDER BY page.expires_at, page.id
 			LIMIT $2
-			FOR UPDATE SKIP LOCKED
+			FOR UPDATE OF page SKIP LOCKED
 		),
 		deleted AS (
 			DELETE FROM focused_pages AS page
@@ -38,7 +42,7 @@ func (s *PostgresStore) CleanupExpired(ctx context.Context, now time.Time) (int6
 			RETURNING page.id
 		)
 		SELECT count(*) FROM deleted`,
-		now, CleanupBatchSize).Scan(&deleted)
+		now, CleanupBatchSize, focusedPageCleanupLockID).Scan(&deleted)
 	if err != nil {
 		return 0, fmt.Errorf("cleanup focused pages: %w", err)
 	}

--- a/internal/focusedpage/store_postgres_integration_test.go
+++ b/internal/focusedpage/store_postgres_integration_test.go
@@ -134,6 +134,7 @@ func startFocusedPagePostgres(t *testing.T, ctx context.Context) *pgxpool.Pool {
 	applyFocusedPageMigration(t, ctx, pool, filepath.Join("..", "..", "migrations", "20260318100300_auth_tables.sql"))
 	applyFocusedPageMigration(t, ctx, pool, filepath.Join("..", "..", "migrations", "20260318100400_auth_identity_tenant_consistency.sql"))
 	applyFocusedPageMigration(t, ctx, pool, filepath.Join("..", "..", "migrations", "20260713100000_focused_pages.sql"))
+	applyFocusedPageMigration(t, ctx, pool, filepath.Join("..", "..", "migrations", "20260723170000_focused_page_cleanup.sql"))
 	return pool
 }
 

--- a/internal/focusedpage/store_postgres_integration_test.go
+++ b/internal/focusedpage/store_postgres_integration_test.go
@@ -163,7 +163,20 @@ func applyFocusedPageMigration(t *testing.T, ctx context.Context, pool *pgxpool.
 	if up < 0 || down < 0 || down <= up {
 		t.Fatalf("invalid goose migration %s", path)
 	}
-	if _, err := pool.Exec(ctx, text[up+len("-- +goose Up"):down]); err != nil {
-		t.Fatalf("apply %s: %v", path, err)
+	upSQL := text[up+len("-- +goose Up") : down]
+	if !strings.Contains(text, "-- +goose NO TRANSACTION") {
+		if _, err := pool.Exec(ctx, upSQL); err != nil {
+			t.Fatalf("apply %s: %v", path, err)
+		}
+		return
+	}
+	for statement := range strings.SplitSeq(upSQL, ";") {
+		statement = strings.TrimSpace(statement)
+		if statement == "" {
+			continue
+		}
+		if _, err := pool.Exec(ctx, statement); err != nil {
+			t.Fatalf("apply %s: %v", path, err)
+		}
 	}
 }

--- a/internal/server/focused_page_cleanup.go
+++ b/internal/server/focused_page_cleanup.go
@@ -1,0 +1,58 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+const FocusedPageCleanupInterval = 15 * time.Minute
+
+type focusedPageCleaner interface {
+	CleanupExpired(context.Context, time.Time) (int64, error)
+}
+
+type FocusedPageCleanupWorker struct {
+	cleaner focusedPageCleaner
+	logger  *slog.Logger
+	now     func() time.Time
+}
+
+func NewFocusedPageCleanupWorker(cleaner focusedPageCleaner, logger *slog.Logger) (*FocusedPageCleanupWorker, error) {
+	if cleaner == nil {
+		return nil, fmt.Errorf("focused page cleaner is required")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &FocusedPageCleanupWorker{cleaner: cleaner, logger: logger, now: time.Now}, nil
+}
+
+func (w *FocusedPageCleanupWorker) Run(ctx context.Context) {
+	ticker := time.NewTicker(FocusedPageCleanupInterval)
+	defer ticker.Stop()
+	w.run(ctx, ticker.C)
+}
+
+func (w *FocusedPageCleanupWorker) run(ctx context.Context, ticks <-chan time.Time) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticks:
+			deleted, err := w.cleaner.CleanupExpired(ctx, w.now().UTC())
+			if ctx.Err() != nil {
+				return
+			}
+			if err != nil {
+				w.logger.Warn("focused page cleanup failed", "deleted", 0, "failed", true)
+				continue
+			}
+			w.logger.Info("focused page cleanup completed", "deleted", deleted, "failed", false)
+		}
+	}
+}

--- a/internal/server/focused_page_cleanup_test.go
+++ b/internal/server/focused_page_cleanup_test.go
@@ -1,0 +1,144 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestFocusedPageCleanupWorkerDoesNotOverlapAndStopsWithContext(t *testing.T) {
+	cleaner := &blockingFocusedPageCleaner{started: make(chan struct{}, 1)}
+	worker, err := NewFocusedPageCleanupWorker(cleaner, slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ticks := make(chan time.Time, 3)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		worker.run(ctx, ticks)
+		close(done)
+	}()
+
+	ticks <- time.Now()
+	select {
+	case <-cleaner.started:
+	case <-time.After(time.Second):
+		t.Fatal("cleanup did not start")
+	}
+	ticks <- time.Now()
+	ticks <- time.Now()
+	if got := cleaner.calls.Load(); got != 1 {
+		t.Fatalf("cleanup calls while first call is active = %d, want 1", got)
+	}
+	if got := cleaner.maxActive.Load(); got != 1 {
+		t.Fatalf("maximum concurrent cleanup calls = %d, want 1", got)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("worker did not stop with its context")
+	}
+	if got := cleaner.calls.Load(); got != 1 {
+		t.Fatalf("cleanup calls after cancellation = %d, want 1", got)
+	}
+	if got := cleaner.active.Load(); got != 0 {
+		t.Fatalf("active cleanup calls after shutdown = %d, want 0", got)
+	}
+}
+
+func TestFocusedPageCleanupWorkerLogsSafeFailureState(t *testing.T) {
+	var output lockedBuffer
+	worker, err := NewFocusedPageCleanupWorker(
+		failingFocusedPageCleaner{},
+		slog.New(slog.NewJSONHandler(&output, nil)),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ticks := make(chan time.Time, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		worker.run(ctx, ticks)
+		close(done)
+	}()
+
+	ticks <- time.Now()
+	deadline := time.Now().Add(time.Second)
+	for output.Len() == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	cancel()
+	<-done
+
+	logged := output.String()
+	if !strings.Contains(logged, `"failed":true`) {
+		t.Fatalf("failure log = %q, want structured failure state", logged)
+	}
+	if strings.Contains(logged, "private page content") || strings.Contains(logged, "capability-fragment") {
+		t.Fatalf("failure log exposed private error content: %q", logged)
+	}
+}
+
+type blockingFocusedPageCleaner struct {
+	calls     atomic.Int32
+	active    atomic.Int32
+	maxActive atomic.Int32
+	started   chan struct{}
+}
+
+func (c *blockingFocusedPageCleaner) CleanupExpired(ctx context.Context, _ time.Time) (int64, error) {
+	c.calls.Add(1)
+	active := c.active.Add(1)
+	for {
+		current := c.maxActive.Load()
+		if active <= current || c.maxActive.CompareAndSwap(current, active) {
+			break
+		}
+	}
+	c.started <- struct{}{}
+	<-ctx.Done()
+	c.active.Add(-1)
+	return 0, ctx.Err()
+}
+
+type failingFocusedPageCleaner struct{}
+
+func (failingFocusedPageCleaner) CleanupExpired(context.Context, time.Time) (int64, error) {
+	return 0, errors.New("private page content capability-fragment")
+}
+
+type lockedBuffer struct {
+	mu     sync.Mutex
+	buffer bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(data []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buffer.Write(data)
+}
+
+func (b *lockedBuffer) Len() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buffer.Len()
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buffer.String()
+}

--- a/internal/server/run.go
+++ b/internal/server/run.go
@@ -26,6 +26,8 @@ func Run(ctx context.Context, opts Options) error {
 	if ctx == nil {
 		return errors.New("context is required")
 	}
+	runCtx, cancelRun := context.WithCancel(ctx)
+	defer cancelRun()
 	if opts.BuildHandler == nil {
 		return errors.New("build handler is required")
 	}
@@ -57,7 +59,7 @@ func Run(ctx context.Context, opts Options) error {
 		serveErr <- nil
 	}()
 
-	fullHandler, startAfterSwap, err := opts.BuildHandler(ctx)
+	fullHandler, startAfterSwap, err := opts.BuildHandler(runCtx)
 	if err != nil {
 		return shutdownAfterStartupError(srv, opts.ShutdownTimeout, fmt.Errorf("build handler: %w", err))
 	}
@@ -69,7 +71,7 @@ func Run(ctx context.Context, opts Options) error {
 	slog.Info("full handler active")
 
 	if startAfterSwap != nil {
-		if err := startAfterSwap(ctx); err != nil {
+		if err := startAfterSwap(runCtx); err != nil {
 			return shutdownAfterStartupError(srv, opts.ShutdownTimeout, fmt.Errorf("start after swap: %w", err))
 		}
 	}

--- a/internal/server/run_test.go
+++ b/internal/server/run_test.go
@@ -80,6 +80,48 @@ func TestRunServesHealthBeforeSwapAndBuiltHandlerAfterSwap(t *testing.T) {
 	}
 }
 
+func TestRunCancelsPostSwapWorkWhenServerExits(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	worker, err := NewFocusedPageCleanupWorker(&blockingFocusedPageCleaner{started: make(chan struct{}, 1)}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workerDone := make(chan struct{})
+	started := make(chan struct{})
+	runErr := Run(context.Background(), Options{
+		Addr:            listener.Addr().String(),
+		ShutdownTimeout: time.Second,
+		BuildHandler: func(context.Context) (http.Handler, func(context.Context) error, error) {
+			return http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), func(ctx context.Context) error {
+				close(started)
+				go func() {
+					worker.run(ctx, make(chan time.Time))
+					close(workerDone)
+				}()
+				return nil
+			}, nil
+		},
+	})
+	if runErr == nil {
+		t.Fatal("Run succeeded despite an unavailable listen address")
+	}
+	select {
+	case <-started:
+	default:
+		t.Fatal("post-swap work was not started")
+	}
+	select {
+	case <-workerDone:
+	case <-time.After(time.Second):
+		t.Fatal("post-swap worker outlived the server")
+	}
+}
+
 func freeLocalAddr(t *testing.T) string {
 	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")

--- a/internal/server/run_test.go
+++ b/internal/server/run_test.go
@@ -85,7 +85,11 @@ func TestRunCancelsPostSwapWorkWhenServerExits(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer listener.Close()
+	t.Cleanup(func() {
+		if err := listener.Close(); err != nil {
+			t.Errorf("close reserved listener: %v", err)
+		}
+	})
 
 	worker, err := NewFocusedPageCleanupWorker(&blockingFocusedPageCleaner{started: make(chan struct{}, 1)}, nil)
 	if err != nil {

--- a/migrations/20260723170000_focused_page_cleanup.sql
+++ b/migrations/20260723170000_focused_page_cleanup.sql
@@ -1,7 +1,10 @@
+-- +goose NO TRANSACTION
 -- +goose Up
-DROP INDEX focused_pages_expiry_idx;
-CREATE INDEX focused_pages_expiry_idx ON focused_pages (expires_at, id);
+DROP INDEX CONCURRENTLY IF EXISTS focused_pages_cleanup_idx;
+CREATE INDEX CONCURRENTLY focused_pages_cleanup_idx ON focused_pages (expires_at, id);
+DROP INDEX CONCURRENTLY IF EXISTS focused_pages_expiry_idx;
 
 -- +goose Down
-DROP INDEX focused_pages_expiry_idx;
-CREATE INDEX focused_pages_expiry_idx ON focused_pages (expires_at) WHERE status = 'active';
+DROP INDEX CONCURRENTLY IF EXISTS focused_pages_expiry_idx;
+CREATE INDEX CONCURRENTLY focused_pages_expiry_idx ON focused_pages (expires_at) WHERE status = 'active';
+DROP INDEX CONCURRENTLY IF EXISTS focused_pages_cleanup_idx;

--- a/migrations/20260723170000_focused_page_cleanup.sql
+++ b/migrations/20260723170000_focused_page_cleanup.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+DROP INDEX focused_pages_expiry_idx;
+CREATE INDEX focused_pages_expiry_idx ON focused_pages (expires_at, id);
+
+-- +goose Down
+DROP INDEX focused_pages_expiry_idx;
+CREATE INDEX focused_pages_expiry_idx ON focused_pages (expires_at) WHERE status = 'active';


### PR DESCRIPTION
## Summary

- delete at most 100 focused-page rows per cleanup call using `expires_at` and stable UUID ordering
- run a non-overlapping cleanup batch every 15 minutes under the server lifecycle and serialize batches across replicas
- replace the active-only expiry index without blocking writes and cover retention, tenant, cancellation, failure, migration, and shutdown behavior
- run the focused-page PostgreSQL integration suite in pull-request CI

## Testing

- `go test ./... -count=1`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test -tags integration ./internal/focusedpage -count=1`
- `go test -race ./internal/server -run 'TestFocusedPageCleanupWorker|TestRunCancelsPostSwapWork' -count=1`
- `go run github.com/pressly/goose/v3/cmd/goose@v3.26.0 -dir migrations validate`

Closes #186
