### PR TITLE
feat(ai): support native OpenAI tool continuation

### DIFF
--- a/internal/agent/focused_page_openai_test.go
+++ b/internal/agent/focused_page_openai_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/p-n-ai/pai-bot/internal/ai"
+	"github.com/p-n-ai/pai-bot/internal/chat"
+	"github.com/p-n-ai/pai-bot/internal/focusedpage"
+)
+
+func TestDirectOpenAIFocusedPageTurnContinuesAfterToolResult(t *testing.T) {
+	var calls atomic.Int32
+	var continuation map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if calls.Add(1) == 1 {
+			_, _ = w.Write([]byte(`{"id":"oa-tool","model":"gpt-test","choices":[{"message":{"tool_calls":[{"id":"page-1","type":"function","function":{"name":"create_focused_page","arguments":"{\"message\":\"You completed your goal report.\"}"}}]},"finish_reason":"tool_calls"}]}`))
+			return
+		}
+		continuation = request
+		_, _ = w.Write([]byte(`{"id":"oa-final","model":"gpt-test","choices":[{"message":{"content":"I made a focused page for your report."},"finish_reason":"stop"}]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	store := NewMemoryStore()
+	if err := store.SetUserName("learner-1", "Aina"); err != nil {
+		t.Fatal(err)
+	}
+	pageService, err := focusedpage.NewService(
+		focusedpage.NewMemoryStore(),
+		"https://pages.example",
+		[]byte("0123456789abcdef0123456789abcdef"),
+		time.Now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	router := ai.NewRouterWithConfig(ai.RouterConfig{RetryBackoff: []time.Duration{time.Millisecond}})
+	router.Register("openai", ai.NewOpenAIProvider("test-key", ai.WithBaseURL(server.URL)))
+	engine := NewEngine(EngineConfig{
+		AIRouter:           router,
+		Store:              store,
+		TenantID:           "tenant-1",
+		FocusedPages:       pageService,
+		FocusedPageEnabled: telegramFocusedPageEnabled,
+	})
+
+	result, err := engine.ProcessTurn(context.Background(), chat.InboundMessage{
+		Channel: "telegram",
+		UserID:  "learner-1",
+		Text:    "Give me a report on my goal",
+	})
+	if err != nil {
+		t.Fatalf("ProcessTurn() error = %v", err)
+	}
+	if result.Text != "I made a focused page for your report." || result.FocusedPage == nil {
+		t.Fatalf("text = %q, focused page present = %t", result.Text, result.FocusedPage != nil)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("OpenAI calls = %d, want 2", calls.Load())
+	}
+	assertOpenAIFocusedPageContinuation(t, continuation)
+}
+
+func assertOpenAIFocusedPageContinuation(t *testing.T, request map[string]any) {
+	t.Helper()
+	messages := request["messages"].([]any)
+	var assistant, toolResult map[string]any
+	for _, raw := range messages {
+		message := raw.(map[string]any)
+		switch message["role"] {
+		case "assistant":
+			assistant = message
+		case "tool":
+			toolResult = message
+		}
+	}
+	if assistant == nil || toolResult == nil {
+		t.Fatalf("continuation messages = %#v", messages)
+	}
+	call := assistant["tool_calls"].([]any)[0].(map[string]any)
+	function := call["function"].(map[string]any)
+	if call["id"] != "page-1" || function["name"] != "create_focused_page" {
+		t.Fatalf("assistant tool call = %#v", call)
+	}
+	if toolResult["tool_call_id"] != "page-1" || toolResult["content"] != "Focused page created." {
+		t.Fatalf("tool result = %#v", toolResult)
+	}
+}

--- a/internal/ai/native_provider_contract_test.go
+++ b/internal/ai/native_provider_contract_test.go
@@ -1,0 +1,305 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/p-n-ai/pai-bot/internal/llm"
+)
+
+type nativeProviderContractFixture struct {
+	name       string
+	model      string
+	new        func(string) NativeProvider
+	writeReply func(http.ResponseWriter, string)
+}
+
+func nativeProviderContractFixtures() []nativeProviderContractFixture {
+	return []nativeProviderContractFixture{
+		{
+			name:  "direct OpenAI",
+			model: "gpt-test",
+			new: func(baseURL string) NativeProvider {
+				return NewOpenAIProvider("test-key", WithBaseURL(baseURL)).(NativeProvider)
+			},
+			writeReply: writeDirectOpenAIContractReply,
+		},
+		{
+			name:  "OpenRouter",
+			model: "openai/gpt-test",
+			new: func(baseURL string) NativeProvider {
+				return newOpenRouterLLMAdapter("test-key", baseURL)
+			},
+			writeReply: writeOpenRouterContractReply,
+		},
+	}
+}
+
+func TestNativeProviderContinuationContract(t *testing.T) {
+	for _, fixture := range nativeProviderContractFixtures() {
+		t.Run(fixture.name, func(t *testing.T) {
+			var mu sync.Mutex
+			var requests []map[string]any
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var request map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+					t.Errorf("decode request: %v", err)
+					http.Error(w, "bad request", http.StatusBadRequest)
+					return
+				}
+				mu.Lock()
+				requests = append(requests, request)
+				requestNumber := len(requests)
+				mu.Unlock()
+				if requestNumber == 1 {
+					fixture.writeReply(w, "tool")
+					return
+				}
+				fixture.writeReply(w, "final")
+			}))
+			t.Cleanup(server.Close)
+
+			provider := fixture.new(server.URL)
+			tool := llm.Tool{
+				Name:        "create_focused_page",
+				Description: "Create one focused page.",
+				Parameters:  json.RawMessage(`{"type":"object","additionalProperties":false,"properties":{"message":{"type":"string"}},"required":["message"]}`),
+			}
+			initial := llm.Context{
+				SystemPrompt: "Tutor policy",
+				Messages:     []llm.Message{llm.UserText("Show my goal report")},
+				Tools:        []llm.Tool{tool},
+			}
+			first, err := provider.CompleteNative(context.Background(), fixture.model, initial, &llm.StreamOptions{MaxTokens: 128})
+			if err != nil {
+				t.Fatalf("first CompleteNative() error = %v", err)
+			}
+			call := requireContractToolCall(t, first)
+			if call.ID != "call-page-1" || call.Name != "create_focused_page" || call.Arguments["message"] != "You are making steady progress." {
+				t.Fatalf("tool call = %#v", call)
+			}
+
+			continuation := llm.Context{
+				SystemPrompt: initial.SystemPrompt,
+				Messages: append(append([]llm.Message(nil), initial.Messages...),
+					first,
+					llm.ToolResultMessage{
+						ToolCallID: call.ID,
+						ToolName:   call.Name,
+						Content:    []llm.UserContent{llm.TextContent{Text: "Focused page created."}},
+					},
+				),
+				Tools: []llm.Tool{tool},
+			}
+			final, err := provider.CompleteNative(context.Background(), fixture.model, continuation, &llm.StreamOptions{MaxTokens: 128})
+			if err != nil {
+				t.Fatalf("continuation CompleteNative() error = %v", err)
+			}
+			if text := contractAssistantText(final); text != "Your focused page is ready." {
+				t.Fatalf("final text = %q", text)
+			}
+
+			mu.Lock()
+			captured := append([]map[string]any(nil), requests...)
+			mu.Unlock()
+			if len(captured) != 2 {
+				t.Fatalf("request count = %d, want 2", len(captured))
+			}
+			assertContractToolDefinition(t, captured[0])
+			assertContractContinuation(t, captured[1])
+		})
+	}
+}
+
+func TestNativeProviderRejectsMalformedToolArguments(t *testing.T) {
+	for _, fixture := range nativeProviderContractFixtures() {
+		t.Run(fixture.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				fixture.writeReply(w, "malformed")
+			}))
+			t.Cleanup(server.Close)
+
+			_, err := fixture.new(server.URL).CompleteNative(
+				context.Background(),
+				fixture.model,
+				llm.Context{Messages: []llm.Message{llm.UserText("Create a page")}},
+				nil,
+			)
+			if err == nil {
+				t.Fatal("CompleteNative() should reject malformed tool arguments")
+			}
+		})
+	}
+}
+
+func TestNativeProviderToolFreeContract(t *testing.T) {
+	for _, fixture := range nativeProviderContractFixtures() {
+		t.Run(fixture.name, func(t *testing.T) {
+			var captured map[string]any
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+					t.Errorf("decode request: %v", err)
+				}
+				fixture.writeReply(w, "plain")
+			}))
+			t.Cleanup(server.Close)
+
+			temperature := 0.25
+			response, err := fixture.new(server.URL).CompleteNative(
+				context.Background(),
+				fixture.model,
+				llm.Context{
+					SystemPrompt: "Tutor policy",
+					Messages: []llm.Message{llm.UserMessage{Content: []llm.UserContent{
+						llm.TextContent{Text: "Explain this image"},
+						llm.ImageContent{MimeType: "image/png", Data: "AAEC"},
+					}}},
+				},
+				&llm.StreamOptions{
+					MaxTokens:   64,
+					Temperature: &temperature,
+					StructuredOutput: &llm.StructuredOutputSpec{
+						Name:       "tutor_response",
+						JSONSchema: json.RawMessage(`{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"],"additionalProperties":false}`),
+						Strict:     true,
+					},
+				},
+			)
+			if err != nil {
+				t.Fatalf("CompleteNative() error = %v", err)
+			}
+			if text := contractAssistantText(response); text != `{"answer":"Use the diagram."}` {
+				t.Fatalf("tool-free text = %q", text)
+			}
+			if _, present := captured["tools"]; present {
+				t.Fatalf("tool-free request contains tools: %#v", captured["tools"])
+			}
+			assertContractImageAndStructuredOutput(t, captured)
+		})
+	}
+}
+
+func TestDeepSeekProviderDoesNotImplementNativeContract(t *testing.T) {
+	if _, ok := any(NewDeepSeekProvider("test-key")).(NativeProvider); ok {
+		t.Fatal("DeepSeek must remain outside the direct OpenAI native contract")
+	}
+	if _, ok := NewOpenAIProvider("test-key", WithProviderName("compatible")).(NativeProvider); ok {
+		t.Fatal("arbitrary OpenAI-compatible providers must remain outside the direct OpenAI native contract")
+	}
+}
+
+func requireContractToolCall(t *testing.T, message llm.AssistantMessage) llm.ToolCall {
+	t.Helper()
+	for _, content := range message.Content {
+		if call, ok := content.(llm.ToolCall); ok {
+			return call
+		}
+	}
+	t.Fatalf("assistant content has no tool call: %#v", message.Content)
+	return llm.ToolCall{}
+}
+
+func contractAssistantText(message llm.AssistantMessage) string {
+	var text strings.Builder
+	for _, content := range message.Content {
+		if block, ok := content.(llm.TextContent); ok {
+			text.WriteString(block.Text)
+		}
+	}
+	return text.String()
+}
+
+func assertContractToolDefinition(t *testing.T, request map[string]any) {
+	t.Helper()
+	tools, ok := request["tools"].([]any)
+	if !ok || len(tools) != 1 {
+		t.Fatalf("tools = %#v", request["tools"])
+	}
+	function := tools[0].(map[string]any)["function"].(map[string]any)
+	parameters := function["parameters"].(map[string]any)
+	if function["name"] != "create_focused_page" || function["description"] != "Create one focused page." || parameters["type"] != "object" {
+		t.Fatalf("tool definition = %#v", function)
+	}
+}
+
+func assertContractContinuation(t *testing.T, request map[string]any) {
+	t.Helper()
+	messages := request["messages"].([]any)
+	var assistant, tool map[string]any
+	for _, raw := range messages {
+		message := raw.(map[string]any)
+		switch message["role"] {
+		case "assistant":
+			assistant = message
+		case "tool":
+			tool = message
+		}
+	}
+	if assistant == nil || tool == nil {
+		t.Fatalf("continuation messages = %#v", messages)
+	}
+	calls := assistant["tool_calls"].([]any)
+	call := calls[0].(map[string]any)
+	function := call["function"].(map[string]any)
+	var arguments map[string]any
+	if err := json.Unmarshal([]byte(function["arguments"].(string)), &arguments); err != nil {
+		t.Fatalf("decode assistant tool arguments: %v", err)
+	}
+	if call["id"] != "call-page-1" || function["name"] != "create_focused_page" || arguments["message"] != "You are making steady progress." {
+		t.Fatalf("assistant tool call = %#v", call)
+	}
+	if tool["tool_call_id"] != "call-page-1" || tool["content"] != "Focused page created." {
+		t.Fatalf("tool result = %#v", tool)
+	}
+}
+
+func assertContractImageAndStructuredOutput(t *testing.T, request map[string]any) {
+	t.Helper()
+	messages := request["messages"].([]any)
+	user := messages[1].(map[string]any)
+	parts := user["content"].([]any)
+	image := parts[1].(map[string]any)["image_url"].(map[string]any)
+	if image["url"] != "data:image/png;base64,AAEC" {
+		t.Fatalf("image = %#v", image)
+	}
+	responseFormat := request["response_format"].(map[string]any)
+	jsonSchema := responseFormat["json_schema"].(map[string]any)
+	if responseFormat["type"] != "json_schema" || jsonSchema["name"] != "tutor_response" || jsonSchema["strict"] != true {
+		t.Fatalf("response_format = %#v", responseFormat)
+	}
+}
+
+func writeDirectOpenAIContractReply(w http.ResponseWriter, kind string) {
+	w.Header().Set("Content-Type", "application/json")
+	switch kind {
+	case "tool":
+		_, _ = w.Write([]byte(`{"id":"oa-tool","model":"gpt-test","choices":[{"message":{"content":"Checking.","tool_calls":[{"id":"call-page-1","type":"function","function":{"name":"create_focused_page","arguments":"{\"message\":\"You are making steady progress.\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":12,"completion_tokens":4}}`))
+	case "final":
+		_, _ = w.Write([]byte(`{"id":"oa-final","model":"gpt-test","choices":[{"message":{"content":"Your focused page is ready."},"finish_reason":"stop"}],"usage":{"prompt_tokens":20,"completion_tokens":6}}`))
+	case "malformed":
+		_, _ = w.Write([]byte(`{"id":"oa-bad","model":"gpt-test","choices":[{"message":{"tool_calls":[{"id":"call-bad","type":"function","function":{"name":"create_focused_page","arguments":"{not-json"}}]},"finish_reason":"tool_calls"}]}`))
+	case "plain":
+		_, _ = w.Write([]byte(`{"id":"oa-plain","model":"gpt-test","choices":[{"message":{"content":"{\"answer\":\"Use the diagram.\"}"},"finish_reason":"stop"}]}`))
+	}
+}
+
+func writeOpenRouterContractReply(w http.ResponseWriter, kind string) {
+	switch kind {
+	case "tool":
+		writeOpenRouterLLMStream(w, `{"id":"or-tool","model":"openai/gpt-test","choices":[{"delta":{"content":"Checking.","tool_calls":[{"index":0,"id":"call-page-1","type":"function","function":{"name":"create_focused_page","arguments":"{\"message\":\"You are making steady progress.\"}"}}]},"finish_reason":"tool_calls"}]}`)
+	case "final":
+		writeOpenRouterLLMStream(w, `{"id":"or-final","model":"openai/gpt-test","choices":[{"delta":{"content":"Your focused page is ready."},"finish_reason":"stop"}]}`)
+	case "malformed":
+		writeOpenRouterLLMStream(w, `{"id":"or-bad","model":"openai/gpt-test","choices":[{"delta":{"tool_calls":[{"index":0,"id":"call-bad","type":"function","function":{"name":"create_focused_page","arguments":"{not-json"}}]},"finish_reason":"tool_calls"}]}`)
+	case "plain":
+		writeOpenRouterLLMStream(w, `{"id":"or-plain","model":"openai/gpt-test","choices":[{"delta":{"content":"{\"answer\":\"Use the diagram.\"}"},"finish_reason":"stop"}]}`)
+	}
+}

--- a/internal/ai/provider_openai.go
+++ b/internal/ai/provider_openai.go
@@ -11,6 +11,9 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
+
+	"github.com/p-n-ai/pai-bot/internal/llm"
 )
 
 const (
@@ -27,6 +30,13 @@ type OpenAIProvider struct {
 	name    string
 	models  []ModelInfo
 }
+
+type directOpenAIProvider struct {
+	*OpenAIProvider
+}
+
+var _ Provider = (*directOpenAIProvider)(nil)
+var _ NativeProvider = (*directOpenAIProvider)(nil)
 
 // OpenAIOption configures an OpenAIProvider.
 type OpenAIOption func(*OpenAIProvider)
@@ -60,7 +70,15 @@ func WithProviderName(name string) OpenAIOption {
 }
 
 // NewOpenAIProvider creates a new OpenAI-compatible provider.
-func NewOpenAIProvider(apiKey string, opts ...OpenAIOption) *OpenAIProvider {
+func NewOpenAIProvider(apiKey string, opts ...OpenAIOption) Provider {
+	provider := newOpenAIProvider(apiKey, opts...)
+	if provider.name != "openai" {
+		return provider
+	}
+	return &directOpenAIProvider{OpenAIProvider: provider}
+}
+
+func newOpenAIProvider(apiKey string, opts ...OpenAIOption) *OpenAIProvider {
 	p := &OpenAIProvider{
 		apiKey:  apiKey,
 		baseURL: defaultOpenAIBaseURL,
@@ -79,13 +97,14 @@ func NewDeepSeekProvider(apiKey string, opts ...OpenAIOption) *OpenAIProvider {
 		WithBaseURL(defaultDeepSeekBaseURL),
 		WithProviderName("deepseek"),
 	}, opts...)
-	return NewOpenAIProvider(apiKey, opts...)
+	return newOpenAIProvider(apiKey, opts...)
 }
 
 // openaiRequest is the request body for the OpenAI chat completions API.
 type openaiRequest struct {
 	Model               string                `json:"model"`
 	Messages            []openaiMessage       `json:"messages"`
+	Tools               []openaiTool          `json:"tools,omitempty"`
 	ResponseFormat      *openaiResponseFormat `json:"response_format,omitempty"`
 	MaxTokens           int                   `json:"max_tokens,omitempty"`
 	MaxCompletionTokens int                   `json:"max_completion_tokens,omitempty"`
@@ -93,8 +112,30 @@ type openaiRequest struct {
 }
 
 type openaiMessage struct {
-	Role    string `json:"role"`
-	Content any    `json:"content"`
+	Role       string           `json:"role"`
+	Content    any              `json:"content,omitempty"`
+	ToolCalls  []openaiToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string           `json:"tool_call_id,omitempty"`
+}
+
+type openaiToolCall struct {
+	ID       string             `json:"id"`
+	Type     string             `json:"type"`
+	Function openaiToolFunction `json:"function"`
+}
+
+type openaiToolFunction struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+type openaiTool struct {
+	Type     string `json:"type"`
+	Function struct {
+		Name        string          `json:"name"`
+		Description string          `json:"description"`
+		Parameters  json.RawMessage `json:"parameters"`
+	} `json:"function"`
 }
 
 type openaiResponseFormat struct {
@@ -129,6 +170,25 @@ type openaiResponse struct {
 	Usage struct {
 		PromptTokens     int `json:"prompt_tokens"`
 		CompletionTokens int `json:"completion_tokens"`
+	} `json:"usage"`
+}
+
+type openaiNativeResponse struct {
+	ID      string `json:"id"`
+	Choices []struct {
+		Message struct {
+			Content   string           `json:"content"`
+			ToolCalls []openaiToolCall `json:"tool_calls"`
+		} `json:"message"`
+		FinishReason string `json:"finish_reason"`
+	} `json:"choices"`
+	Model string `json:"model"`
+	Usage struct {
+		PromptTokens        int `json:"prompt_tokens"`
+		CompletionTokens    int `json:"completion_tokens"`
+		PromptTokensDetails *struct {
+			CachedTokens int `json:"cached_tokens"`
+		} `json:"prompt_tokens_details"`
 	} `json:"usage"`
 }
 
@@ -201,6 +261,260 @@ func (p *OpenAIProvider) Complete(ctx context.Context, req CompletionRequest) (C
 		InputTokens:  oaiResp.Usage.PromptTokens,
 		OutputTokens: oaiResp.Usage.CompletionTokens,
 	}, nil
+}
+
+func (p *directOpenAIProvider) CompleteNative(ctx context.Context, model string, c llm.Context, opts *llm.StreamOptions) (llm.AssistantMessage, error) {
+	if model == "" {
+		model = "gpt-5.4-mini"
+	}
+	messages, err := buildNativeOpenAIMessages(c)
+	if err != nil {
+		return llm.AssistantMessage{}, err
+	}
+	tools, err := buildNativeOpenAITools(c.Tools)
+	if err != nil {
+		return llm.AssistantMessage{}, err
+	}
+	request := openaiRequest{
+		Model:    model,
+		Messages: messages,
+		Tools:    tools,
+	}
+	if opts != nil {
+		if opts.MaxTokens > 0 {
+			if needsMaxCompletionTokens(model) {
+				request.MaxCompletionTokens = opts.MaxTokens
+			} else {
+				request.MaxTokens = opts.MaxTokens
+			}
+		}
+		request.Temperature = opts.Temperature
+		if opts.StructuredOutput != nil {
+			spec := &StructuredOutputSpec{
+				Name:       opts.StructuredOutput.Name,
+				JSONSchema: append(json.RawMessage(nil), opts.StructuredOutput.JSONSchema...),
+				Strict:     opts.StructuredOutput.Strict,
+			}
+			if err := applyOpenAIStructuredOutput(p.name, &request, spec); err != nil {
+				return llm.AssistantMessage{}, err
+			}
+		}
+	}
+
+	body, err := json.Marshal(request)
+	if err != nil {
+		return llm.AssistantMessage{}, fmt.Errorf("marshal native OpenAI request: %w", err)
+	}
+	httpRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(p.baseURL, "/")+"/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return llm.AssistantMessage{}, fmt.Errorf("create native OpenAI request: %w", err)
+	}
+	httpRequest.Header.Set("Content-Type", "application/json")
+	httpRequest.Header.Set("Authorization", "Bearer "+p.apiKey)
+	if opts != nil {
+		for name, value := range opts.Headers {
+			httpRequest.Header.Set(name, value)
+		}
+	}
+
+	response, err := p.client.Do(httpRequest)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return llm.AssistantMessage{}, ctxErr
+		}
+		return llm.AssistantMessage{}, fmt.Errorf("send native OpenAI request: %w", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		return llm.AssistantMessage{}, fmt.Errorf("read native OpenAI response: %w", err)
+	}
+	if response.StatusCode != http.StatusOK {
+		return llm.AssistantMessage{}, fmt.Errorf("native OpenAI API returned status %d", response.StatusCode)
+	}
+
+	var decoded openaiNativeResponse
+	if err := json.Unmarshal(responseBody, &decoded); err != nil {
+		return llm.AssistantMessage{}, fmt.Errorf("decode native OpenAI response: %w", err)
+	}
+	if len(decoded.Choices) == 0 {
+		return llm.AssistantMessage{}, fmt.Errorf("native OpenAI response contains no choices")
+	}
+	return projectNativeOpenAIResponse(model, decoded)
+}
+
+func buildNativeOpenAIMessages(c llm.Context) ([]openaiMessage, error) {
+	messages := make([]openaiMessage, 0, len(c.Messages)+1)
+	if c.SystemPrompt != "" {
+		messages = append(messages, openaiMessage{Role: "system", Content: c.SystemPrompt})
+	}
+	for _, message := range c.Messages {
+		switch typed := message.(type) {
+		case llm.SystemMessage:
+			messages = append(messages, openaiMessage{Role: "system", Content: typed.Content})
+		case llm.UserMessage:
+			projected, ok := projectNativeUserMessage(typed)
+			if !ok {
+				return nil, fmt.Errorf("native OpenAI user message contains invalid image data")
+			}
+			messages = append(messages, buildOpenAIMessages([]Message{projected})...)
+		case llm.AssistantMessage:
+			projected, err := buildNativeOpenAIAssistantMessage(typed)
+			if err != nil {
+				return nil, err
+			}
+			if projected.Content != nil || len(projected.ToolCalls) > 0 {
+				messages = append(messages, projected)
+			}
+		case llm.ToolResultMessage:
+			content, err := nativeOpenAIToolResultText(typed)
+			if err != nil {
+				return nil, err
+			}
+			messages = append(messages, openaiMessage{
+				Role:       "tool",
+				Content:    content,
+				ToolCallID: typed.ToolCallID,
+			})
+		default:
+			return nil, fmt.Errorf("native OpenAI message type %T is unsupported", message)
+		}
+	}
+	return messages, nil
+}
+
+func buildNativeOpenAIAssistantMessage(message llm.AssistantMessage) (openaiMessage, error) {
+	var text strings.Builder
+	projected := openaiMessage{Role: "assistant"}
+	for _, content := range message.Content {
+		switch block := content.(type) {
+		case llm.TextContent:
+			text.WriteString(block.Text)
+		case llm.ToolCall:
+			arguments, err := json.Marshal(block.Arguments)
+			if err != nil {
+				return openaiMessage{}, fmt.Errorf("native OpenAI tool call %q arguments: %w", block.Name, err)
+			}
+			if block.Arguments == nil {
+				arguments = []byte("{}")
+			}
+			projected.ToolCalls = append(projected.ToolCalls, openaiToolCall{
+				ID:   block.ID,
+				Type: "function",
+				Function: openaiToolFunction{
+					Name:      block.Name,
+					Arguments: string(arguments),
+				},
+			})
+		case llm.ThinkingContent:
+		default:
+			return openaiMessage{}, fmt.Errorf("native OpenAI assistant content type %T is unsupported", content)
+		}
+	}
+	if text.Len() > 0 {
+		projected.Content = text.String()
+	}
+	return projected, nil
+}
+
+func nativeOpenAIToolResultText(message llm.ToolResultMessage) (string, error) {
+	var text []string
+	for _, content := range message.Content {
+		block, ok := content.(llm.TextContent)
+		if !ok {
+			return "", fmt.Errorf("native OpenAI tool result content type %T is unsupported", content)
+		}
+		text = append(text, block.Text)
+	}
+	if len(text) == 0 {
+		return "(no text result)", nil
+	}
+	return strings.Join(text, "\n"), nil
+}
+
+func buildNativeOpenAITools(tools []llm.Tool) ([]openaiTool, error) {
+	projected := make([]openaiTool, len(tools))
+	for index, tool := range tools {
+		var parameters map[string]any
+		if err := json.Unmarshal(tool.Parameters, &parameters); err != nil {
+			return nil, fmt.Errorf("native OpenAI tool %q parameters: %w", tool.Name, err)
+		}
+		if parameters == nil {
+			return nil, fmt.Errorf("native OpenAI tool %q parameters must be a JSON object", tool.Name)
+		}
+		projected[index].Type = "function"
+		projected[index].Function.Name = tool.Name
+		projected[index].Function.Description = tool.Description
+		projected[index].Function.Parameters = append(json.RawMessage(nil), tool.Parameters...)
+	}
+	return projected, nil
+}
+
+func projectNativeOpenAIResponse(requestModel string, response openaiNativeResponse) (llm.AssistantMessage, error) {
+	choice := response.Choices[0]
+	content := make([]llm.AssistantContent, 0, 1+len(choice.Message.ToolCalls))
+	if choice.Message.Content != "" {
+		content = append(content, llm.TextContent{Text: choice.Message.Content})
+	}
+	for _, toolCall := range choice.Message.ToolCalls {
+		var arguments map[string]any
+		encoded := strings.TrimSpace(toolCall.Function.Arguments)
+		if encoded == "" {
+			arguments = map[string]any{}
+		} else if err := json.Unmarshal([]byte(encoded), &arguments); err != nil {
+			return llm.AssistantMessage{}, fmt.Errorf("native OpenAI tool call %q arguments: %w", toolCall.Function.Name, err)
+		} else if arguments == nil {
+			return llm.AssistantMessage{}, fmt.Errorf("native OpenAI tool call %q arguments must be a JSON object", toolCall.Function.Name)
+		}
+		content = append(content, llm.ToolCall{
+			ID:        toolCall.ID,
+			Name:      toolCall.Function.Name,
+			Arguments: arguments,
+		})
+	}
+	stopReason, err := nativeOpenAIStopReason(choice.FinishReason)
+	if err != nil {
+		return llm.AssistantMessage{}, err
+	}
+	cacheRead := 0
+	if response.Usage.PromptTokensDetails != nil {
+		cacheRead = response.Usage.PromptTokensDetails.CachedTokens
+	}
+	input := max(0, response.Usage.PromptTokens-cacheRead)
+	responseModel := response.Model
+	if responseModel == "" {
+		responseModel = requestModel
+	}
+	return llm.AssistantMessage{
+		Content:       content,
+		API:           llm.APIOpenAICompletions,
+		Provider:      "openai",
+		Model:         requestModel,
+		ResponseModel: responseModel,
+		ResponseID:    response.ID,
+		Usage: llm.Usage{
+			Input:       input,
+			Output:      response.Usage.CompletionTokens,
+			CacheRead:   cacheRead,
+			TotalTokens: response.Usage.PromptTokens + response.Usage.CompletionTokens,
+		},
+		StopReason: stopReason,
+		Timestamp:  time.Now(),
+	}, nil
+}
+
+func nativeOpenAIStopReason(reason string) (llm.StopReason, error) {
+	switch reason {
+	case "stop":
+		return llm.StopReasonStop, nil
+	case "length":
+		return llm.StopReasonLength, nil
+	case "tool_calls", "function_call":
+		return llm.StopReasonToolUse, nil
+	default:
+		return llm.StopReasonError, fmt.Errorf("native OpenAI finish reason %q is unsupported", reason)
+	}
 }
 
 func applyOpenAIStructuredOutput(providerName string, oaiReq *openaiRequest, spec *StructuredOutputSpec) error {


### PR DESCRIPTION
## Summary
- make the configured direct OpenAI provider preserve provider-neutral native tool transcripts while leaving DeepSeek and other compatible endpoints on the legacy path
- map tool definitions, assistant tool calls, matching tool results, final text, images, and structured output through Chat Completions
- add shared OpenAI/OpenRouter contract fixtures and an end-to-end focused-page continuation regression

## Testing
- `go test ./internal/ai ./internal/llm ./internal/agentcore ./internal/agent ./internal/chat ./internal/platform/airouter`

Closes #185