### PR TITLE
Refine teacher navigation

### DIFF
--- a/admin-spa/src/components/shared/admin-sidebar.test.tsx
+++ b/admin-spa/src/components/shared/admin-sidebar.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom/vitest'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { AdminSidebar } from './admin-sidebar'
+import type { MouseEventHandler, ReactNode } from 'react'
+import type * as TanStackRouter from '@tanstack/react-router'
+import type { AuthContextValue } from '@/auth-provider'
+import type * as AuthProviderModule from '@/auth-provider'
+import { SidebarProvider } from '@/components/ui/sidebar'
+
+const authContext: AuthContextValue = {
+  auth: {
+    status: 'authenticated',
+    session: {
+      expires_at: '2099-01-01T00:00:00Z',
+      user: {
+        role: 'teacher',
+        tenant_id: 'school_1',
+        user_id: 'teacher_1',
+      },
+    },
+    error: null,
+  },
+  setAnonymousSession: vi.fn(),
+  setAuthenticatedSession: vi.fn(),
+}
+
+vi.mock('@/auth-provider', async (importOriginal) => {
+  const actual = await importOriginal<typeof AuthProviderModule>()
+
+  return {
+    ...actual,
+    useAuth: () => authContext,
+  }
+})
+
+vi.mock('@/hooks/use-mobile', () => ({
+  useIsMobile: () => false,
+}))
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof TanStackRouter>()
+
+  return {
+    ...actual,
+    Link: ({
+      'aria-current': ariaCurrent,
+      children,
+      className,
+      onClick,
+      to,
+    }: {
+      'aria-current'?: 'page'
+      children: ReactNode
+      className?: string
+      onClick?: MouseEventHandler<HTMLAnchorElement>
+      to: string
+    }) => (
+      <a
+        aria-current={ariaCurrent}
+        className={className}
+        href={to}
+        onClick={onClick}
+      >
+        {children}
+      </a>
+    ),
+    useRouterState: ({
+      select,
+    }: {
+      select: (state: { location: { pathname: string } }) => unknown
+    }) => select({ location: { pathname: '/dashboard/classes' } }),
+  }
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('admin sidebar', () => {
+  it('announces the current page without linking to retired tools', () => {
+    render(
+      <SidebarProvider>
+        <AdminSidebar />
+      </SidebarProvider>,
+    )
+
+    expect(screen.getByRole('link', { name: 'My classes' })).toHaveAttribute(
+      'aria-current',
+      'page',
+    )
+    expect(screen.getByRole('link', { name: 'Today' })).not.toHaveAttribute(
+      'aria-current',
+    )
+    expect(
+      screen.queryByRole('link', { name: 'Content search' }),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/admin-spa/src/components/shared/admin-sidebar.tsx
+++ b/admin-spa/src/components/shared/admin-sidebar.tsx
@@ -1,21 +1,9 @@
 import { Link, useRouterState } from '@tanstack/react-router'
-import {
-  BarChart3Icon,
-  BookOpenCheckIcon,
-  BotIcon,
-  CableIcon,
-  DownloadIcon,
-  GaugeIcon,
-  LogOutIcon,
-  MessageCircleMoreIcon,
-  Settings2Icon,
-  SparklesIcon,
-  UsersIcon,
-  WalletCardsIcon,
-} from 'lucide-react'
+import { LogOutIcon, SparklesIcon, XIcon } from 'lucide-react'
 import { useCallback } from 'react'
 
 import type { AuthUser } from '@/lib/auth-types'
+import type { NavigationItem } from '@/lib/admin-navigation'
 import { useAuth } from '@/auth-provider'
 import { Button } from '@/components/ui/button'
 import {
@@ -29,87 +17,29 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  useSidebar,
 } from '@/components/ui/sidebar'
+import {
+  getVisibleNavigationGroups,
+  isNavigationItemActive,
+} from '@/lib/admin-navigation'
 import { logout } from '@/lib/auth-client'
 import { getAdminUserInitials } from '@/lib/admin-user-label'
-import { canAccessPath } from '@/lib/rbac'
 
 const dashboardSearch = { student: undefined }
-
-const navigationGroups = [
-  {
-    label: 'Workspace',
-    items: [
-      {
-        Icon: GaugeIcon,
-        href: '/dashboard',
-        label: 'Dashboard',
-      },
-      {
-        Icon: BookOpenCheckIcon,
-        href: '/dashboard/classes',
-        label: 'Classes',
-      },
-      {
-        Icon: BarChart3Icon,
-        href: '/dashboard/metrics',
-        label: 'Learning metrics',
-      },
-      {
-        Icon: BotIcon,
-        href: '/dashboard/ai-usage',
-        label: 'AI usage',
-      },
-    ],
-  },
-  {
-    label: 'Manage',
-    items: [
-      {
-        Icon: WalletCardsIcon,
-        href: '/settings/budget',
-        label: 'Budget',
-      },
-      {
-        Icon: UsersIcon,
-        href: '/settings/users',
-        label: 'Users',
-      },
-      {
-        // Visible only with can_manage_ai_settings (canAccessPath filter).
-        Icon: Settings2Icon,
-        href: '/settings/ai',
-        label: 'AI settings',
-      },
-      {
-        Icon: MessageCircleMoreIcon,
-        href: '/settings/whatsapp',
-        label: 'WhatsApp',
-      },
-      {
-        Icon: CableIcon,
-        href: '/settings/embed',
-        label: 'Embed',
-      },
-      {
-        Icon: DownloadIcon,
-        href: '/export',
-        label: 'Export',
-      },
-    ],
-  },
-]
-
-type NavigationItem = (typeof navigationGroups)[number]['items'][number]
 
 /** Renders role-aware navigation and session controls for the admin workspace. */
 export function AdminSidebar() {
   const { auth, setAnonymousSession } = useAuth()
+  const { isMobile, setOpenMobile } = useSidebar()
   const pathname = useRouterState({
     select: (state) => state.location.pathname,
   })
   const user = auth.session?.user ?? null
   const visibleGroups = getVisibleNavigationGroups(user)
+  const handleCloseNavigation = useCallback(() => {
+    setOpenMobile(false)
+  }, [setOpenMobile])
 
   const handleLogout = useCallback(() => {
     logout()
@@ -125,29 +55,44 @@ export function AdminSidebar() {
       collapsible='offcanvas'
       className='border-r border-[#e6e9ef] bg-white'
     >
-      <SidebarHeader className='px-4 pt-5 pb-4'>
-        <Link
-          className='flex items-center gap-3 rounded-xl px-2 py-2 text-sm font-semibold text-[#101828] no-underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2f80ed]'
-          search={dashboardSearch}
-          to='/dashboard'
-        >
-          <span className='relative flex size-9 items-center justify-center overflow-hidden rounded-xl bg-[#101828] text-white shadow-[0_1px_2px_rgb(16_24_40/0.15),0_4px_12px_rgb(16_24_40/0.12)]'>
-            <SparklesIcon aria-hidden='true' className='size-[18px]' />
-            <span className='absolute right-1.5 bottom-1.5 size-1.5 rounded-full bg-[#53d3a0] ring-2 ring-[#101828]' />
-          </span>
-          <span className='leading-tight'>
-            <span className='block'>P&AI Bot</span>
-            <span className='mt-0.5 block text-[10px] font-medium tracking-[0.08em] text-[#98a2b3] uppercase'>
-              Learning OS
+      <SidebarHeader className='px-4 pt-4 pb-3'>
+        <div className='flex min-h-11 items-center gap-2'>
+          <Link
+            className='flex min-w-0 flex-1 items-center gap-3 rounded-xl px-2 py-1 text-sm font-semibold text-[#101828] no-underline transition-[background-color,box-shadow,transform] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:bg-[#f8fafc] focus-visible:ring-3 focus-visible:ring-[#2f80ed]/35 focus-visible:outline-none active:scale-[0.96]'
+            onClick={handleCloseNavigation}
+            search={dashboardSearch}
+            to='/dashboard'
+          >
+            <span className='relative flex size-9 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-[#101828] text-white shadow-[0_1px_2px_rgb(16_24_40/0.15),0_4px_12px_rgb(16_24_40/0.12)]'>
+              <SparklesIcon aria-hidden='true' className='size-[18px]' />
+              <span className='absolute right-1.5 bottom-1.5 size-1.5 rounded-full bg-[#53d3a0] ring-2 ring-[#101828]' />
             </span>
-          </span>
-        </Link>
+            <span className='min-w-0 leading-tight'>
+              <span className='block truncate'>P&AI Bot</span>
+              <span className='mt-0.5 block truncate text-[10px] font-medium tracking-[0.08em] text-[#98a2b3] uppercase'>
+                Learning OS
+              </span>
+            </span>
+          </Link>
+          {isMobile && (
+            <Button
+              aria-label='Close navigation'
+              className='size-11 shrink-0 text-[#667085] focus-visible:ring-[#2f80ed]/35'
+              onClick={handleCloseNavigation}
+              size='icon'
+              type='button'
+              variant='ghost'
+            >
+              <XIcon aria-hidden='true' />
+            </Button>
+          )}
+        </div>
       </SidebarHeader>
 
       <SidebarContent className='px-4'>
         <nav aria-label='Admin navigation'>
           {visibleGroups.map((group) => (
-            <SidebarGroup className='px-0 py-2' key={group.label}>
+            <SidebarGroup className='px-0 py-1.5' key={group.label}>
               <SidebarGroupLabel className='h-6 px-3 text-[10px] font-semibold tracking-[0.12em] text-[#98a2b3] uppercase'>
                 {group.label}
               </SidebarGroupLabel>
@@ -157,6 +102,7 @@ export function AdminSidebar() {
                     <AdminNavigationLink
                       item={item}
                       key={item.href}
+                      onNavigate={handleCloseNavigation}
                       pathname={pathname}
                     />
                   ))}
@@ -182,7 +128,7 @@ export function AdminSidebar() {
           </div>
           <Button
             aria-label='Log out'
-            className='text-[#667085] hover:bg-white hover:text-[#101828]'
+            className='size-11 text-[#667085] hover:bg-white hover:text-[#101828] focus-visible:ring-[#2f80ed]/35 md:size-8'
             onClick={handleLogout}
             size='icon-sm'
             type='button'
@@ -198,9 +144,11 @@ export function AdminSidebar() {
 
 function AdminNavigationLink({
   item,
+  onNavigate,
   pathname,
 }: {
   item: NavigationItem
+  onNavigate: () => void
   pathname: string
 }) {
   const { Icon, href, label } = item
@@ -210,10 +158,14 @@ function AdminNavigationLink({
     <SidebarMenuItem>
       <SidebarMenuButton
         asChild
-        className='relative h-10 gap-3 rounded-lg px-3 text-[#667085] transition-[background-color,color,transform] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:bg-[#f4f7fb] hover:text-[#101828] active:scale-[0.96] data-active:bg-[#eaf2ff] data-active:font-semibold data-active:text-[#175cd3]'
+        className='relative h-11 gap-3 rounded-lg px-3 text-[#667085] transition-[background-color,color,box-shadow,transform] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:bg-[#f4f7fb] hover:text-[#101828] focus-visible:ring-3 focus-visible:ring-[#2f80ed]/35 active:scale-[0.96] data-active:bg-[#eaf2ff] data-active:font-semibold data-active:text-[#175cd3]'
         isActive={isActive}
       >
-        <Link to={href}>
+        <Link
+          aria-current={isActive ? 'page' : undefined}
+          onClick={onNavigate}
+          to={href}
+        >
           <span
             aria-hidden='true'
             className='absolute left-0 h-5 w-0.5 rounded-full bg-transparent group-data-[active=true]/menu-button:bg-[#2f80ed]'
@@ -227,37 +179,6 @@ function AdminNavigationLink({
         </Link>
       </SidebarMenuButton>
     </SidebarMenuItem>
-  )
-}
-
-function isNavigationItemVisible(item: NavigationItem, user: AuthUser | null) {
-  return canAccessPath(user, item.href)
-}
-
-function getVisibleNavigationGroups(user: AuthUser | null) {
-  return navigationGroups
-    .map((group) => createVisibleNavigationGroup(group, user))
-    .filter(hasNavigationItems)
-}
-
-function createVisibleNavigationGroup(
-  group: (typeof navigationGroups)[number],
-  user: AuthUser | null,
-) {
-  return {
-    label: group.label,
-    items: group.items.filter((item) => isNavigationItemVisible(item, user)),
-  }
-}
-
-function hasNavigationItems(group: { items: Array<NavigationItem> }) {
-  return group.items.length > 0
-}
-
-function isNavigationItemActive(href: string, pathname: string) {
-  return (
-    pathname === href ||
-    (href !== '/dashboard' && pathname.startsWith(`${href}/`))
   )
 }
 

--- a/admin-spa/src/components/shared/admin-topbar.tsx
+++ b/admin-spa/src/components/shared/admin-topbar.tsx
@@ -1,0 +1,42 @@
+import { useRouterState } from '@tanstack/react-router'
+
+import { useAuth } from '@/auth-provider'
+import { SidebarTrigger } from '@/components/ui/sidebar'
+import { getAdminPageLabel } from '@/lib/admin-page-label'
+import { getAdminUserInitials } from '@/lib/admin-user-label'
+
+export function AdminTopbar() {
+  const { auth } = useAuth()
+  const pathname = useRouterState({
+    select: (state) => state.location.pathname,
+  })
+  const user = auth.session?.user ?? null
+  const pageLabel = getAdminPageLabel(pathname)
+
+  return (
+    <header className='sticky top-0 z-20 flex min-h-16 items-center justify-between gap-3 border-b border-[#e6e9ef]/90 bg-white/95 px-3 backdrop-blur-xl sm:px-6 lg:px-10'>
+      <div className='flex min-w-0 items-center gap-2 sm:gap-3'>
+        <SidebarTrigger
+          aria-label='Open navigation'
+          className='size-11 shrink-0 text-[#475467] focus-visible:ring-[#2f80ed]/35 md:hidden'
+        />
+        <div className='min-w-0 leading-tight'>
+          <p className='truncate text-[11px] font-medium text-[#98a2b3] sm:text-xs'>
+            {user?.tenant_name ?? 'School workspace'}
+          </p>
+          <p className='truncate text-sm font-semibold text-[#101828] sm:text-[15px]'>
+            {pageLabel}
+          </p>
+        </div>
+      </div>
+      <div className='flex min-h-9 min-w-0 items-center gap-2 rounded-full bg-white py-1 pr-2.5 pl-1 shadow-[0_0_0_1px_rgb(16_24_40/0.08),0_1px_2px_rgb(16_24_40/0.04)]'>
+        <span className='flex size-7 shrink-0 items-center justify-center rounded-full bg-[#eaf2ff] text-[10px] font-semibold text-[#175cd3]'>
+          {getAdminUserInitials(user)}
+        </span>
+        <span className='hidden max-w-40 truncate text-xs font-medium text-[#475467] sm:block'>
+          {user?.name ?? 'Administrator'}
+        </span>
+      </div>
+    </header>
+  )
+}

--- a/admin-spa/src/lib/admin-navigation.test.ts
+++ b/admin-spa/src/lib/admin-navigation.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getVisibleNavigationGroups,
+  isNavigationItemActive,
+} from './admin-navigation'
+import type { AuthUser } from '@/lib/auth-types'
+
+const teacher: AuthUser = {
+  role: 'teacher',
+  tenant_id: 'school_1',
+  user_id: 'teacher_1',
+}
+
+describe('admin sidebar navigation', () => {
+  it('keeps daily teaching separate from technical tools', () => {
+    const groups = getVisibleNavigationGroups(teacher)
+
+    expect(groups.map(({ label }) => label)).toEqual([
+      'Teaching',
+      'Technical tools',
+    ])
+    expect(groups[0]?.items.map(({ label }) => label)).toEqual([
+      'Today',
+      'My classes',
+      'Learning progress',
+    ])
+    expect(groups[1]?.items.map(({ label }) => label)).toEqual(['AI activity'])
+    expect(
+      groups.flatMap(({ items }) => items).map(({ href }) => href),
+    ).not.toContain('/dashboard/retrieval-lab')
+  })
+
+  it('shows school administration only to roles with access', () => {
+    const adminGroups = getVisibleNavigationGroups({
+      ...teacher,
+      role: 'admin',
+    })
+
+    expect(
+      adminGroups
+        .find(({ label }) => label === 'School administration')
+        ?.items.map(({ label }) => label),
+    ).toEqual(['Staff access', 'AI budget', 'Download records'])
+
+    expect(getVisibleNavigationGroups({ ...teacher, role: 'parent' })).toEqual(
+      [],
+    )
+  })
+
+  it('keeps AI settings capability-aware', () => {
+    const withoutCapability = getVisibleNavigationGroups({
+      ...teacher,
+      role: 'platform_admin',
+    })
+    const withCapability = getVisibleNavigationGroups({
+      ...teacher,
+      can_manage_ai_settings: true,
+      role: 'platform_admin',
+    })
+
+    expect(
+      withoutCapability.flatMap(({ items }) => items).map(({ label }) => label),
+    ).not.toContain('AI settings')
+    expect(
+      withCapability.flatMap(({ items }) => items).map(({ label }) => label),
+    ).toContain('AI settings')
+  })
+
+  it('marks only the active destination and its descendants as current', () => {
+    expect(
+      isNavigationItemActive(
+        '/dashboard/classes',
+        '/dashboard/classes/class_1',
+      ),
+    ).toBe(true)
+    expect(isNavigationItemActive('/dashboard', '/dashboard/classes')).toBe(
+      false,
+    )
+  })
+})

--- a/admin-spa/src/lib/admin-navigation.ts
+++ b/admin-spa/src/lib/admin-navigation.ts
@@ -1,0 +1,105 @@
+import {
+  BarChart3Icon,
+  BookOpenCheckIcon,
+  BotIcon,
+  CableIcon,
+  DownloadIcon,
+  GaugeIcon,
+  MessageCircleMoreIcon,
+  Settings2Icon,
+  UsersIcon,
+  WalletCardsIcon,
+} from 'lucide-react'
+
+import { canAccessPath } from './rbac'
+import type { AuthUser } from './auth-types'
+
+const navigationGroups = [
+  {
+    label: 'Teaching',
+    items: [
+      {
+        Icon: GaugeIcon,
+        href: '/dashboard',
+        label: 'Today',
+      },
+      {
+        Icon: BookOpenCheckIcon,
+        href: '/dashboard/classes',
+        label: 'My classes',
+      },
+      {
+        Icon: BarChart3Icon,
+        href: '/dashboard/metrics',
+        label: 'Learning progress',
+      },
+    ],
+  },
+  {
+    label: 'School administration',
+    items: [
+      {
+        Icon: UsersIcon,
+        href: '/settings/users',
+        label: 'Staff access',
+      },
+      {
+        Icon: WalletCardsIcon,
+        href: '/settings/budget',
+        label: 'AI budget',
+      },
+      {
+        Icon: DownloadIcon,
+        href: '/export',
+        label: 'Download records',
+      },
+    ],
+  },
+  {
+    label: 'Technical tools',
+    items: [
+      {
+        Icon: BotIcon,
+        href: '/dashboard/ai-usage',
+        label: 'AI activity',
+      },
+      {
+        // Visible only with can_manage_ai_settings (canAccessPath filter).
+        Icon: Settings2Icon,
+        href: '/settings/ai',
+        label: 'AI settings',
+      },
+      {
+        Icon: MessageCircleMoreIcon,
+        href: '/settings/whatsapp',
+        label: 'WhatsApp setup',
+      },
+      {
+        Icon: CableIcon,
+        href: '/settings/embed',
+        label: 'Website chat',
+      },
+    ],
+  },
+]
+
+export type NavigationItem = (typeof navigationGroups)[number]['items'][number]
+
+export function getVisibleNavigationGroups(user: AuthUser | null) {
+  return navigationGroups
+    .map((group) => ({
+      label: group.label,
+      items: group.items.filter((item) => canAccessPath(user, item.href)),
+    }))
+    .filter(({ items }) => items.length > 0)
+}
+
+export function isNavigationItemActive(
+  href: string,
+  pathname: string,
+): boolean {
+  return (
+    pathname === href ||
+    (href !== '/dashboard' && pathname.startsWith(`${href}/`))
+  )
+}

--- a/admin-spa/src/lib/admin-page-label.test.ts
+++ b/admin-spa/src/lib/admin-page-label.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { getAdminPageLabel } from './admin-page-label'
+
+describe('admin topbar context', () => {
+  it.each([
+    ['/dashboard', 'Today'],
+    ['/dashboard/classes', 'My classes'],
+    ['/dashboard/classes/class_1', 'My classes'],
+    ['/dashboard/metrics', 'Learning progress'],
+    ['/settings/users', 'Staff access'],
+    ['/settings/embed', 'Website chat'],
+    ['/students/student_1', 'Learner profile'],
+    ['/parents/parent_1', 'Family overview'],
+    ['/export', 'Download records'],
+  ])('labels %s as %s', (pathname, label) => {
+    expect(getAdminPageLabel(pathname)).toBe(label)
+  })
+
+  it('uses a calm fallback for an unknown authenticated path', () => {
+    expect(getAdminPageLabel('/unknown')).toBe('School workspace')
+  })
+
+  it('does not restore context for the retired retrieval lab', () => {
+    expect(getAdminPageLabel('/dashboard/retrieval-lab')).toBe(
+      'School workspace',
+    )
+  })
+})

--- a/admin-spa/src/lib/admin-page-label.ts
+++ b/admin-spa/src/lib/admin-page-label.ts
@@ -1,0 +1,26 @@
+const pageLabels = [
+  { prefix: '/dashboard/classes', label: 'My classes' },
+  { prefix: '/dashboard/metrics', label: 'Learning progress' },
+  { prefix: '/dashboard/ai-usage', label: 'AI activity' },
+  { prefix: '/settings/users', label: 'Staff access' },
+  { prefix: '/settings/budget', label: 'AI budget' },
+  { prefix: '/settings/ai', label: 'AI settings' },
+  { prefix: '/settings/whatsapp', label: 'WhatsApp setup' },
+  { prefix: '/settings/embed', label: 'Website chat' },
+  { prefix: '/students', label: 'Learner profile' },
+  { prefix: '/parents', label: 'Family overview' },
+  { prefix: '/setup', label: 'School setup' },
+  { prefix: '/export', label: 'Download records' },
+] as const
+
+export function getAdminPageLabel(pathname: string): string {
+  if (pathname === '/dashboard') {
+    return 'Today'
+  }
+
+  return (
+    pageLabels.find(
+      ({ prefix }) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+    )?.label ?? 'School workspace'
+  )
+}

--- a/admin-spa/src/routes/_authenticated.tsx
+++ b/admin-spa/src/routes/_authenticated.tsx
@@ -1,13 +1,8 @@
 import { Outlet, createFileRoute } from '@tanstack/react-router'
 
-import { useAuth } from '@/auth-provider'
 import { AdminSidebar } from '@/components/shared/admin-sidebar'
-import {
-  SidebarInset,
-  SidebarProvider,
-  SidebarTrigger,
-} from '@/components/ui/sidebar'
-import { getAdminUserInitials } from '@/lib/admin-user-label'
+import { AdminTopbar } from '@/components/shared/admin-topbar'
+import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar'
 import { requireAdminPath } from '@/lib/router-guards'
 
 export const Route = createFileRoute('/_authenticated')({
@@ -20,37 +15,21 @@ export const Route = createFileRoute('/_authenticated')({
 function AuthenticatedLayout() {
   return (
     <SidebarProvider className='min-h-svh w-full bg-[#f7f8fa] text-[#101828]'>
+      <a
+        className='fixed top-3 left-3 z-50 -translate-y-20 rounded-lg bg-[#101828] px-4 py-3 text-sm font-semibold text-white shadow-[0_1px_2px_rgb(16_24_40/0.18),0_8px_20px_rgb(16_24_40/0.16)] transition-transform duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] focus:translate-y-0 focus:ring-3 focus:ring-[#2f80ed]/40 focus:outline-none'
+        href='#admin-content'
+      >
+        Skip to content
+      </a>
       <AdminSidebar />
-      <SidebarInset className='min-h-svh min-w-0 flex-1 bg-[#f7f8fa]'>
+      <SidebarInset
+        className='min-h-svh min-w-0 flex-1 bg-[#f7f8fa]'
+        id='admin-content'
+        tabIndex={-1}
+      >
         <AdminTopbar />
         <Outlet />
       </SidebarInset>
     </SidebarProvider>
-  )
-}
-
-function AdminTopbar() {
-  const { auth } = useAuth()
-  const user = auth.session?.user ?? null
-
-  return (
-    <header className='sticky top-0 z-20 flex h-14 items-center justify-between border-b border-[#e6e9ef]/90 bg-white/90 px-4 backdrop-blur-xl sm:px-6 lg:px-10'>
-      <div className='flex min-w-0 items-center gap-3'>
-        <SidebarTrigger className='-ml-1 size-11 md:hidden' />
-        <div className='min-w-0'>
-          <p className='truncate text-sm font-medium text-[#344054]'>
-            {user?.tenant_name ?? 'Learning operations'}
-          </p>
-        </div>
-      </div>
-      <div className='flex items-center gap-2 rounded-full border border-[#e6e9ef] bg-white py-1 pr-2.5 pl-1 shadow-[0_1px_2px_rgb(16_24_40/0.04)]'>
-        <span className='flex size-6 items-center justify-center rounded-full bg-[#eaf2ff] text-[10px] font-semibold text-[#175cd3]'>
-          {getAdminUserInitials(user)}
-        </span>
-        <span className='hidden max-w-40 truncate text-xs font-medium text-[#475467] sm:block'>
-          {user?.name ?? 'Administrator'}
-        </span>
-      </div>
-    </header>
   )
 }


### PR DESCRIPTION
## Summary

- reorganize teacher navigation around daily workflows
- preserve retired retrieval-lab behavior
- improve current-route accessibility and move navigation helpers into the shared library

## Testing

- `cd admin-spa && pnpm run check`
- 49 test files, 203 tests, and production build passed