### PR TITLE
Make learner detail actionable

### DIFF
--- a/admin-spa/src/components/dashboard/student-detail-panel.test.tsx
+++ b/admin-spa/src/components/dashboard/student-detail-panel.test.tsx
@@ -3,7 +3,13 @@
  */
 import '@testing-library/jest-dom/vitest'
 
-import { cleanup, render, screen, within } from '@testing-library/react'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { StudentDetailPanel } from './student-detail-panel'
@@ -36,35 +42,55 @@ describe('StudentDetailPanel', () => {
     cleanup()
   })
 
-  it('renders profile, progress, and recent conversations', async () => {
+  it('puts an actionable learner summary before progress and conversations', async () => {
     getStudentDetail.mockResolvedValue(studentDetailWithStruggleFixture)
     getStudentConversations.mockResolvedValue(studentConversationFixture)
 
     render(<StudentDetailPanel studentID='student_1' />)
 
     expect(await screen.findByText('Alya')).toBeInTheDocument()
+    expect(screen.getByText('Needs attention')).toBeInTheDocument()
+    expect(screen.getByText('Review Fractions next')).toBeInTheDocument()
+    expect(screen.getByText('Strengths & struggles')).toBeInTheDocument()
+    expect(screen.getByText('Recent activity')).toBeInTheDocument()
     expect(screen.getByText('3 days')).toBeInTheDocument()
     expect(screen.getByText('8 days')).toBeInTheDocument()
     expect(screen.getByText('Linear Equations')).toBeInTheDocument()
-    expect(screen.getByText('Struggle areas')).toBeInTheDocument()
-    const strugglePanel = screen
-      .getByText('Struggle areas')
+    const snapshot = screen
+      .getByText('Teacher snapshot')
       .closest('[data-slot="card"]')
-    if (!(strugglePanel instanceof HTMLElement)) {
-      throw new Error('Expected struggle areas panel to render')
+    if (!(snapshot instanceof HTMLElement)) {
+      throw new Error('Expected teacher snapshot to render')
     }
+    expect(within(snapshot).getByText(/Fractions\s+42%/)).toBeInTheDocument()
+    const snapshotHeading = screen.getByText('Teacher snapshot')
+    const masteryHeading = screen.getByText('Mastery overview')
+    const conversationHeading = screen.getByText('Recent conversations')
     expect(
-      within(strugglePanel).getByText(/Fractions\s+42%/),
-    ).toBeInTheDocument()
-    expect(screen.getByText('Mastery radar')).toBeInTheDocument()
-    expect(screen.getByText('72% mastery')).toBeInTheDocument()
-    expect(screen.getByText('Activity grid')).toBeInTheDocument()
-    expect(screen.getByTitle('May 8: 2 messages')).toBeInTheDocument()
-    expect(screen.getByLabelText('May 8: 2 messages')).toBeInTheDocument()
+      snapshotHeading.compareDocumentPosition(masteryHeading) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+    expect(
+      snapshotHeading.compareDocumentPosition(conversationHeading) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+    expect(screen.getAllByText('72%').length).toBeGreaterThan(0)
+    expect(screen.getByText('14-day activity')).toBeInTheDocument()
+    expect(
+      screen.getByRole('region', { name: '14-day tutoring activity' }),
+    ).toHaveAttribute('tabindex', '0')
+    expect(
+      screen.getByRole('region', { name: 'Conversation history' }),
+    ).toHaveAttribute('tabindex', '0')
     expect(
       screen.getAllByText('08 May 2026, 00:00 UTC').length,
     ).toBeGreaterThan(0)
-    expect(screen.getByText('How do I solve x + 2 = 5?')).toBeInTheDocument()
+    const latestMessage = screen.getByText('Subtract 2 from both sides.')
+    const firstMessage = screen.getByText('How do I solve x + 2 = 5?')
+    expect(
+      latestMessage.compareDocumentPosition(firstMessage) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
   })
 
   it('shows a hard load error without empty-state fallthrough', async () => {
@@ -77,6 +103,40 @@ describe('StudentDetailPanel', () => {
       await screen.findByText('Student detail unavailable'),
     ).toBeInTheDocument()
     expect(screen.queryByText('No topic progress yet')).not.toBeInTheDocument()
+  })
+
+  it('recovers from a load error when the teacher retries', async () => {
+    getStudentDetail
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce(studentDetailFixture)
+    getStudentConversations.mockResolvedValue([])
+
+    render(<StudentDetailPanel studentID='student_1' />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Try again' }))
+
+    expect(await screen.findByText('Alya')).toBeInTheDocument()
+    expect(getStudentDetail).toHaveBeenCalledTimes(2)
+    expect(getStudentConversations).toHaveBeenCalledTimes(2)
+  })
+
+  it('shows actionable empty states in the sheet layout', async () => {
+    getStudentDetail.mockResolvedValue({
+      ...studentDetailFixture,
+      progress: [],
+    })
+    getStudentConversations.mockResolvedValue([])
+
+    render(<StudentDetailPanel studentID='student_1' variant='sheet' />)
+
+    expect(await screen.findByText('Teacher snapshot')).toBeInTheDocument()
+    expect(screen.getByText('Getting started')).toBeInTheDocument()
+    expect(screen.getByText('Start with a guided check-in')).toBeInTheDocument()
+    expect(screen.getByText('No mastery overview yet')).toBeInTheDocument()
+    expect(screen.getByText('No tutoring messages yet')).toBeInTheDocument()
+    expect(
+      screen.getByText('Mastery overview').closest('section'),
+    ).not.toHaveClass('xl:grid-cols-[0.8fr_1.2fr]')
   })
 })
 

--- a/admin-spa/src/components/dashboard/student-detail-panel.tsx
+++ b/admin-spa/src/components/dashboard/student-detail-panel.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useState } from 'react'
+/* oxlint-disable jsx-a11y/no-noninteractive-tabindex -- Scrollable regions must be keyboard-focusable. */
+import { useCallback, useEffect, useState } from 'react'
 import {
   PolarAngleAxis,
   PolarGrid,
@@ -20,7 +21,9 @@ import {
 import { LoadState } from '@/components/shared/load-state'
 import { PageHero } from '@/components/shared/page-hero'
 import { StatePanel } from '@/components/shared/state-panel'
-import { StreakMetricsPanel } from '@/components/shared/streak-metrics-panel'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Progress } from '@/components/ui/progress'
 import { getStudentConversations, getStudentDetail } from '@/lib/admin-api'
 import { formatAdminDateTime } from '@/lib/date-format'
 import {
@@ -43,9 +46,14 @@ export function StudentDetailPanel({
     Array<StudentConversation>
   >([])
   const [loadState, setLoadState] = useState<StudentLoadState>('loading')
+  const [requestVersion, setRequestVersion] = useState(0)
+  const retryLoad = useCallback(() => {
+    setRequestVersion((version) => version + 1)
+  }, [])
 
   useEffect(() => {
     let mounted = true
+    setLoadState('loading')
 
     Promise.all([
       getStudentDetail(studentID),
@@ -71,16 +79,34 @@ export function StudentDetailPanel({
     return () => {
       mounted = false
     }
-  }, [studentID])
+  }, [requestVersion, studentID])
 
-  if (loadState !== 'ready') {
+  if (loadState === 'loading') {
     return (
       <LoadState
-        error='Student information is not available right now.'
+        error={null}
         errorTitle='Student detail unavailable'
-        loadingTitle='Loading student detail'
+        loadingTitle='Loading student detail…'
         status={loadState}
       />
+    )
+  }
+
+  if (loadState === 'error') {
+    return (
+      <StatePanel role='alert' title='Student detail unavailable'>
+        <p>
+          The latest learner record could not be loaded. Check your connection
+          and try again.
+        </p>
+        <Button
+          className='mt-4 transition-transform duration-150 active:scale-[0.96]'
+          onClick={retryLoad}
+          type='button'
+        >
+          Try again
+        </Button>
+      </StatePanel>
     )
   }
 
@@ -127,63 +153,472 @@ function StudentDetailReady({
   variant: 'page' | 'sheet'
 }) {
   const view = buildStudentViewModel(detail, conversations)
-  const heroAside = useMemo(
-    () => <StudentHeroAside detail={detail} />,
-    [detail],
-  )
 
   return (
-    <div className='space-y-6'>
+    <div className='min-w-0 space-y-6'>
       {variant === 'page' ? (
         <PageHero
           eyebrow='Student detail'
           title={detail.student.name}
           description={`${detail.student.form} | ${detail.student.channel} | ${detail.student.external_id}`}
-          aside={heroAside}
-          className='bg-white/85 lg:grid-cols-[1.15fr_0.85fr] dark:bg-slate-950/60'
+          className='bg-white/85 dark:bg-slate-950/60'
         >
           <a
             href='/dashboard'
-            className='text-sm font-medium text-sky-700 hover:text-sky-900 dark:text-sky-300 dark:hover:text-sky-200'
+            className='inline-flex rounded-sm text-sm font-medium text-sky-700 transition-colors duration-150 hover:text-sky-900 focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:outline-none dark:text-sky-300 dark:hover:text-sky-200 dark:focus-visible:ring-offset-slate-950'
           >
             Back to dashboard
           </a>
         </PageHero>
       ) : null}
 
+      <StudentActionSummary detail={detail} view={view} />
+
       <section
         className={
           variant === 'sheet'
-            ? 'grid gap-4'
-            : 'grid gap-4 xl:grid-cols-[0.75fr_1fr_0.9fr]'
+            ? 'grid min-w-0 gap-4'
+            : 'grid min-w-0 gap-4 xl:grid-cols-[0.8fr_1.2fr]'
         }
       >
-        <StudentProfileCard detail={detail} />
         <StudentMasteryRadar view={view} />
-        <StudentStruggleAreas detail={detail} view={view} />
+        <StudentTopicProgress detail={detail} view={view} />
       </section>
 
       <StudentActivityGrid view={view} />
-      <StudentConversationList conversations={conversations} view={view} />
+      <StudentConversationList view={view} />
+      <StudentProfileCard detail={detail} />
     </div>
   )
 }
 
-function StudentHeroAside({ detail }: { detail: StudentDetail }) {
+function StudentActionSummary({
+  detail,
+  view,
+}: {
+  detail: StudentDetail
+  view: ReturnType<typeof buildStudentViewModel>
+}) {
+  const statusClassName = {
+    attention:
+      'border-amber-300 bg-amber-50 text-amber-900 dark:border-amber-300/30 dark:bg-amber-300/10 dark:text-amber-100',
+    neutral:
+      'border-slate-300 bg-slate-50 text-slate-700 dark:border-white/15 dark:bg-white/5 dark:text-slate-200',
+    positive:
+      'border-emerald-300 bg-emerald-50 text-emerald-800 dark:border-emerald-300/30 dark:bg-emerald-300/10 dark:text-emerald-100',
+  }[view.status.tone]
+
   return (
-    <StreakMetricsPanel
-      current={detail.streak.current}
-      longest={detail.streak.longest}
-      totalXP={detail.streak.total_xp}
-    />
+    <AdminSurface
+      className='overflow-hidden border-sky-200/80 bg-sky-50/50 shadow-sm dark:border-sky-400/15 dark:bg-sky-400/5'
+      contentClassName='p-4 sm:p-6'
+    >
+      <AdminSurfaceHeader
+        title='Teacher snapshot'
+        description='What to know and what to do next.'
+        action={renderStatusBadge(view.status.label, statusClassName)}
+      />
+
+      <div className='mt-5 grid gap-3 lg:grid-cols-2'>
+        <AdminInsetPanel className='rounded-lg border-sky-200 bg-white p-4 shadow-xs lg:col-span-2 dark:border-sky-300/15 dark:bg-slate-950/55'>
+          <p className='text-xs font-semibold tracking-[0.12em] text-sky-700 uppercase dark:text-sky-300'>
+            Recommended next step
+          </p>
+          <h3 className='mt-2 text-lg font-semibold text-pretty text-slate-950 dark:text-white'>
+            {view.recommendation.title}
+          </h3>
+          <p className='mt-1 max-w-3xl text-sm leading-6 text-slate-600 dark:text-slate-300'>
+            {view.recommendation.description}
+          </p>
+        </AdminInsetPanel>
+
+        <StudentTopicSummary view={view} />
+        <StudentRecentActivity view={view} />
+      </div>
+
+      <dl className='mt-3 grid grid-cols-2 gap-px overflow-hidden rounded-lg bg-slate-200/80 sm:grid-cols-4 dark:bg-white/10'>
+        <StudentSummaryMetric
+          label='Current streak'
+          value={`${detail.streak.current} ${detail.streak.current === 1 ? 'day' : 'days'}`}
+        />
+        <StudentSummaryMetric
+          label='Longest streak'
+          value={`${detail.streak.longest} ${detail.streak.longest === 1 ? 'day' : 'days'}`}
+        />
+        <StudentSummaryMetric
+          label='Total XP'
+          value={xpNumberFormatter.format(detail.streak.total_xp)}
+        />
+        <StudentSummaryMetric
+          label='Topics tracked'
+          value={String(detail.progress.length)}
+        />
+      </dl>
+    </AdminSurface>
+  )
+}
+
+function StudentTopicSummary({
+  view,
+}: {
+  view: ReturnType<typeof buildStudentViewModel>
+}) {
+  return (
+    <AdminInsetPanel className='rounded-lg bg-white p-4 dark:bg-slate-950/55'>
+      <h3 className='text-sm font-semibold text-slate-950 dark:text-white'>
+        Strengths & struggles
+      </h3>
+      <p className='mt-1 text-sm leading-5 text-slate-500 dark:text-slate-400'>
+        {view.status.description}
+      </p>
+      <div className='mt-4 space-y-3'>
+        <TopicBadgeList
+          emptyLabel='No established strengths yet'
+          items={view.strengthAreas}
+          label='Strengths'
+          tone='strength'
+        />
+        <TopicBadgeList
+          emptyLabel='No active struggles'
+          items={view.struggleAreas}
+          label='Needs support'
+          tone='struggle'
+        />
+      </div>
+    </AdminInsetPanel>
+  )
+}
+
+function TopicBadgeList({
+  emptyLabel,
+  items,
+  label,
+  tone,
+}: {
+  emptyLabel: string
+  items: StudentDetail['progress']
+  label: string
+  tone: 'strength' | 'struggle'
+}) {
+  return (
+    <div>
+      <p className='text-xs font-medium text-slate-500 dark:text-slate-400'>
+        {label}
+      </p>
+      <div className='mt-1.5 flex flex-wrap gap-1.5'>
+        {items.length > 0 ? (
+          items.map((item) => (
+            <Badge
+              className={
+                tone === 'strength'
+                  ? 'h-auto border-emerald-200 bg-emerald-50 py-1 text-emerald-800 tabular-nums dark:border-emerald-300/20 dark:bg-emerald-300/10 dark:text-emerald-100'
+                  : 'h-auto border-amber-200 bg-amber-50 py-1 text-amber-900 tabular-nums dark:border-amber-300/20 dark:bg-amber-300/10 dark:text-amber-100'
+              }
+              key={item.topic_id}
+              variant='outline'
+            >
+              {formatTopicLabel(item.topic_id)}{' '}
+              {Math.round(item.mastery_score * 100)}%
+            </Badge>
+          ))
+        ) : (
+          <span className='text-sm text-slate-500 dark:text-slate-400'>
+            {emptyLabel}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function StudentRecentActivity({
+  view,
+}: {
+  view: ReturnType<typeof buildStudentViewModel>
+}) {
+  return (
+    <AdminInsetPanel className='rounded-lg bg-white p-4 dark:bg-slate-950/55'>
+      <h3 className='text-sm font-semibold text-slate-950 dark:text-white'>
+        Recent activity
+      </h3>
+      {view.hasConversations ? (
+        <dl className='mt-4 grid grid-cols-2 gap-4'>
+          <div>
+            <dt className='text-xs text-slate-500 dark:text-slate-400'>
+              Last 14 days
+            </dt>
+            <dd className='mt-1 text-2xl font-semibold tracking-tight text-slate-950 tabular-nums dark:text-white'>
+              {view.recentMessageCount}
+            </dd>
+            <p className='text-xs text-slate-500 dark:text-slate-400'>
+              messages
+            </p>
+          </div>
+          <div>
+            <dt className='text-xs text-slate-500 dark:text-slate-400'>
+              Active days
+            </dt>
+            <dd className='mt-1 text-2xl font-semibold tracking-tight text-slate-950 tabular-nums dark:text-white'>
+              {view.activeDays}
+            </dd>
+            <p className='text-xs text-slate-500 dark:text-slate-400'>
+              of 14 days
+            </p>
+          </div>
+          <div className='col-span-2 border-t border-slate-200 pt-3 dark:border-white/10'>
+            <dt className='text-xs text-slate-500 dark:text-slate-400'>
+              Latest message
+            </dt>
+            <dd className='mt-1 text-sm font-medium text-slate-800 tabular-nums dark:text-slate-200'>
+              {formatAdminDateTime(view.latestActivityAt)}
+            </dd>
+          </div>
+        </dl>
+      ) : (
+        <div className='mt-4 rounded-md bg-slate-50 p-3 text-sm leading-5 text-slate-600 dark:bg-white/5 dark:text-slate-300'>
+          No tutoring activity yet. The recommended check-in will create a
+          baseline.
+        </div>
+      )}
+    </AdminInsetPanel>
+  )
+}
+
+function StudentSummaryMetric({
+  label,
+  value,
+}: {
+  label: string
+  value: string
+}) {
+  return (
+    <div className='min-w-0 bg-white px-3 py-3 dark:bg-slate-950/55'>
+      <dt className='truncate text-[11px] font-medium text-slate-500 dark:text-slate-400'>
+        {label}
+      </dt>
+      <dd className='mt-1 truncate text-sm font-semibold text-slate-950 tabular-nums dark:text-white'>
+        {value}
+      </dd>
+    </div>
+  )
+}
+
+function StudentMasteryRadar({
+  view,
+}: {
+  view: ReturnType<typeof buildStudentViewModel>
+}) {
+  return (
+    <AdminSurface>
+      <AdminSurfaceHeader
+        title='Mastery overview'
+        description='Relative mastery across tracked topics.'
+      />
+      <div className='mt-4 h-[280px] sm:h-[320px]'>
+        {view.radarData.length > 0 ? (
+          <ResponsiveContainer height='100%' width='100%'>
+            <RadarChart data={view.radarData}>
+              <PolarGrid />
+              <PolarAngleAxis dataKey='topic' tick={radarAxisTick} />
+              <Tooltip />
+              <Radar
+                dataKey='mastery'
+                stroke='#0284c7'
+                fill='#38bdf8'
+                fillOpacity={0.35}
+              />
+            </RadarChart>
+          </ResponsiveContainer>
+        ) : (
+          <div className='flex h-full items-center justify-center'>
+            <EmptyDetail
+              title='No mastery overview yet'
+              description='Complete a guided check-in to start tracking topic mastery.'
+            />
+          </div>
+        )}
+      </div>
+    </AdminSurface>
+  )
+}
+
+function StudentTopicProgress({
+  detail,
+  view,
+}: {
+  detail: StudentDetail
+  view: ReturnType<typeof buildStudentViewModel>
+}) {
+  return (
+    <AdminSurface>
+      <AdminSurfaceHeader
+        title='Topic progress'
+        description='Mastery and review timing for each tracked topic.'
+      />
+      <div className='mt-4 space-y-2'>
+        {view.hasProgress ? (
+          detail.progress.map((item) => {
+            const mastery = Math.round(item.mastery_score * 100)
+
+            return (
+              <AdminInsetPanel
+                className='rounded-lg p-3 sm:p-4'
+                key={item.topic_id}
+              >
+                <div className='flex min-w-0 items-start justify-between gap-3'>
+                  <p className='min-w-0 truncate text-sm font-semibold text-slate-900 dark:text-slate-100'>
+                    {formatTopicLabel(item.topic_id)}
+                  </p>
+                  <span className='shrink-0 text-sm font-semibold text-slate-700 tabular-nums dark:text-slate-200'>
+                    {mastery}%
+                  </span>
+                </div>
+                <Progress
+                  aria-label={`${formatTopicLabel(item.topic_id)} mastery`}
+                  className='mt-2 h-1.5'
+                  value={mastery}
+                />
+                <dl className='mt-3 grid gap-2 text-xs sm:grid-cols-2'>
+                  <div>
+                    <dt className='text-slate-500 dark:text-slate-400'>
+                      Last studied
+                    </dt>
+                    <dd className='mt-0.5 text-slate-700 tabular-nums dark:text-slate-200'>
+                      {item.last_studied_at
+                        ? formatAdminDateTime(item.last_studied_at)
+                        : 'Not recorded yet'}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className='text-slate-500 dark:text-slate-400'>
+                      Next review
+                    </dt>
+                    <dd className='mt-0.5 text-slate-700 tabular-nums dark:text-slate-200'>
+                      {item.next_review_at
+                        ? formatAdminDateTime(item.next_review_at)
+                        : 'To be scheduled'}
+                    </dd>
+                  </div>
+                </dl>
+              </AdminInsetPanel>
+            )
+          })
+        ) : (
+          <EmptyDetail
+            title='No topic progress yet'
+            description='Topic progress will appear after the learner completes a guided check-in.'
+          />
+        )}
+      </div>
+    </AdminSurface>
+  )
+}
+
+function StudentActivityGrid({
+  view,
+}: {
+  view: ReturnType<typeof buildStudentViewModel>
+}) {
+  return (
+    <AdminSurface>
+      <AdminSurfaceHeader
+        title='14-day activity'
+        description='Tutoring message activity by day.'
+      />
+      <div className='mt-4 space-y-3'>
+        <section
+          aria-label='14-day tutoring activity'
+          className='overflow-x-auto rounded-sm pb-2 focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:outline-none dark:focus-visible:ring-offset-slate-950'
+          tabIndex={0}
+        >
+          <div className='grid min-w-[42rem] grid-cols-[repeat(14,minmax(0,1fr))] gap-2'>
+            {view.activityGrid.map((item) => (
+              <div className='space-y-1.5 text-center' key={item.date}>
+                <div
+                  aria-label={`${item.shortLabel}: ${item.count} messages`}
+                  className={`flex h-10 items-center justify-center rounded-md border border-white/60 text-xs font-semibold tabular-nums shadow-inner dark:border-white/10 ${getActivityTone(item.level)}`}
+                  title={`${item.shortLabel}: ${item.count} messages`}
+                >
+                  {item.count}
+                </div>
+                <p className='text-[10px] text-slate-500 tabular-nums dark:text-slate-400'>
+                  {item.shortLabel}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+        <div className='flex flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-slate-400'>
+          <span>Less active</span>
+          {[0, 1, 2, 3, 4].map((level) => (
+            <span
+              className={`inline-flex size-3 rounded-sm border border-white/60 dark:border-white/10 ${getActivityTone(level)}`}
+              key={level}
+            />
+          ))}
+          <span>More active</span>
+        </div>
+      </div>
+    </AdminSurface>
+  )
+}
+
+function StudentConversationList({
+  view,
+}: {
+  view: ReturnType<typeof buildStudentViewModel>
+}) {
+  return (
+    <AdminSurface>
+      <AdminSurfaceHeader
+        title='Recent conversations'
+        description='Raw tutoring messages for context.'
+        action={renderConversationCount(view.conversations.length)}
+      />
+      <section
+        aria-label='Conversation history'
+        className='mt-4 max-h-[32rem] space-y-2 overflow-y-auto overscroll-contain rounded-sm pr-1 focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:outline-none dark:focus-visible:ring-offset-slate-950'
+        tabIndex={0}
+      >
+        {!view.hasConversations ? (
+          <EmptyDetail
+            title='No tutoring messages yet'
+            description='Messages will appear here after the learner starts a guided check-in.'
+          />
+        ) : null}
+        {view.conversations.map((item) => (
+          <AdminInsetPanel
+            className={`rounded-lg p-3 [content-visibility:auto] ${
+              item.role === 'student'
+                ? 'bg-slate-50 dark:border-white/10 dark:bg-slate-900/80'
+                : 'bg-sky-50 dark:border-sky-400/20 dark:bg-sky-400/10'
+            }`}
+            key={item.id}
+          >
+            <div className='mb-2 flex flex-wrap items-center justify-between gap-1 text-xs font-medium text-slate-500 dark:text-slate-400'>
+              <span>{item.role}</span>
+              <span className='tabular-nums'>
+                {formatAdminDateTime(item.timestamp)}
+              </span>
+            </div>
+            <p className='text-sm leading-6 break-words text-slate-700 dark:text-slate-200'>
+              {item.text}
+            </p>
+          </AdminInsetPanel>
+        ))}
+      </section>
+    </AdminSurface>
   )
 }
 
 function StudentProfileCard({ detail }: { detail: StudentDetail }) {
   return (
     <AdminSurface>
-      <AdminSurfaceHeader title='Profile card' />
-      <div className='mt-6 space-y-4'>
+      <AdminSurfaceHeader
+        title='Learner record'
+        description='Profile and channel identifiers.'
+      />
+      <dl className='mt-4 grid gap-px overflow-hidden rounded-lg bg-slate-200 sm:grid-cols-2 lg:grid-cols-4 dark:bg-white/10'>
         <StudentProfileField label='Form' value={detail.student.form} />
         <StudentProfileField
           label='Channel'
@@ -199,7 +634,7 @@ function StudentProfileCard({ detail }: { detail: StudentDetail }) {
           label='Joined'
           value={formatAdminDateTime(detail.student.created_at)}
         />
-      </div>
+      </dl>
     </AdminSurface>
   )
 }
@@ -214,199 +649,60 @@ function StudentProfileField({
   valueClassName?: string
 }) {
   return (
-    <AdminInsetPanel>
-      <p className='text-xs font-semibold tracking-[0.18em] text-slate-500 uppercase dark:text-slate-400'>
+    <div className='min-w-0 bg-white p-3 dark:bg-slate-950/45'>
+      <dt className='text-xs font-medium text-slate-500 dark:text-slate-400'>
         {label}
-      </p>
-      <p
-        className={`mt-2 text-sm font-medium text-slate-900 dark:text-slate-100 ${valueClassName ?? ''}`}
+      </dt>
+      <dd
+        className={`mt-1 text-sm font-medium text-slate-900 tabular-nums dark:text-slate-100 ${valueClassName ?? ''}`}
       >
-        {value}
+        {value || 'Not recorded'}
+      </dd>
+    </div>
+  )
+}
+
+function EmptyDetail({
+  description,
+  title,
+}: {
+  description: string
+  title: string
+}) {
+  return (
+    <div className='w-full rounded-lg border border-dashed border-slate-300 bg-slate-50/70 p-4 dark:border-white/15 dark:bg-white/5'>
+      <h3 className='text-sm font-semibold text-slate-900 dark:text-slate-100'>
+        {title}
+      </h3>
+      <p className='mt-1 text-sm leading-5 text-slate-500 dark:text-slate-400'>
+        {description}
       </p>
-    </AdminInsetPanel>
+    </div>
   )
 }
 
-function StudentMasteryRadar({
-  view,
-}: {
-  view: ReturnType<typeof buildStudentViewModel>
-}) {
+function renderStatusBadge(label: string, className: string) {
   return (
-    <AdminSurface>
-      <AdminSurfaceHeader title='Mastery radar' />
-      <div className='mt-6 h-[320px]'>
-        {view.radarData.length > 0 ? (
-          <ResponsiveContainer height='100%' width='100%'>
-            <RadarChart data={view.radarData}>
-              <PolarGrid />
-              <PolarAngleAxis dataKey='topic' />
-              <Tooltip />
-              <Radar
-                dataKey='mastery'
-                stroke='#0284c7'
-                fill='#38bdf8'
-                fillOpacity={0.35}
-              />
-            </RadarChart>
-          </ResponsiveContainer>
-        ) : (
-          <div className='flex h-full items-center justify-center'>
-            <StatePanel title='No mastery radar yet'>
-              Progress details will appear after the student completes some
-              work.
-            </StatePanel>
-          </div>
-        )}
-      </div>
-    </AdminSurface>
+    <Badge
+      className={`h-auto min-h-7 px-2.5 py-1 tabular-nums transition-none! ${className}`}
+      variant='outline'
+    >
+      {label}
+    </Badge>
   )
 }
 
-function StudentStruggleAreas({
-  detail,
-  view,
-}: {
-  detail: StudentDetail
-  view: ReturnType<typeof buildStudentViewModel>
-}) {
+function renderConversationCount(count: number) {
+  if (count === 0) {
+    return null
+  }
+
   return (
-    <AdminSurface>
-      <AdminSurfaceHeader title='Struggle areas' />
-      <div className='mt-6 space-y-4'>
-        <div className='flex flex-wrap gap-2'>
-          {view.struggleAreas.length > 0 ? (
-            view.struggleAreas.map((item) => (
-              <span
-                className='inline-flex min-h-7 items-center rounded-full bg-amber-100 px-3 py-1 text-sm font-medium text-amber-900 hover:bg-amber-100 dark:bg-amber-300/15 dark:text-amber-100 dark:hover:bg-amber-300/15'
-                key={item.topic_id}
-              >
-                {formatTopicLabel(item.topic_id)}{' '}
-                {Math.round(item.mastery_score * 100)}%
-              </span>
-            ))
-          ) : (
-            <StatePanel title='No active struggle areas'>
-              This learner does not currently have any topics below the
-              intervention threshold.
-            </StatePanel>
-          )}
-        </div>
-
-        <div className='space-y-3'>
-          {view.hasProgress ? (
-            detail.progress.map((item) => (
-              <AdminInsetPanel key={item.topic_id}>
-                <div className='flex items-center justify-between gap-3'>
-                  <p className='text-sm font-medium text-slate-900 dark:text-slate-100'>
-                    {formatTopicLabel(item.topic_id)}
-                  </p>
-                  <span className='text-xs tracking-[0.16em] text-slate-500 uppercase dark:text-slate-400'>
-                    {Math.round(item.mastery_score * 100)}% mastery
-                  </span>
-                </div>
-                <p className='mt-2 text-xs text-slate-500 dark:text-slate-400'>
-                  Last studied:{' '}
-                  {item.last_studied_at
-                    ? formatAdminDateTime(item.last_studied_at)
-                    : 'Not recorded yet'}
-                </p>
-                <p className='text-xs text-slate-500 dark:text-slate-400'>
-                  Next review:{' '}
-                  {item.next_review_at
-                    ? formatAdminDateTime(item.next_review_at)
-                    : 'To be scheduled'}
-                </p>
-              </AdminInsetPanel>
-            ))
-          ) : (
-            <StatePanel title='No topic progress yet'>
-              No topic progress has been recorded for this student yet.
-            </StatePanel>
-          )}
-        </div>
-      </div>
-    </AdminSurface>
+    <Badge className='tabular-nums transition-none!' variant='outline'>
+      {count} {count === 1 ? 'message' : 'messages'}
+    </Badge>
   )
 }
 
-function StudentActivityGrid({
-  view,
-}: {
-  view: ReturnType<typeof buildStudentViewModel>
-}) {
-  return (
-    <AdminSurface>
-      <AdminSurfaceHeader
-        title='Activity grid'
-        description='Conversation activity over the last 14 days.'
-      />
-      <div className='mt-6 space-y-4'>
-        <div className='grid grid-cols-7 gap-2 md:grid-cols-[repeat(14,minmax(0,1fr))]'>
-          {view.activityGrid.map((item) => (
-            <div className='space-y-2 text-center' key={item.date}>
-              <div
-                aria-label={`${item.shortLabel}: ${item.count} messages`}
-                className={`h-12 rounded-2xl border border-white/60 shadow-inner dark:border-white/10 ${getActivityTone(item.level)}`}
-                title={`${item.shortLabel}: ${item.count} messages`}
-              />
-              <p className='text-[11px] tracking-[0.14em] text-slate-500 uppercase dark:text-slate-400'>
-                {item.shortLabel}
-              </p>
-            </div>
-          ))}
-        </div>
-        <div className='flex flex-wrap items-center gap-3 text-xs text-slate-500 dark:text-slate-400'>
-          <span>Less active</span>
-          {[0, 1, 2, 3, 4].map((level) => (
-            <span
-              className={`inline-flex size-4 rounded-full border border-white/60 dark:border-white/10 ${getActivityTone(level)}`}
-              key={level}
-            />
-          ))}
-          <span>More active</span>
-        </div>
-      </div>
-    </AdminSurface>
-  )
-}
-
-function StudentConversationList({
-  conversations,
-  view,
-}: {
-  conversations: Array<StudentConversation>
-  view: ReturnType<typeof buildStudentViewModel>
-}) {
-  return (
-    <AdminSurface>
-      <AdminSurfaceHeader title='Recent conversations' />
-      <div className='mt-6 space-y-3'>
-        {!view.hasConversations ? (
-          <StatePanel title='No tutoring messages yet'>
-            Recent tutoring messages will appear here once the student has
-            chatted.
-          </StatePanel>
-        ) : null}
-        {conversations.map((item) => (
-          <AdminInsetPanel
-            className={
-              item.role === 'student'
-                ? 'bg-slate-50 dark:border-white/10 dark:bg-slate-900/80'
-                : 'bg-sky-50 dark:border-sky-400/20 dark:bg-sky-400/10'
-            }
-            key={item.id}
-          >
-            <div className='mb-2 flex items-center justify-between text-xs font-medium tracking-[0.18em] text-slate-500 uppercase dark:text-slate-400'>
-              <span>{item.role}</span>
-              <span>{formatAdminDateTime(item.timestamp)}</span>
-            </div>
-            <p className='text-sm leading-6 text-slate-700 dark:text-slate-200'>
-              {item.text}
-            </p>
-          </AdminInsetPanel>
-        ))}
-      </div>
-    </AdminSurface>
-  )
-}
+const radarAxisTick = { fontSize: 11 }
+const xpNumberFormatter = new Intl.NumberFormat('en-US')

--- a/admin-spa/src/lib/student-detail-view.test.ts
+++ b/admin-spa/src/lib/student-detail-view.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildStudentViewModel, getActivityTone } from './student-detail-view'
+import {
+  studentConversationFixture,
+  studentDetailFixture,
+} from './student-detail-types.test'
+
+describe('buildStudentViewModel', () => {
+  it('prioritizes the weakest struggle and summarizes recent activity', () => {
+    const detail = {
+      ...studentDetailFixture,
+      progress: [
+        ...studentDetailFixture.progress,
+        {
+          ease_factor: 2.1,
+          interval_days: 1,
+          last_studied_at: '2026-05-07T00:00:00Z',
+          mastery_score: 0.42,
+          next_review_at: '2026-05-09T00:00:00Z',
+          topic_id: 'fractions',
+        },
+      ],
+    }
+
+    const view = buildStudentViewModel(
+      detail,
+      [...studentConversationFixture],
+      new Date('2026-05-08T12:00:00Z'),
+    )
+
+    expect(view.status).toEqual({
+      description: '1 topic needs targeted support.',
+      label: 'Needs attention',
+      tone: 'attention',
+    })
+    expect(view.struggleAreas[0]?.topic_id).toBe('fractions')
+    expect(view.strengthAreas[0]?.topic_id).toBe('linear-equations')
+    expect(view.recommendation.title).toBe('Review Fractions next')
+    expect(view.recentMessageCount).toBe(2)
+    expect(view.activeDays).toBe(1)
+    expect(view.latestActivityAt).toBe('2026-05-08T00:01:00Z')
+    expect(view.conversations.map((conversation) => conversation.id)).toEqual([
+      'message_2',
+      'message_1',
+    ])
+  })
+
+  it('gives a useful starting action when no learning data exists', () => {
+    const view = buildStudentViewModel(
+      { ...studentDetailFixture, progress: [] },
+      [],
+    )
+
+    expect(view.status.label).toBe('Getting started')
+    expect(view.recommendation).toEqual({
+      description:
+        'Ask the learner to complete a short diagnostic conversation so strengths and support needs can be identified.',
+      title: 'Start with a guided check-in',
+    })
+    expect(view.latestActivityAt).toBeNull()
+    expect(view.recentMessageCount).toBe(0)
+  })
+
+  it('does not treat stale conversation history as recent activity', () => {
+    const view = buildStudentViewModel(
+      {
+        ...studentDetailFixture,
+        progress: [...studentDetailFixture.progress],
+      },
+      [...studentConversationFixture],
+      new Date('2026-05-30T12:00:00Z'),
+    )
+
+    expect(view.recentMessageCount).toBe(0)
+    expect(view.activeDays).toBe(0)
+    expect(view.latestActivityAt).toBe('2026-05-08T00:01:00Z')
+    expect(view.status).toEqual({
+      description:
+        'Mastery is developing, but no recent tutoring activity is recorded.',
+      label: 'Check in',
+      tone: 'neutral',
+    })
+  })
+
+  it('provides contrasting text for each activity intensity', () => {
+    for (const level of [0, 1, 2, 3, 4]) {
+      expect(getActivityTone(level)).toContain('text-')
+      expect(getActivityTone(level)).toContain('dark:text-')
+    }
+  })
+})

--- a/admin-spa/src/lib/student-detail-view.ts
+++ b/admin-spa/src/lib/student-detail-view.ts
@@ -12,33 +12,191 @@ export interface StudentActivityGridItem {
 
 export interface StudentViewModel {
   activityGrid: Array<StudentActivityGridItem>
+  activeDays: number
+  conversations: Array<StudentConversation>
   hasConversations: boolean
   hasProgress: boolean
+  latestActivityAt: string | null
+  recentMessageCount: number
+  recommendation: {
+    description: string
+    title: string
+  }
   radarData: Array<{
     mastery: number
     topic: string
   }>
+  status: {
+    description: string
+    label: string
+    tone: 'attention' | 'neutral' | 'positive'
+  }
+  strengthAreas: StudentDetail['progress']
   struggleAreas: StudentDetail['progress']
 }
 
 export function buildStudentViewModel(
   detail: StudentDetail,
   conversations: Array<StudentConversation>,
+  currentDate = new Date(),
 ): StudentViewModel {
+  const activityGrid = buildStudentActivityGrid(conversations, currentDate)
+  const recentMessageCount = activityGrid.reduce(
+    (total, item) => total + item.count,
+    0,
+  )
+  const struggleAreas = getStruggleAreas(detail)
+  const strengthAreas = getStrengthAreas(detail)
+
   return {
-    activityGrid: buildStudentActivityGrid(conversations),
+    activityGrid,
+    activeDays: activityGrid.filter((item) => item.count > 0).length,
+    conversations: getConversationsNewestFirst(conversations),
     hasConversations: conversations.length > 0,
     hasProgress: detail.progress.length > 0,
+    latestActivityAt: getLatestConversationTimestamp(conversations),
+    recentMessageCount,
+    recommendation: getRecommendation(detail, struggleAreas),
     radarData: detail.progress.map((item) => ({
       mastery: Math.round(item.mastery_score * 100),
       topic: formatTopicLabel(item.topic_id),
     })),
-    struggleAreas: getStruggleAreas(detail),
+    status: getLearnerStatus(detail, recentMessageCount, struggleAreas),
+    strengthAreas,
+    struggleAreas,
   }
 }
 
 function getStruggleAreas(detail: StudentDetail): StudentDetail['progress'] {
-  return detail.progress.filter((item) => item.mastery_score < 0.6)
+  return detail.progress.filter((item) => item.mastery_score < masteryThreshold)
+}
+
+function getStrengthAreas(detail: StudentDetail): StudentDetail['progress'] {
+  return detail.progress.filter(
+    (item) => item.mastery_score >= masteryThreshold,
+  )
+}
+
+function getLearnerStatus(
+  detail: StudentDetail,
+  recentMessageCount: number,
+  struggleAreas: StudentDetail['progress'],
+): StudentViewModel['status'] {
+  if (struggleAreas.length > 0) {
+    return {
+      description: `${struggleAreas.length} ${struggleAreas.length === 1 ? 'topic needs' : 'topics need'} targeted support.`,
+      label: 'Needs attention',
+      tone: 'attention',
+    }
+  }
+
+  if (detail.progress.length > 0) {
+    return {
+      description:
+        recentMessageCount > 0
+          ? 'Recent learning activity has no topics below the support threshold.'
+          : 'Mastery is developing, but no recent tutoring activity is recorded.',
+      label: recentMessageCount > 0 ? 'On track' : 'Check in',
+      tone: recentMessageCount > 0 ? 'positive' : 'neutral',
+    }
+  }
+
+  return {
+    description:
+      'There is not enough progress data to assess this learner yet.',
+    label: 'Getting started',
+    tone: 'neutral',
+  }
+}
+
+function getRecommendation(
+  detail: StudentDetail,
+  struggleAreas: StudentDetail['progress'],
+): StudentViewModel['recommendation'] {
+  const priorityTopic = getLowestMasteryArea(struggleAreas)
+
+  if (priorityTopic) {
+    const mastery = Math.round(priorityTopic.mastery_score * 100)
+    const topic = formatTopicLabel(priorityTopic.topic_id)
+
+    return {
+      description: `${topic} is the lowest-mastery topic at ${mastery}%. Use a short worked example, then check understanding.`,
+      title: `Review ${topic} next`,
+    }
+  }
+
+  const strongestTopic = getHighestMasteryArea(getStrengthAreas(detail))
+  if (strongestTopic) {
+    const topic = formatTopicLabel(strongestTopic.topic_id)
+
+    return {
+      description: `${topic} is currently secure. Reinforce it with a mixed-practice question before introducing the next topic.`,
+      title: `Build from ${topic}`,
+    }
+  }
+
+  return {
+    description:
+      'Ask the learner to complete a short diagnostic conversation so strengths and support needs can be identified.',
+    title: 'Start with a guided check-in',
+  }
+}
+
+function getLowestMasteryArea(
+  progress: StudentDetail['progress'],
+): StudentDetail['progress'][number] | undefined {
+  return progress.reduce<StudentDetail['progress'][number] | undefined>(
+    (lowest, item) =>
+      !lowest || item.mastery_score < lowest.mastery_score ? item : lowest,
+    undefined,
+  )
+}
+
+function getHighestMasteryArea(
+  progress: StudentDetail['progress'],
+): StudentDetail['progress'][number] | undefined {
+  return progress.reduce<StudentDetail['progress'][number] | undefined>(
+    (highest, item) =>
+      !highest || item.mastery_score > highest.mastery_score ? item : highest,
+    undefined,
+  )
+}
+
+function getLatestConversationTimestamp(
+  conversations: Array<StudentConversation>,
+): string | null {
+  let latestTimestamp: string | null = null
+  let latestTime = Number.NEGATIVE_INFINITY
+
+  conversations.forEach((conversation) => {
+    const timestamp = new Date(conversation.timestamp).getTime()
+
+    if (!Number.isNaN(timestamp) && timestamp > latestTime) {
+      latestTimestamp = conversation.timestamp
+      latestTime = timestamp
+    }
+  })
+
+  return latestTimestamp
+}
+
+function getConversationsNewestFirst(
+  conversations: Array<StudentConversation>,
+): Array<StudentConversation> {
+  const orderedConversations = [...conversations]
+
+  // oxlint-disable-next-line unicorn/no-array-sort -- ES2022 does not provide Array.prototype.toSorted.
+  return orderedConversations.sort(
+    (left, right) =>
+      getConversationTime(right.timestamp) -
+      getConversationTime(left.timestamp),
+  )
+}
+
+function getConversationTime(timestamp: string): number {
+  const time = new Date(timestamp).getTime()
+
+  return Number.isNaN(time) ? Number.MIN_SAFE_INTEGER : time
 }
 
 export function getActivityTone(level: number): string {
@@ -47,9 +205,10 @@ export function getActivityTone(level: number): string {
 
 function buildStudentActivityGrid(
   conversations: Array<StudentConversation>,
+  currentDate: Date,
 ): Array<StudentActivityGridItem> {
   const timestamps = conversations.map((item) => toISODate(item.timestamp))
-  const anchorDate = getLatestTimestamp(timestamps)
+  const anchorDate = currentDate.toISOString().slice(0, 10)
   const counts = countConversationDates(timestamps)
 
   return Array.from({ length: activityWindowDays }, (_, index) => {
@@ -63,18 +222,6 @@ function buildStudentActivityGrid(
       shortLabel: formatGridLabel(date),
     }
   })
-}
-
-function getLatestTimestamp(timestamps: Array<string | null>): string {
-  for (let index = timestamps.length - 1; index >= 0; index -= 1) {
-    const timestamp = timestamps[index]
-
-    if (timestamp) {
-      return timestamp
-    }
-  }
-
-  return new Date().toISOString().slice(0, 10)
 }
 
 function getActivityLevel(count: number): number {
@@ -117,11 +264,11 @@ const activityDateFormatter = new Intl.DateTimeFormat('en-US', {
 })
 
 const activityTones = [
-  'bg-slate-200 dark:bg-slate-800',
-  'bg-sky-200 dark:bg-sky-700',
-  'bg-sky-300 dark:bg-sky-500',
-  'bg-sky-500 dark:bg-sky-400',
-  'bg-sky-600 dark:bg-sky-300',
+  'bg-slate-200 text-slate-700 dark:bg-slate-800 dark:text-slate-100',
+  'bg-sky-200 text-sky-950 dark:bg-sky-700 dark:text-white',
+  'bg-sky-300 text-sky-950 dark:bg-sky-500 dark:text-slate-950',
+  'bg-sky-500 text-white dark:bg-sky-400 dark:text-slate-950',
+  'bg-sky-600 text-white dark:bg-sky-300 dark:text-slate-950',
 ] as const
 
 const activityLevelThresholds = [
@@ -132,3 +279,4 @@ const activityLevelThresholds = [
 ] as const
 
 const activityWindowDays = 14
+const masteryThreshold = 0.6


### PR DESCRIPTION
## Summary

- turn learner detail into an actionable teacher workflow
- order conversations newest first and anchor recency to the current day
- improve focus, scrolling, sheet layout, and dark-theme behavior

## Testing

- `cd admin-spa && pnpm run check`
- 47 test files, 195 tests, and production build passed