### PR TITLE
Persist focused-page delivery retries

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/p-n-ai/pai-bot/internal/chat"
 	"github.com/p-n-ai/pai-bot/internal/curriculum"
 	"github.com/p-n-ai/pai-bot/internal/focusedpage"
+	"github.com/p-n-ai/pai-bot/internal/focusedpagedelivery"
 	"github.com/p-n-ai/pai-bot/internal/platform/airouter"
 	"github.com/p-n-ai/pai-bot/internal/platform/cache"
 	"github.com/p-n-ai/pai-bot/internal/platform/config"
@@ -254,7 +255,18 @@ func main() {
 
 			// Wire challenge notifications through the gateway.
 			engine.SetNotifier(server.NewGatewayNotifier(gw, store))
-			engine.SetTurnDeliverer(server.NewGatewayTurnDeliverer(gw, store))
+			var focusedPageDeliveries *focusedpagedelivery.Processor
+			if focusedPageService != nil {
+				focusedPageDeliveries, err = focusedpagedelivery.NewProcessor(
+					focusedpagedelivery.NewPostgresStore(db.Pool),
+					server.NewGatewayFocusedPageSender(gw, store, focusedPageService),
+					focusedpagedelivery.DefaultConfig(),
+				)
+				if err != nil {
+					return nil, nil, fmt.Errorf("initialize focused-page deliveries: %w", err)
+				}
+			}
+			engine.SetTurnDeliverer(server.NewGatewayTurnDeliverer(gw, store, focusedPageDeliveries))
 
 			// Start proactive scheduler (nudges for due reviews).
 			nudgeTracker := agent.NewPostgresNudgeTracker(db.Pool, store.TenantID())
@@ -375,6 +387,18 @@ func main() {
 			return http.Handler(topMux), func(ctx context.Context) error {
 				if err := gw.StartAll(ctx, handleInbound); err != nil {
 					return err
+				}
+				if focusedPageDeliveries != nil {
+					workerCtx, cancelWorker := context.WithCancel(ctx)
+					workerDone := make(chan struct{})
+					go func() {
+						defer close(workerDone)
+						focusedPageDeliveries.Run(workerCtx)
+					}()
+					cleanup = append(cleanup, func() {
+						cancelWorker()
+						<-workerDone
+					})
 				}
 				slog.Info("P&AI Bot is running")
 				return nil

--- a/internal/focusedpage/page.go
+++ b/internal/focusedpage/page.go
@@ -172,6 +172,17 @@ func (s *Service) Revoke(ctx context.Context, publicID, tenantID, ownerUserID st
 	return s.store.Revoke(ctx, publicID, tenantID, ownerUserID, s.now().UTC())
 }
 
+// URLFor reconstructs an artifact capability from trusted persisted identity.
+func (s *Service) URLFor(tenantID, turnID, publicID string) (string, error) {
+	if strings.TrimSpace(tenantID) == "" || strings.TrimSpace(turnID) == "" || strings.TrimSpace(publicID) == "" {
+		return "", fmt.Errorf("trusted focused page identity is incomplete")
+	}
+	link := *s.baseURL
+	link.Path = strings.TrimRight(link.Path, "/") + "/a/" + url.PathEscape(publicID)
+	link.Fragment = s.capability(tenantID, turnID, PageIndex)
+	return link.String(), nil
+}
+
 func (s *Service) capability(tenantID, turnID string, pageIndex int) string {
 	mac := hmac.New(sha256.New, s.secret)
 	_, _ = fmt.Fprintf(mac, "focused-page:v1\x00%s\x00%s\x00%d", tenantID, turnID, pageIndex)

--- a/internal/focusedpage/page_test.go
+++ b/internal/focusedpage/page_test.go
@@ -160,6 +160,30 @@ func FuzzParseMessageNormalizationProperties(f *testing.F) {
 	})
 }
 
+func TestURLForReconstructsTheOriginalCapabilityFromPersistedIdentity(t *testing.T) {
+	service, err := NewService(NewMemoryStore(), "https://pages.example", []byte("0123456789abcdef0123456789abcdef"), time.Now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	artifact, err := service.Create(context.Background(), CreateInput{
+		TenantID: "tenant-1", OwnerUserID: "user-1", ConversationID: "conversation-1",
+		TurnID: "turn-1", RecipientName: "Aina", Message: "Goal report",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	reconstructed, err := service.URLFor(artifact.TenantID, artifact.TurnID, artifact.PublicID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reconstructed != artifact.URL {
+		t.Fatalf("reconstructed URL = %q, want %q", reconstructed, artifact.URL)
+	}
+	if _, err := service.URLFor("", artifact.TurnID, artifact.PublicID); err == nil {
+		t.Fatal("incomplete persisted identity was accepted")
+	}
+}
+
 func TestFocusedPageConfigurationRejectsInsecureOriginsAndSecrets(t *testing.T) {
 	store := NewMemoryStore()
 	validSecret := []byte("0123456789abcdef0123456789abcdef")

--- a/internal/focusedpagedelivery/delivery.go
+++ b/internal/focusedpagedelivery/delivery.go
@@ -1,0 +1,288 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package focusedpagedelivery owns durable delivery of focused-page turns.
+package focusedpagedelivery
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+var ErrLeaseLost = errors.New("focused-page delivery lease lost")
+
+type Status string
+
+const (
+	StatusPending   Status = "pending"
+	StatusLeased    Status = "leased"
+	StatusDelivered Status = "delivered"
+)
+
+type Delivery struct {
+	ID                  string
+	TenantID            string
+	TurnID              string
+	Channel             string
+	RecipientID         string
+	FinalText           string
+	FocusedPagePublicID string
+	Status              Status
+	AttemptCount        int
+	NextAttemptAt       time.Time
+	LeaseToken          string
+	LeaseExpiresAt      *time.Time
+	DeliveredAt         *time.Time
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+}
+
+type EnqueueInput struct {
+	TenantID            string
+	TurnID              string
+	Channel             string
+	RecipientID         string
+	FinalText           string
+	FocusedPagePublicID string
+}
+
+type Store interface {
+	Enqueue(context.Context, EnqueueInput, time.Time) (Delivery, error)
+	Claim(context.Context, string, string, time.Time, time.Time) (Delivery, bool, error)
+	ClaimDue(context.Context, string, time.Time, time.Time) (Delivery, bool, error)
+	MarkDelivered(context.Context, string, string, time.Time) error
+	ScheduleRetry(context.Context, string, string, time.Time, time.Time) error
+}
+
+type Sender interface {
+	SendFocusedPage(context.Context, Delivery) error
+}
+
+type Config struct {
+	LeaseDuration time.Duration
+	PollInterval  time.Duration
+	BaseBackoff   time.Duration
+	MaxBackoff    time.Duration
+	Now           func() time.Time
+}
+
+func DefaultConfig() Config {
+	return Config{
+		LeaseDuration: 30 * time.Second,
+		PollInterval:  time.Second,
+		BaseBackoff:   time.Second,
+		MaxBackoff:    5 * time.Minute,
+		Now:           time.Now,
+	}
+}
+
+type Processor struct {
+	store Store
+	send  Sender
+	cfg   Config
+	wake  chan struct{}
+}
+
+func NewProcessor(store Store, sender Sender, cfg Config) (*Processor, error) {
+	if store == nil {
+		return nil, fmt.Errorf("focused-page delivery store is required")
+	}
+	if sender == nil {
+		return nil, fmt.Errorf("focused-page delivery sender is required")
+	}
+	defaults := DefaultConfig()
+	if cfg.LeaseDuration <= 0 {
+		cfg.LeaseDuration = defaults.LeaseDuration
+	}
+	if cfg.PollInterval <= 0 {
+		cfg.PollInterval = defaults.PollInterval
+	}
+	if cfg.BaseBackoff <= 0 {
+		cfg.BaseBackoff = defaults.BaseBackoff
+	}
+	if cfg.MaxBackoff <= 0 {
+		cfg.MaxBackoff = defaults.MaxBackoff
+	}
+	if cfg.MaxBackoff < cfg.BaseBackoff {
+		return nil, fmt.Errorf("focused-page delivery max backoff must not be shorter than base backoff")
+	}
+	if cfg.Now == nil {
+		cfg.Now = defaults.Now
+	}
+	return &Processor{store: store, send: sender, cfg: cfg, wake: make(chan struct{}, 1)}, nil
+}
+
+func (p *Processor) EnqueueAndDeliver(ctx context.Context, input EnqueueInput) error {
+	now := p.now()
+	delivery, err := p.store.Enqueue(ctx, input, now)
+	if err != nil {
+		return fmt.Errorf("enqueue focused-page delivery: %w", err)
+	}
+	p.notify()
+	if delivery.Status == StatusDelivered {
+		return nil
+	}
+	claimed, ok, err := p.claim(ctx, delivery.ID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	return p.sendClaimed(ctx, claimed)
+}
+
+func (p *Processor) Run(ctx context.Context) {
+	timer := time.NewTimer(0)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-p.wake:
+		case <-timer.C:
+		}
+
+		for ctx.Err() == nil {
+			claimed, ok, err := p.claimDue(ctx)
+			if err != nil {
+				if !errors.Is(err, context.Canceled) {
+					slog.Error("focused-page delivery claim failed", "error_category", "store")
+				}
+				break
+			}
+			if !ok {
+				break
+			}
+			_ = p.sendClaimed(ctx, claimed)
+		}
+		timer.Reset(p.cfg.PollInterval)
+	}
+}
+
+func (p *Processor) claim(ctx context.Context, deliveryID string) (Delivery, bool, error) {
+	now := p.now()
+	delivery, ok, err := p.store.Claim(ctx, deliveryID, randomToken(), now, now.Add(p.cfg.LeaseDuration))
+	if err != nil {
+		return Delivery{}, false, fmt.Errorf("claim focused-page delivery: %w", err)
+	}
+	return delivery, ok, nil
+}
+
+func (p *Processor) claimDue(ctx context.Context) (Delivery, bool, error) {
+	now := p.now()
+	delivery, ok, err := p.store.ClaimDue(ctx, randomToken(), now, now.Add(p.cfg.LeaseDuration))
+	if err != nil {
+		return Delivery{}, false, fmt.Errorf("claim due focused-page delivery: %w", err)
+	}
+	return delivery, ok, nil
+}
+
+func (p *Processor) sendClaimed(ctx context.Context, delivery Delivery) error {
+	err := p.send.SendFocusedPage(ctx, delivery)
+	if err != nil {
+		if isCancellation(ctx, err) {
+			return err
+		}
+		nextAttempt := p.now().Add(p.backoff(delivery.AttemptCount + 1))
+		if retryErr := p.store.ScheduleRetry(ctx, delivery.ID, delivery.LeaseToken, nextAttempt, p.now()); retryErr != nil {
+			slog.Error("focused-page delivery retry update failed",
+				"delivery_id", delivery.ID,
+				"status", StatusLeased,
+				"attempt_count", delivery.AttemptCount,
+				"error_category", "store",
+			)
+			return safeDeliveryError{category: "store", cause: retryErr}
+		}
+		slog.Warn("focused-page delivery scheduled for retry",
+			"delivery_id", delivery.ID,
+			"status", StatusPending,
+			"attempt_count", delivery.AttemptCount+1,
+			"error_category", "channel",
+		)
+		return safeDeliveryError{category: "channel", cause: err}
+	}
+	if err := p.store.MarkDelivered(ctx, delivery.ID, delivery.LeaseToken, p.now()); err != nil {
+		slog.Error("focused-page delivery acknowledgement failed",
+			"delivery_id", delivery.ID,
+			"status", StatusLeased,
+			"attempt_count", delivery.AttemptCount,
+			"error_category", "store",
+		)
+		return safeDeliveryError{category: "store", cause: err}
+	}
+	slog.Info("focused-page delivery completed",
+		"delivery_id", delivery.ID,
+		"status", StatusDelivered,
+		"attempt_count", delivery.AttemptCount,
+	)
+	return nil
+}
+
+func (p *Processor) backoff(attempt int) time.Duration {
+	delay := p.cfg.BaseBackoff
+	for currentAttempt := 1; currentAttempt < attempt; currentAttempt++ {
+		if delay >= p.cfg.MaxBackoff/2 {
+			return p.cfg.MaxBackoff
+		}
+		delay *= 2
+	}
+	if delay > p.cfg.MaxBackoff {
+		return p.cfg.MaxBackoff
+	}
+	return delay
+}
+
+func (p *Processor) now() time.Time {
+	return p.cfg.Now().UTC()
+}
+
+func (p *Processor) notify() {
+	select {
+	case p.wake <- struct{}{}:
+	default:
+	}
+}
+
+func isCancellation(ctx context.Context, err error) bool {
+	return ctx.Err() != nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+type safeDeliveryError struct {
+	category string
+	cause    error
+}
+
+func (e safeDeliveryError) Error() string {
+	return "focused-page delivery failed: " + e.category
+}
+
+func (e safeDeliveryError) Unwrap() error {
+	return e.cause
+}
+
+func randomToken() string {
+	var raw [16]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		panic(fmt.Sprintf("generate focused-page delivery lease token: %v", err))
+	}
+	return hex.EncodeToString(raw[:])
+}
+
+func validateInput(input EnqueueInput) error {
+	if strings.TrimSpace(input.TenantID) == "" ||
+		strings.TrimSpace(input.TurnID) == "" ||
+		strings.TrimSpace(input.Channel) == "" ||
+		strings.TrimSpace(input.RecipientID) == "" ||
+		strings.TrimSpace(input.FinalText) == "" ||
+		strings.TrimSpace(input.FocusedPagePublicID) == "" {
+		return fmt.Errorf("focused-page delivery identity and payload are required")
+	}
+	return nil
+}

--- a/internal/focusedpagedelivery/delivery_test.go
+++ b/internal/focusedpagedelivery/delivery_test.go
@@ -1,0 +1,326 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package focusedpagedelivery
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestMemoryStoreEnqueueIsIdempotentAndTenantScoped(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Date(2026, 7, 23, 10, 0, 0, 0, time.UTC)
+	firstInput := deliveryInput("tenant-1", "turn-1")
+	first, err := store.Enqueue(context.Background(), firstInput, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	changed := firstInput
+	changed.RecipientID = "attacker"
+	changed.FinalText = "changed payload"
+	changed.FocusedPagePublicID = "changed-page"
+	duplicate, err := store.Enqueue(context.Background(), changed, now.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if duplicate != first {
+		t.Fatalf("duplicate enqueue changed delivery: got %#v want %#v", duplicate, first)
+	}
+	otherTenant, err := store.Enqueue(context.Background(), deliveryInput("tenant-2", "turn-1"), now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if otherTenant.ID == first.ID {
+		t.Fatal("same turn and channel collided across tenants")
+	}
+}
+
+func TestMemoryStoreAllowsOnlyOneConcurrentClaimer(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Date(2026, 7, 23, 10, 0, 0, 0, time.UTC)
+	delivery, err := store.Enqueue(context.Background(), deliveryInput("tenant-1", "turn-1"), now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var claims atomic.Int32
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, ok, claimErr := store.Claim(context.Background(), delivery.ID, randomToken(), now, now.Add(time.Minute)); claimErr != nil {
+				t.Errorf("claim: %v", claimErr)
+			} else if ok {
+				claims.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+	if claims.Load() != 1 {
+		t.Fatalf("successful claims = %d, want 1", claims.Load())
+	}
+}
+
+func TestProcessorRecoversPendingAndExpiredLeasesWithoutChangingPayload(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Date(2026, 7, 23, 10, 0, 0, 0, time.UTC)
+	current := now
+	input := deliveryInput("tenant-1", "turn-1")
+	pending, err := store.Enqueue(context.Background(), input, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sender := &recordingSender{}
+	processor := newTestProcessor(t, store, sender, func() time.Time { return current })
+	if err := processor.deliverPendingForTest(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(sender.deliveries) != 1 || sender.deliveries[0].FinalText != input.FinalText ||
+		sender.deliveries[0].FocusedPagePublicID != input.FocusedPagePublicID {
+		t.Fatalf("recovered deliveries = %#v", sender.deliveries)
+	}
+	delivered, _ := store.Get(pending.ID)
+	if delivered.Status != StatusDelivered {
+		t.Fatalf("status = %q, want delivered", delivered.Status)
+	}
+
+	second, err := store.Enqueue(context.Background(), deliveryInput("tenant-1", "turn-2"), now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claimed, ok, err := store.Claim(context.Background(), second.ID, "crashed-worker", now, now.Add(time.Minute))
+	if err != nil || !ok {
+		t.Fatalf("initial claim ok = %t, err = %v", ok, err)
+	}
+	if _, ok, err := store.ClaimDue(context.Background(), "new-worker", now.Add(30*time.Second), now.Add(90*time.Second)); err != nil || ok {
+		t.Fatalf("claim before lease expiry ok = %t, err = %v", ok, err)
+	}
+	current = now.Add(time.Minute)
+	reclaimed, ok, err := store.ClaimDue(context.Background(), "new-worker", current, current.Add(time.Minute))
+	if err != nil || !ok {
+		t.Fatalf("expired lease reclaim ok = %t, err = %v", ok, err)
+	}
+	if reclaimed.ID != claimed.ID || reclaimed.FinalText != claimed.FinalText ||
+		reclaimed.FocusedPagePublicID != claimed.FocusedPagePublicID {
+		t.Fatal("lease reclaim changed delivery identity or payload")
+	}
+}
+
+func TestProcessorRetriesWithBoundedBackoffThenSucceeds(t *testing.T) {
+	store := NewMemoryStore()
+	current := time.Date(2026, 7, 23, 10, 0, 0, 0, time.UTC)
+	sender := &recordingSender{failures: 2}
+	processor := newTestProcessor(t, store, sender, func() time.Time { return current })
+	input := deliveryInput("tenant-1", "turn-retry")
+
+	if err := processor.EnqueueAndDeliver(context.Background(), input); err == nil {
+		t.Fatal("first channel failure was not returned")
+	}
+	delivery := onlyDelivery(t, store)
+	if delivery.Status != StatusPending || delivery.AttemptCount != 1 ||
+		!delivery.NextAttemptAt.Equal(current.Add(time.Second)) {
+		t.Fatalf("first retry state = %#v", delivery)
+	}
+	current = current.Add(500 * time.Millisecond)
+	if err := processor.deliverPendingForTest(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(sender.deliveries) != 1 {
+		t.Fatalf("send count before retry due = %d, want 1", len(sender.deliveries))
+	}
+	current = current.Add(500 * time.Millisecond)
+	if err := processor.deliverPendingForTest(context.Background()); err == nil {
+		t.Fatal("second channel failure was not returned")
+	}
+	delivery = onlyDelivery(t, store)
+	if delivery.AttemptCount != 2 || !delivery.NextAttemptAt.Equal(current.Add(2*time.Second)) {
+		t.Fatalf("second retry state = %#v", delivery)
+	}
+	current = current.Add(2 * time.Second)
+	if err := processor.deliverPendingForTest(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	delivery = onlyDelivery(t, store)
+	if delivery.Status != StatusDelivered || len(sender.deliveries) != 3 {
+		t.Fatalf("final state = %#v, sends = %d", delivery, len(sender.deliveries))
+	}
+	if got := processor.backoff(100); got != 8*time.Second {
+		t.Fatalf("bounded backoff = %s, want 8s", got)
+	}
+	for _, attempt := range sender.deliveries {
+		if attempt.FinalText != input.FinalText || attempt.FocusedPagePublicID != input.FocusedPagePublicID {
+			t.Fatal("retry changed immutable payload")
+		}
+	}
+}
+
+func TestSendBeforeAckFailureReplaysAfterLeaseExpiry(t *testing.T) {
+	base := NewMemoryStore()
+	current := time.Date(2026, 7, 23, 10, 0, 0, 0, time.UTC)
+	store := &failFirstAckStore{MemoryStore: base}
+	sender := &recordingSender{}
+	processor := newTestProcessor(t, store, sender, func() time.Time { return current })
+	if err := processor.EnqueueAndDeliver(context.Background(), deliveryInput("tenant-1", "turn-ack")); err == nil {
+		t.Fatal("ack failure was not returned")
+	}
+	if len(sender.deliveries) != 1 {
+		t.Fatalf("first send count = %d, want 1", len(sender.deliveries))
+	}
+	current = current.Add(time.Minute)
+	if err := processor.deliverPendingForTest(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(sender.deliveries) != 2 {
+		t.Fatalf("send-before-ack replay count = %d, want 2", len(sender.deliveries))
+	}
+	if sender.deliveries[0].FinalText != sender.deliveries[1].FinalText ||
+		sender.deliveries[0].FocusedPagePublicID != sender.deliveries[1].FocusedPagePublicID {
+		t.Fatal("send-before-ack replay changed payload")
+	}
+}
+
+func TestProcessorCancellationLeavesLeaseForRestartAndStopsWorker(t *testing.T) {
+	store := NewMemoryStore()
+	current := time.Date(2026, 7, 23, 10, 0, 0, 0, time.UTC)
+	sender := &cancelingSender{entered: make(chan struct{})}
+	processor := newTestProcessor(t, store, sender, func() time.Time { return current })
+	if _, err := store.Enqueue(context.Background(), deliveryInput("tenant-1", "turn-cancel"), current); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		processor.Run(ctx)
+	}()
+	<-sender.entered
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("worker did not stop after context cancellation")
+	}
+	delivery := onlyDelivery(t, store)
+	if delivery.Status != StatusLeased || delivery.AttemptCount != 0 {
+		t.Fatalf("cancelled delivery state = %#v", delivery)
+	}
+}
+
+func TestProcessorLogsOnlySafeDeliveryMetadata(t *testing.T) {
+	store := NewMemoryStore()
+	current := time.Date(2026, 7, 23, 10, 0, 0, 0, time.UTC)
+	sender := &recordingSender{failures: 1, err: errors.New("secret-token private page content")}
+	processor := newTestProcessor(t, store, sender, func() time.Time { return current })
+	var logs bytes.Buffer
+	original := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, nil)))
+	t.Cleanup(func() { slog.SetDefault(original) })
+
+	input := deliveryInput("tenant-1", "turn-safe-logs")
+	input.FinalText = "private tutor response"
+	input.FocusedPagePublicID = "private-public-id"
+	_ = processor.EnqueueAndDeliver(context.Background(), input)
+	output := logs.String()
+	for _, secret := range []string{input.FinalText, input.FocusedPagePublicID, input.RecipientID, "secret-token", "private page content"} {
+		if strings.Contains(output, secret) {
+			t.Fatalf("log contains private value %q: %s", secret, output)
+		}
+	}
+	for _, safe := range []string{"delivery_id", "status", "attempt_count", "error_category"} {
+		if !strings.Contains(output, safe) {
+			t.Fatalf("log missing safe field %q: %s", safe, output)
+		}
+	}
+}
+
+func (p *Processor) deliverPendingForTest(ctx context.Context) error {
+	delivery, ok, err := p.claimDue(ctx)
+	if err != nil || !ok {
+		return err
+	}
+	return p.sendClaimed(ctx, delivery)
+}
+
+func newTestProcessor(t *testing.T, store Store, sender Sender, now func() time.Time) *Processor {
+	t.Helper()
+	processor, err := NewProcessor(store, sender, Config{
+		LeaseDuration: time.Minute,
+		PollInterval:  time.Millisecond,
+		BaseBackoff:   time.Second,
+		MaxBackoff:    8 * time.Second,
+		Now:           now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return processor
+}
+
+func deliveryInput(tenantID, turnID string) EnqueueInput {
+	return EnqueueInput{
+		TenantID: tenantID, TurnID: turnID, Channel: "telegram", RecipientID: "learner-1",
+		FinalText: "Your report is ready.", FocusedPagePublicID: "page-" + turnID,
+	}
+}
+
+func onlyDelivery(t *testing.T, store *MemoryStore) Delivery {
+	t.Helper()
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if len(store.deliveries) != 1 {
+		t.Fatalf("deliveries = %d, want 1", len(store.deliveries))
+	}
+	for _, delivery := range store.deliveries {
+		return cloneDelivery(delivery)
+	}
+	return Delivery{}
+}
+
+type recordingSender struct {
+	failures   int
+	err        error
+	deliveries []Delivery
+}
+
+func (s *recordingSender) SendFocusedPage(_ context.Context, delivery Delivery) error {
+	s.deliveries = append(s.deliveries, delivery)
+	if len(s.deliveries) <= s.failures {
+		if s.err != nil {
+			return s.err
+		}
+		return errors.New("channel unavailable")
+	}
+	return nil
+}
+
+type cancelingSender struct {
+	entered chan struct{}
+	once    sync.Once
+}
+
+func (s *cancelingSender) SendFocusedPage(ctx context.Context, _ Delivery) error {
+	s.once.Do(func() { close(s.entered) })
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+type failFirstAckStore struct {
+	*MemoryStore
+	failed bool
+}
+
+func (s *failFirstAckStore) MarkDelivered(ctx context.Context, id, token string, now time.Time) error {
+	if !s.failed {
+		s.failed = true
+		return errors.New("database unavailable")
+	}
+	return s.MemoryStore.MarkDelivered(ctx, id, token, now)
+}

--- a/internal/focusedpagedelivery/store_memory.go
+++ b/internal/focusedpagedelivery/store_memory.go
@@ -1,0 +1,164 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package focusedpagedelivery
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+type MemoryStore struct {
+	mu         sync.Mutex
+	nextID     int
+	deliveries map[string]Delivery
+	keys       map[string]string
+}
+
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{deliveries: make(map[string]Delivery), keys: make(map[string]string)}
+}
+
+func (s *MemoryStore) Enqueue(ctx context.Context, input EnqueueInput, now time.Time) (Delivery, error) {
+	if err := ctx.Err(); err != nil {
+		return Delivery{}, err
+	}
+	if err := validateInput(input); err != nil {
+		return Delivery{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := input.TenantID + "\x00" + input.TurnID + "\x00" + input.Channel
+	if id, ok := s.keys[key]; ok {
+		return cloneDelivery(s.deliveries[id]), nil
+	}
+	s.nextID++
+	id := fmt.Sprintf("delivery-%d", s.nextID)
+	delivery := Delivery{
+		ID: id, TenantID: input.TenantID, TurnID: input.TurnID, Channel: input.Channel,
+		RecipientID: input.RecipientID, FinalText: input.FinalText,
+		FocusedPagePublicID: input.FocusedPagePublicID, Status: StatusPending,
+		NextAttemptAt: now, CreatedAt: now, UpdatedAt: now,
+	}
+	s.deliveries[id] = delivery
+	s.keys[key] = id
+	return cloneDelivery(delivery), nil
+}
+
+func (s *MemoryStore) Claim(ctx context.Context, id, token string, now, leaseExpiry time.Time) (Delivery, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return Delivery{}, false, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delivery, ok := s.deliveries[id]
+	if !ok || !claimable(delivery, now) {
+		return Delivery{}, false, nil
+	}
+	return s.lease(delivery, token, now, leaseExpiry), true, nil
+}
+
+func (s *MemoryStore) ClaimDue(ctx context.Context, token string, now, leaseExpiry time.Time) (Delivery, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return Delivery{}, false, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var selected *Delivery
+	for _, delivery := range s.deliveries {
+		if !claimable(delivery, now) {
+			continue
+		}
+		if selected == nil || delivery.NextAttemptAt.Before(selected.NextAttemptAt) ||
+			(delivery.NextAttemptAt.Equal(selected.NextAttemptAt) && delivery.CreatedAt.Before(selected.CreatedAt)) {
+			copy := delivery
+			selected = &copy
+		}
+	}
+	if selected == nil {
+		return Delivery{}, false, nil
+	}
+	return s.lease(*selected, token, now, leaseExpiry), true, nil
+}
+
+func (s *MemoryStore) MarkDelivered(ctx context.Context, id, token string, now time.Time) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delivery, ok := s.deliveries[id]
+	if !ok || delivery.Status != StatusLeased || delivery.LeaseToken != token {
+		return ErrLeaseLost
+	}
+	delivery.Status = StatusDelivered
+	delivery.LeaseToken = ""
+	delivery.LeaseExpiresAt = nil
+	delivery.DeliveredAt = timePointer(now)
+	delivery.UpdatedAt = now
+	s.deliveries[id] = delivery
+	return nil
+}
+
+func (s *MemoryStore) ScheduleRetry(ctx context.Context, id, token string, nextAttempt, now time.Time) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delivery, ok := s.deliveries[id]
+	if !ok || delivery.Status != StatusLeased || delivery.LeaseToken != token {
+		return ErrLeaseLost
+	}
+	delivery.Status = StatusPending
+	delivery.AttemptCount++
+	delivery.NextAttemptAt = nextAttempt
+	delivery.LeaseToken = ""
+	delivery.LeaseExpiresAt = nil
+	delivery.UpdatedAt = now
+	s.deliveries[id] = delivery
+	return nil
+}
+
+func (s *MemoryStore) Get(id string) (Delivery, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delivery, ok := s.deliveries[id]
+	return cloneDelivery(delivery), ok
+}
+
+func (s *MemoryStore) lease(delivery Delivery, token string, now, leaseExpiry time.Time) Delivery {
+	delivery.Status = StatusLeased
+	delivery.LeaseToken = token
+	delivery.LeaseExpiresAt = timePointer(leaseExpiry)
+	delivery.UpdatedAt = now
+	s.deliveries[delivery.ID] = delivery
+	return cloneDelivery(delivery)
+}
+
+func claimable(delivery Delivery, now time.Time) bool {
+	switch delivery.Status {
+	case StatusPending:
+		return !delivery.NextAttemptAt.After(now)
+	case StatusLeased:
+		return delivery.LeaseExpiresAt != nil && !delivery.LeaseExpiresAt.After(now)
+	default:
+		return false
+	}
+}
+
+func cloneDelivery(delivery Delivery) Delivery {
+	if delivery.LeaseExpiresAt != nil {
+		delivery.LeaseExpiresAt = timePointer(*delivery.LeaseExpiresAt)
+	}
+	if delivery.DeliveredAt != nil {
+		delivery.DeliveredAt = timePointer(*delivery.DeliveredAt)
+	}
+	return delivery
+}
+
+func timePointer(value time.Time) *time.Time {
+	return &value
+}

--- a/internal/focusedpagedelivery/store_postgres.go
+++ b/internal/focusedpagedelivery/store_postgres.go
@@ -1,0 +1,153 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package focusedpagedelivery
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type PostgresStore struct{ pool *pgxpool.Pool }
+
+func NewPostgresStore(pool *pgxpool.Pool) *PostgresStore {
+	return &PostgresStore{pool: pool}
+}
+
+func (s *PostgresStore) Enqueue(ctx context.Context, input EnqueueInput, now time.Time) (Delivery, error) {
+	if s.pool == nil {
+		return Delivery{}, fmt.Errorf("focused-page delivery pool is nil")
+	}
+	if err := validateInput(input); err != nil {
+		return Delivery{}, err
+	}
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO focused_page_deliveries (
+			tenant_id, turn_id, channel, recipient_id, final_text,
+			focused_page_public_id, status, next_attempt_at, created_at, updated_at
+		) VALUES ($1::uuid, $2, $3, $4, $5, $6, 'pending', $7, $7, $7)
+		ON CONFLICT (tenant_id, turn_id, channel) DO NOTHING`,
+		input.TenantID, input.TurnID, input.Channel, input.RecipientID, input.FinalText,
+		input.FocusedPagePublicID, now)
+	if err != nil {
+		return Delivery{}, fmt.Errorf("enqueue focused-page delivery: %w", err)
+	}
+	delivery, err := s.getByKey(ctx, input.TenantID, input.TurnID, input.Channel)
+	if err != nil {
+		return Delivery{}, err
+	}
+	return delivery, nil
+}
+
+func (s *PostgresStore) Claim(ctx context.Context, id, token string, now, leaseExpiry time.Time) (Delivery, bool, error) {
+	return s.claim(ctx, `id = $1::uuid`, []any{id}, token, now, leaseExpiry)
+}
+
+func (s *PostgresStore) ClaimDue(ctx context.Context, token string, now, leaseExpiry time.Time) (Delivery, bool, error) {
+	return s.claim(ctx, `TRUE`, nil, token, now, leaseExpiry)
+}
+
+func (s *PostgresStore) claim(ctx context.Context, selector string, selectorArgs []any, token string, now, leaseExpiry time.Time) (Delivery, bool, error) {
+	args := append(selectorArgs, token, now, leaseExpiry)
+	tokenArg := len(selectorArgs) + 1
+	nowArg := tokenArg + 1
+	expiryArg := nowArg + 1
+	query := fmt.Sprintf(`
+		WITH candidate AS (
+			SELECT id
+			FROM focused_page_deliveries
+			WHERE %s
+			  AND (
+				(status = 'pending' AND next_attempt_at <= $%d)
+				OR (status = 'leased' AND lease_expires_at <= $%d)
+			  )
+			ORDER BY next_attempt_at, created_at
+			FOR UPDATE SKIP LOCKED
+			LIMIT 1
+		)
+		UPDATE focused_page_deliveries AS delivery
+		SET status = 'leased', lease_token = $%d, lease_expires_at = $%d, updated_at = $%d
+		FROM candidate
+		WHERE delivery.id = candidate.id
+		RETURNING delivery.id::text, delivery.tenant_id::text, delivery.turn_id,
+		          delivery.channel, delivery.recipient_id, delivery.final_text,
+		          delivery.focused_page_public_id, delivery.status, delivery.attempt_count,
+		          delivery.next_attempt_at, delivery.lease_token, delivery.lease_expires_at,
+		          delivery.delivered_at, delivery.created_at, delivery.updated_at`,
+		selector, nowArg, nowArg, tokenArg, expiryArg, nowArg)
+	delivery, err := scanDelivery(s.pool.QueryRow(ctx, query, args...))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Delivery{}, false, nil
+	}
+	if err != nil {
+		return Delivery{}, false, fmt.Errorf("claim focused-page delivery: %w", err)
+	}
+	return delivery, true, nil
+}
+
+func (s *PostgresStore) MarkDelivered(ctx context.Context, id, token string, now time.Time) error {
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE focused_page_deliveries
+		SET status = 'delivered', lease_token = NULL, lease_expires_at = NULL,
+		    delivered_at = $3, updated_at = $3
+		WHERE id = $1::uuid AND status = 'leased' AND lease_token = $2`,
+		id, token, now)
+	if err != nil {
+		return fmt.Errorf("mark focused-page delivery delivered: %w", err)
+	}
+	if tag.RowsAffected() != 1 {
+		return ErrLeaseLost
+	}
+	return nil
+}
+
+func (s *PostgresStore) ScheduleRetry(ctx context.Context, id, token string, nextAttempt, now time.Time) error {
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE focused_page_deliveries
+		SET status = 'pending', attempt_count = attempt_count + 1,
+		    next_attempt_at = $3, lease_token = NULL, lease_expires_at = NULL, updated_at = $4
+		WHERE id = $1::uuid AND status = 'leased' AND lease_token = $2`,
+		id, token, nextAttempt, now)
+	if err != nil {
+		return fmt.Errorf("schedule focused-page delivery retry: %w", err)
+	}
+	if tag.RowsAffected() != 1 {
+		return ErrLeaseLost
+	}
+	return nil
+}
+
+func (s *PostgresStore) getByKey(ctx context.Context, tenantID, turnID, channel string) (Delivery, error) {
+	delivery, err := scanDelivery(s.pool.QueryRow(ctx, `
+		SELECT id::text, tenant_id::text, turn_id, channel, recipient_id, final_text,
+		       focused_page_public_id, status, attempt_count, next_attempt_at,
+		       COALESCE(lease_token, ''), lease_expires_at, delivered_at, created_at, updated_at
+		FROM focused_page_deliveries
+		WHERE tenant_id = $1::uuid AND turn_id = $2 AND channel = $3`,
+		tenantID, turnID, channel))
+	if err != nil {
+		return Delivery{}, fmt.Errorf("get focused-page delivery: %w", err)
+	}
+	return delivery, nil
+}
+
+type rowScanner interface {
+	Scan(...any) error
+}
+
+func scanDelivery(row rowScanner) (Delivery, error) {
+	var delivery Delivery
+	err := row.Scan(
+		&delivery.ID, &delivery.TenantID, &delivery.TurnID, &delivery.Channel,
+		&delivery.RecipientID, &delivery.FinalText, &delivery.FocusedPagePublicID,
+		&delivery.Status, &delivery.AttemptCount, &delivery.NextAttemptAt,
+		&delivery.LeaseToken, &delivery.LeaseExpiresAt, &delivery.DeliveredAt,
+		&delivery.CreatedAt, &delivery.UpdatedAt,
+	)
+	return delivery, err
+}

--- a/internal/focusedpagedelivery/store_postgres_integration_test.go
+++ b/internal/focusedpagedelivery/store_postgres_integration_test.go
@@ -209,6 +209,7 @@ func startDeliveryPostgres(t *testing.T, ctx context.Context) *pgxpool.Pool {
 		"20260318100400_auth_identity_tenant_consistency.sql",
 		"20260713100000_focused_pages.sql",
 		"20260723163958_focused_page_deliveries.sql",
+		"20260723170429_focused_page_delivery_cleanup_cascade.sql",
 	} {
 		applyDeliveryMigration(t, ctx, pool, filepath.Join("..", "..", "migrations", name))
 	}

--- a/internal/focusedpagedelivery/store_postgres_integration_test.go
+++ b/internal/focusedpagedelivery/store_postgres_integration_test.go
@@ -24,6 +24,7 @@ func TestPostgresStoreDurableLeasingAndTenantIsolation(t *testing.T) {
 	pool := startDeliveryPostgres(t, ctx)
 	tenant1, page1 := seedDeliveryIdentity(t, ctx, pool, "tenant-one", "turn-1", "page-one")
 	tenant2, page2 := seedDeliveryIdentity(t, ctx, pool, "tenant-two", "turn-1", "page-two")
+	tenant3, page3 := seedDeliveryIdentity(t, ctx, pool, "tenant-three", "turn-1", "page-three")
 	store := NewPostgresStore(pool)
 	now := time.Date(2026, 7, 23, 10, 0, 0, 0, time.UTC)
 
@@ -55,6 +56,17 @@ func TestPostgresStoreDurableLeasingAndTenantIsolation(t *testing.T) {
 	}
 	if otherTenant.ID == first.ID {
 		t.Fatal("delivery identity collided across tenants")
+	}
+	leased, err := store.Enqueue(ctx, EnqueueInput{
+		TenantID: tenant3, TurnID: "turn-1", Channel: "telegram", RecipientID: "learner-three",
+		FinalText: "Leased tenant text", FocusedPagePublicID: page3,
+	}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leased, ok, err := store.Claim(ctx, leased.ID, "cleanup-lease", now, now.Add(time.Minute))
+	if err != nil || !ok {
+		t.Fatalf("cleanup lease claim ok = %t, err = %v", ok, err)
 	}
 	if _, err := store.Enqueue(ctx, EnqueueInput{
 		TenantID: tenant1, TurnID: "turn-1", Channel: "whatsapp", RecipientID: "learner-one",
@@ -118,6 +130,48 @@ func TestPostgresStoreDurableLeasingAndTenantIsolation(t *testing.T) {
 	}
 	if _, ok, err := restarted.Claim(ctx, first.ID, "after-delivery", now.Add(4*time.Minute), now.Add(5*time.Minute)); err != nil || ok {
 		t.Fatalf("delivered row claim ok = %t, err = %v", ok, err)
+	}
+
+	t.Run("parent deletion cascades pending leased and delivered rows", func(t *testing.T) {
+		assertDeliveryStatus(t, ctx, pool, otherTenant.ID, StatusPending)
+		assertDeliveryStatus(t, ctx, pool, leased.ID, StatusLeased)
+		assertDeliveryStatus(t, ctx, pool, first.ID, StatusDelivered)
+		tag, err := pool.Exec(ctx, `
+			DELETE FROM focused_pages
+			WHERE public_id = ANY($1::text[])`,
+			[]string{page1, page2, page3})
+		if err != nil {
+			t.Fatalf("delete expired parent pages: %v", err)
+		}
+		if tag.RowsAffected() != 3 {
+			t.Fatalf("deleted parent pages = %d, want 3", tag.RowsAffected())
+		}
+		var remaining int
+		if err := pool.QueryRow(ctx, `
+			SELECT count(*)
+			FROM focused_page_deliveries
+			WHERE id = ANY($1::uuid[])`,
+			[]string{first.ID, otherTenant.ID, leased.ID}).Scan(&remaining); err != nil {
+			t.Fatal(err)
+		}
+		if remaining != 0 {
+			t.Fatalf("orphaned delivery rows = %d, want 0", remaining)
+		}
+	})
+}
+
+func assertDeliveryStatus(t *testing.T, ctx context.Context, pool *pgxpool.Pool, deliveryID string, want Status) {
+	t.Helper()
+	var got Status
+	if err := pool.QueryRow(ctx, `
+		SELECT status
+		FROM focused_page_deliveries
+		WHERE id = $1::uuid`,
+		deliveryID).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("delivery %s status = %q, want %q", deliveryID, got, want)
 	}
 }
 

--- a/internal/focusedpagedelivery/store_postgres_integration_test.go
+++ b/internal/focusedpagedelivery/store_postgres_integration_test.go
@@ -1,0 +1,211 @@
+//go:build integration
+
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package focusedpagedelivery
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+)
+
+func TestPostgresStoreDurableLeasingAndTenantIsolation(t *testing.T) {
+	ctx := context.Background()
+	pool := startDeliveryPostgres(t, ctx)
+	tenant1, page1 := seedDeliveryIdentity(t, ctx, pool, "tenant-one", "turn-1", "page-one")
+	tenant2, page2 := seedDeliveryIdentity(t, ctx, pool, "tenant-two", "turn-1", "page-two")
+	store := NewPostgresStore(pool)
+	now := time.Date(2026, 7, 23, 10, 0, 0, 0, time.UTC)
+
+	firstInput := EnqueueInput{
+		TenantID: tenant1, TurnID: "turn-1", Channel: "telegram", RecipientID: "learner-one",
+		FinalText: "Original text", FocusedPagePublicID: page1,
+	}
+	first, err := store.Enqueue(ctx, firstInput, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	changed := firstInput
+	changed.RecipientID = "changed"
+	changed.FinalText = "Changed text"
+	duplicate, err := store.Enqueue(ctx, changed, now.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if duplicate.ID != first.ID || duplicate.RecipientID != firstInput.RecipientID ||
+		duplicate.FinalText != firstInput.FinalText || duplicate.FocusedPagePublicID != page1 {
+		t.Fatalf("idempotent enqueue changed row: %#v", duplicate)
+	}
+	otherTenant, err := store.Enqueue(ctx, EnqueueInput{
+		TenantID: tenant2, TurnID: "turn-1", Channel: "telegram", RecipientID: "learner-two",
+		FinalText: "Other tenant text", FocusedPagePublicID: page2,
+	}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if otherTenant.ID == first.ID {
+		t.Fatal("delivery identity collided across tenants")
+	}
+	if _, err := store.Enqueue(ctx, EnqueueInput{
+		TenantID: tenant1, TurnID: "turn-1", Channel: "whatsapp", RecipientID: "learner-one",
+		FinalText: "Wrong page tenant", FocusedPagePublicID: page2,
+	}, now); err == nil {
+		t.Fatal("cross-tenant focused-page reference was accepted")
+	}
+
+	var claims atomic.Int32
+	var claimed Delivery
+	var claimMu sync.Mutex
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			delivery, ok, claimErr := store.Claim(ctx, first.ID, randomToken(), now, now.Add(time.Minute))
+			if claimErr != nil {
+				t.Errorf("claim: %v", claimErr)
+				return
+			}
+			if ok {
+				claims.Add(1)
+				claimMu.Lock()
+				claimed = delivery
+				claimMu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+	if claims.Load() != 1 {
+		t.Fatalf("concurrent successful claims = %d, want 1", claims.Load())
+	}
+
+	restarted := NewPostgresStore(pool)
+	if _, ok, err := restarted.Claim(ctx, first.ID, "early", now.Add(30*time.Second), now.Add(90*time.Second)); err != nil || ok {
+		t.Fatalf("claim before lease expiry ok = %t, err = %v", ok, err)
+	}
+	reclaimed, ok, err := restarted.Claim(ctx, first.ID, "restart", now.Add(time.Minute), now.Add(2*time.Minute))
+	if err != nil || !ok {
+		t.Fatalf("restart reclaim ok = %t, err = %v", ok, err)
+	}
+	if reclaimed.FinalText != claimed.FinalText || reclaimed.FocusedPagePublicID != claimed.FocusedPagePublicID {
+		t.Fatal("restart reclaim changed payload")
+	}
+	if err := restarted.ScheduleRetry(ctx, reclaimed.ID, reclaimed.LeaseToken, now.Add(2*time.Minute), now.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, err := restarted.Claim(ctx, first.ID, "before-backoff", now.Add(90*time.Second), now.Add(3*time.Minute)); err != nil || ok {
+		t.Fatalf("claim before retry backoff ok = %t, err = %v", ok, err)
+	}
+	retry, ok, err := restarted.Claim(ctx, first.ID, "after-backoff", now.Add(2*time.Minute), now.Add(3*time.Minute))
+	if err != nil || !ok {
+		t.Fatalf("claim after retry backoff ok = %t, err = %v", ok, err)
+	}
+	if retry.AttemptCount != 1 {
+		t.Fatalf("attempt count = %d, want 1", retry.AttemptCount)
+	}
+	if err := restarted.MarkDelivered(ctx, retry.ID, retry.LeaseToken, now.Add(2*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, err := restarted.Claim(ctx, first.ID, "after-delivery", now.Add(4*time.Minute), now.Add(5*time.Minute)); err != nil || ok {
+		t.Fatalf("delivered row claim ok = %t, err = %v", ok, err)
+	}
+}
+
+func startDeliveryPostgres(t *testing.T, ctx context.Context) *pgxpool.Pool {
+	t.Helper()
+	container, err := tcpostgres.Run(ctx, "postgres:17-alpine",
+		tcpostgres.WithDatabase("pai"),
+		tcpostgres.WithUsername("pai"),
+		tcpostgres.WithPassword("pai"),
+		tcpostgres.BasicWaitStrategies(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = container.Terminate(context.Background()) })
+	connString, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool, err := pgxpool.New(ctx, connString)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	deadline := time.Now().Add(15 * time.Second)
+	for pool.Ping(ctx) != nil {
+		if time.Now().After(deadline) {
+			t.Fatal("postgres did not become ready")
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	for _, name := range []string{
+		"20260318100000_initial.sql",
+		"20260318100300_auth_tables.sql",
+		"20260318100400_auth_identity_tenant_consistency.sql",
+		"20260713100000_focused_pages.sql",
+		"20260723163958_focused_page_deliveries.sql",
+	} {
+		applyDeliveryMigration(t, ctx, pool, filepath.Join("..", "..", "migrations", name))
+	}
+	return pool
+}
+
+func seedDeliveryIdentity(t *testing.T, ctx context.Context, pool *pgxpool.Pool, slug, turnID, publicID string) (string, string) {
+	t.Helper()
+	var tenantID string
+	if err := pool.QueryRow(ctx, `INSERT INTO tenants (name, slug) VALUES ($1, $1) RETURNING id::text`, slug).Scan(&tenantID); err != nil {
+		t.Fatal(err)
+	}
+	var userID string
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO users (tenant_id, role, name, external_id, channel)
+		VALUES ($1, 'student', $2, $2, 'telegram') RETURNING id::text`,
+		tenantID, slug+"-learner").Scan(&userID); err != nil {
+		t.Fatal(err)
+	}
+	var conversationID string
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO conversations (tenant_id, user_id, state)
+		VALUES ($1, $2, 'teaching') RETURNING id::text`,
+		tenantID, userID).Scan(&conversationID); err != nil {
+		t.Fatal(err)
+	}
+	created := time.Date(2026, 7, 23, 10, 0, 0, 0, time.UTC)
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO focused_pages (
+			public_id, tenant_id, owner_user_id, conversation_id, turn_id, recipient_name,
+			message, token_hash, status, created_at, expires_at
+		) VALUES ($1, $2, $3, $4, $5, 'Learner', 'Private content', $6, 'active', $7, $8)`,
+		publicID, tenantID, userID, conversationID, turnID, make([]byte, 32), created, created.Add(time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	return tenantID, publicID
+}
+
+func applyDeliveryMigration(t *testing.T, ctx context.Context, pool *pgxpool.Pool, path string) {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(content)
+	up := strings.Index(text, "-- +goose Up")
+	down := strings.Index(text, "-- +goose Down")
+	if up < 0 || down < 0 || down <= up {
+		t.Fatalf("invalid goose migration %s", path)
+	}
+	if _, err := pool.Exec(ctx, text[up+len("-- +goose Up"):down]); err != nil {
+		t.Fatalf("apply %s: %v", path, err)
+	}
+}

--- a/internal/server/focused_page_delivery_test.go
+++ b/internal/server/focused_page_delivery_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/p-n-ai/pai-bot/internal/agent"
+	"github.com/p-n-ai/pai-bot/internal/chat"
+	"github.com/p-n-ai/pai-bot/internal/focusedpage"
+	"github.com/p-n-ai/pai-bot/internal/focusedpagedelivery"
+)
+
+func TestGatewayTurnDelivererPersistsFocusedPageBeforeSendingStoredPayload(t *testing.T) {
+	ctx := context.Background()
+	conversations := agent.NewMemoryStore()
+	_ = conversations.SetUserName("learner-1", "Aina")
+	pages, err := focusedpage.NewService(
+		focusedpage.NewMemoryStore(),
+		"https://pages.example",
+		[]byte("0123456789abcdef0123456789abcdef"),
+		time.Now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	artifact, err := pages.Create(ctx, focusedpage.CreateInput{
+		TenantID: "tenant-1", OwnerUserID: "user-1", ConversationID: "conversation-1",
+		TurnID: "turn-1", RecipientName: "Aina", Message: "Private goal report",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gateway := chat.NewGateway()
+	channel := &chat.MockChannel{}
+	gateway.Register("telegram", channel)
+	outbox := focusedpagedelivery.NewMemoryStore()
+	processor, err := focusedpagedelivery.NewProcessor(
+		outbox,
+		NewGatewayFocusedPageSender(gateway, conversations, pages),
+		focusedpagedelivery.DefaultConfig(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	deliverer := NewGatewayTurnDeliverer(gateway, conversations, processor)
+	result := agent.TurnResult{Text: "Your report is ready.", FocusedPage: &artifact}
+	if err := deliverer.DeliverTurn(ctx, chat.InboundMessage{Channel: "telegram", UserID: "learner-1"}, result); err != nil {
+		t.Fatal(err)
+	}
+	if len(channel.SentMessages) != 1 {
+		t.Fatalf("sent messages = %d, want 1", len(channel.SentMessages))
+	}
+	sent := channel.SentMessages[0]
+	if sent.Text != result.Text {
+		t.Fatalf("sent text = %q, want %q", sent.Text, result.Text)
+	}
+	var focusedURL string
+	for _, row := range sent.InlineKeyboard {
+		for _, button := range row {
+			if button.URL != "" {
+				focusedURL = button.URL
+			}
+		}
+	}
+	if focusedURL != artifact.URL {
+		t.Fatalf("focused-page URL = %q, want %q", focusedURL, artifact.URL)
+	}
+}
+
+func TestFocusedPageOutboxLeavesPlainTurnsRemindersAndNotificationsOnDirectGatewayPaths(t *testing.T) {
+	ctx := context.Background()
+	conversations := agent.NewMemoryStore()
+	_ = conversations.SetUserName("learner-1", "Aina")
+	gateway := chat.NewGateway()
+	channel := &chat.MockChannel{}
+	gateway.Register("telegram", channel)
+
+	turns := NewGatewayTurnDeliverer(gateway, conversations, nil)
+	if err := turns.DeliverTurn(ctx,
+		chat.InboundMessage{Channel: "telegram", UserID: "learner-1"},
+		agent.TurnResult{Text: "Plain tutor response"},
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := NewGatewaySender(gateway).Send(ctx, outboundMessage{
+		Channel: "telegram", UserID: "learner-1", Text: "Reminder",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	NewGatewayNotifier(gateway, conversations).Notify(ctx, "telegram", "learner-1", "Notification")
+
+	if len(channel.SentMessages) != 3 {
+		t.Fatalf("direct gateway messages = %d, want 3", len(channel.SentMessages))
+	}
+	got := []string{
+		channel.SentMessages[0].Text,
+		channel.SentMessages[1].Text,
+		channel.SentMessages[2].Text,
+	}
+	want := []string{"Plain tutor response", "Reminder", "Notification"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("message %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -23,6 +23,8 @@ import (
 	"github.com/p-n-ai/pai-bot/internal/auth"
 	"github.com/p-n-ai/pai-bot/internal/chat"
 	"github.com/p-n-ai/pai-bot/internal/curriculum"
+	"github.com/p-n-ai/pai-bot/internal/focusedpage"
+	"github.com/p-n-ai/pai-bot/internal/focusedpagedelivery"
 	"github.com/p-n-ai/pai-bot/internal/platform/settings"
 	"github.com/p-n-ai/pai-bot/internal/retrieval"
 )
@@ -43,8 +45,11 @@ func NewGatewaySender(gw *chat.Gateway) messageSender { return gatewaySender{gw:
 func NewGatewayNotifier(gw *chat.Gateway, channels userChannelLookup) GatewayNotifier {
 	return gatewayNotifier{gw: gw, channels: channels}
 }
-func NewGatewayTurnDeliverer(gw *chat.Gateway, store agent.ConversationStore) GatewayTurnDeliverer {
-	return gatewayTurnDeliverer{gw: gw, store: store}
+func NewGatewayTurnDeliverer(gw *chat.Gateway, store agent.ConversationStore, deliveries *focusedpagedelivery.Processor) GatewayTurnDeliverer {
+	return gatewayTurnDeliverer{gw: gw, store: store, deliveries: deliveries}
+}
+func NewGatewayFocusedPageSender(gw *chat.Gateway, store agent.ConversationStore, pages *focusedpage.Service) focusedpagedelivery.Sender {
+	return gatewayFocusedPageSender{gw: gw, store: store, pages: pages}
 }
 func NewWeeklyParentReportSource(admin *adminapi.Service) weeklyParentReportSource {
 	return weeklyParentReportSource{admin: admin}
@@ -276,20 +281,52 @@ type gatewayNotifier struct {
 }
 
 type gatewayTurnDeliverer struct {
-	gw    *chat.Gateway
-	store agent.ConversationStore
+	gw         *chat.Gateway
+	store      agent.ConversationStore
+	deliveries *focusedpagedelivery.Processor
 }
 
 func (d gatewayTurnDeliverer) DeliverTurn(ctx context.Context, inbound chat.InboundMessage, result agent.TurnResult) error {
-	pageURL := ""
 	if result.FocusedPage != nil {
-		pageURL = result.FocusedPage.URL
+		if d.deliveries == nil {
+			return fmt.Errorf("focused-page delivery processor is not configured")
+		}
+		return d.deliveries.EnqueueAndDeliver(ctx, focusedpagedelivery.EnqueueInput{
+			TenantID:            result.FocusedPage.TenantID,
+			TurnID:              result.FocusedPage.TurnID,
+			Channel:             inbound.Channel,
+			RecipientID:         inbound.UserID,
+			FinalText:           result.Text,
+			FocusedPagePublicID: result.FocusedPage.PublicID,
+		})
 	}
-	out, ok := chat.RenderTurn(inbound, result.Text, pageURL, telegramInlineKeyboardContext(d.store, inbound.UserID))
+	out, ok := chat.RenderTurn(inbound, result.Text, "", telegramInlineKeyboardContext(d.store, inbound.UserID))
 	if !ok {
 		return nil
 	}
 	return d.gw.Send(ctx, out)
+}
+
+type gatewayFocusedPageSender struct {
+	gw    *chat.Gateway
+	store agent.ConversationStore
+	pages *focusedpage.Service
+}
+
+func (s gatewayFocusedPageSender) SendFocusedPage(ctx context.Context, delivery focusedpagedelivery.Delivery) error {
+	if s.pages == nil {
+		return fmt.Errorf("focused-page service is not configured")
+	}
+	pageURL, err := s.pages.URLFor(delivery.TenantID, delivery.TurnID, delivery.FocusedPagePublicID)
+	if err != nil {
+		return fmt.Errorf("reconstruct focused-page URL: %w", err)
+	}
+	inbound := chat.InboundMessage{Channel: delivery.Channel, UserID: delivery.RecipientID}
+	out, ok := chat.RenderTurn(inbound, delivery.FinalText, pageURL, telegramInlineKeyboardContext(s.store, delivery.RecipientID))
+	if !ok {
+		return nil
+	}
+	return s.gw.Send(ctx, out)
 }
 
 func (g gatewayNotifier) Notify(ctx context.Context, _, userID, text string) {

--- a/migrations/20260723163958_focused_page_deliveries.sql
+++ b/migrations/20260723163958_focused_page_deliveries.sql
@@ -22,7 +22,7 @@ CREATE TABLE focused_page_deliveries (
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     FOREIGN KEY (tenant_id) REFERENCES tenants(id),
     FOREIGN KEY (tenant_id, focused_page_public_id, turn_id)
-        REFERENCES focused_pages(tenant_id, public_id, turn_id) ON DELETE CASCADE,
+        REFERENCES focused_pages(tenant_id, public_id, turn_id),
     UNIQUE (tenant_id, turn_id, channel),
     CHECK (
         (status = 'pending' AND lease_token IS NULL AND lease_expires_at IS NULL AND delivered_at IS NULL)

--- a/migrations/20260723163958_focused_page_deliveries.sql
+++ b/migrations/20260723163958_focused_page_deliveries.sql
@@ -22,7 +22,7 @@ CREATE TABLE focused_page_deliveries (
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     FOREIGN KEY (tenant_id) REFERENCES tenants(id),
     FOREIGN KEY (tenant_id, focused_page_public_id, turn_id)
-        REFERENCES focused_pages(tenant_id, public_id, turn_id),
+        REFERENCES focused_pages(tenant_id, public_id, turn_id) ON DELETE CASCADE,
     UNIQUE (tenant_id, turn_id, channel),
     CHECK (
         (status = 'pending' AND lease_token IS NULL AND lease_expires_at IS NULL AND delivered_at IS NULL)

--- a/migrations/20260723163958_focused_page_deliveries.sql
+++ b/migrations/20260723163958_focused_page_deliveries.sql
@@ -1,0 +1,45 @@
+-- +goose Up
+ALTER TABLE focused_pages
+    ADD CONSTRAINT focused_pages_tenant_public_turn_unique
+    UNIQUE (tenant_id, public_id, turn_id);
+
+CREATE TABLE focused_page_deliveries (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL,
+    turn_id TEXT NOT NULL,
+    channel TEXT NOT NULL CHECK (char_length(channel) > 0),
+    recipient_id TEXT NOT NULL CHECK (char_length(recipient_id) > 0),
+    final_text TEXT NOT NULL CHECK (char_length(final_text) > 0),
+    focused_page_public_id TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'leased', 'delivered')),
+    attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+    next_attempt_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    lease_token TEXT,
+    lease_expires_at TIMESTAMPTZ,
+    delivered_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    FOREIGN KEY (tenant_id) REFERENCES tenants(id),
+    FOREIGN KEY (tenant_id, focused_page_public_id, turn_id)
+        REFERENCES focused_pages(tenant_id, public_id, turn_id),
+    UNIQUE (tenant_id, turn_id, channel),
+    CHECK (
+        (status = 'pending' AND lease_token IS NULL AND lease_expires_at IS NULL AND delivered_at IS NULL)
+        OR (status = 'leased' AND lease_token IS NOT NULL AND lease_expires_at IS NOT NULL AND delivered_at IS NULL)
+        OR (status = 'delivered' AND lease_token IS NULL AND lease_expires_at IS NULL AND delivered_at IS NOT NULL)
+    )
+);
+
+CREATE INDEX focused_page_deliveries_pending_idx
+    ON focused_page_deliveries (next_attempt_at, created_at)
+    WHERE status = 'pending';
+
+CREATE INDEX focused_page_deliveries_lease_idx
+    ON focused_page_deliveries (lease_expires_at, created_at)
+    WHERE status = 'leased';
+
+-- +goose Down
+DROP TABLE IF EXISTS focused_page_deliveries;
+ALTER TABLE focused_pages
+    DROP CONSTRAINT IF EXISTS focused_pages_tenant_public_turn_unique;

--- a/migrations/20260723170429_focused_page_delivery_cleanup_cascade.sql
+++ b/migrations/20260723170429_focused_page_delivery_cleanup_cascade.sql
@@ -1,0 +1,18 @@
+-- +goose Up
+ALTER TABLE focused_page_deliveries
+    DROP CONSTRAINT focused_page_deliveries_tenant_id_focused_page_public_id_t_fkey;
+
+ALTER TABLE focused_page_deliveries
+    ADD CONSTRAINT focused_page_deliveries_focused_page_fkey
+    FOREIGN KEY (tenant_id, focused_page_public_id, turn_id)
+    REFERENCES focused_pages(tenant_id, public_id, turn_id)
+    ON DELETE CASCADE;
+
+-- +goose Down
+ALTER TABLE focused_page_deliveries
+    DROP CONSTRAINT focused_page_deliveries_focused_page_fkey;
+
+ALTER TABLE focused_page_deliveries
+    ADD CONSTRAINT focused_page_deliveries_tenant_id_focused_page_public_id_t_fkey
+    FOREIGN KEY (tenant_id, focused_page_public_id, turn_id)
+    REFERENCES focused_pages(tenant_id, public_id, turn_id);


### PR DESCRIPTION
## Summary
- persist focused-page turn text, recipient, channel, and artifact identity before sending
- claim pending work with fenced leases, capped retry backoff, and restart recovery
- reconstruct the original capability URL without storing fragments or duplicate page content
- cascade delivery rows when expired focused pages are deleted
- keep plain-text turns, reminders, and notifications on their existing direct delivery paths

## Testing
- go test ./...
- go test -race ./internal/focusedpagedelivery
- go test -tags=integration ./internal/focusedpage ./internal/focusedpagedelivery -count=1
- go vet ./...
- just migrate

Closes #187