### PR TITLE
Add Codex provider protocol

### DIFF
--- a/internal/ai/provider_codex.go
+++ b/internal/ai/provider_codex.go
@@ -1,0 +1,1147 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ai
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/p-n-ai/pai-bot/internal/llm"
+)
+
+const (
+	defaultCodexBaseURL     = "https://chatgpt.com/backend-api"
+	defaultCodexAuthBaseURL = "https://auth.openai.com"
+	defaultCodexModel       = "gpt-5.4"
+	codexOAuthClientID      = "app_EMoamEEZ73f0CkXaXp7hrann"
+)
+
+type CodexProvider struct {
+	baseURL     string
+	authBaseURL string
+	client      *http.Client
+
+	mu                sync.Mutex
+	accessToken       string
+	refreshToken      string
+	accountID         string
+	explicitAccountID bool
+	expiresAt         time.Time
+	refreshing        chan struct{}
+	refreshErr        error
+}
+
+type CodexOption func(*CodexProvider)
+
+func WithCodexRefreshToken(token string) CodexOption {
+	return func(p *CodexProvider) {
+		p.refreshToken = strings.TrimSpace(token)
+	}
+}
+
+func WithCodexAccountID(accountID string) CodexOption {
+	return func(p *CodexProvider) {
+		p.accountID = strings.TrimSpace(accountID)
+		p.explicitAccountID = p.accountID != ""
+	}
+}
+
+func WithCodexBaseURL(baseURL string) CodexOption {
+	return func(p *CodexProvider) {
+		p.baseURL = strings.TrimSpace(baseURL)
+	}
+}
+
+func WithCodexHTTPClient(client *http.Client) CodexOption {
+	return func(p *CodexProvider) {
+		p.client = client
+	}
+}
+
+func WithCodexAuthBaseURL(baseURL string) CodexOption {
+	return func(p *CodexProvider) {
+		p.authBaseURL = strings.TrimSpace(baseURL)
+	}
+}
+
+func NewCodexProvider(accessToken string, opts ...CodexOption) (*CodexProvider, error) {
+	accessToken = strings.TrimSpace(accessToken)
+	if accessToken == "" {
+		return nil, errors.New("Codex access token is required")
+	}
+	p := &CodexProvider{
+		accessToken: accessToken,
+		baseURL:     defaultCodexBaseURL,
+		authBaseURL: defaultCodexAuthBaseURL,
+		client:      http.DefaultClient,
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	if p.client == nil {
+		return nil, errors.New("Codex HTTP client is required")
+	}
+	if p.baseURL == "" {
+		return nil, errors.New("Codex base URL is required")
+	}
+	if p.authBaseURL == "" {
+		return nil, errors.New("Codex auth base URL is required")
+	}
+
+	accountID, expiresAt, err := codexJWTMetadata(accessToken)
+	if !p.explicitAccountID {
+		if err != nil || accountID == "" {
+			return nil, errors.New("failed to extract Codex account ID from access token")
+		}
+		p.accountID = accountID
+	}
+	if err == nil {
+		p.expiresAt = expiresAt
+	}
+	return p, nil
+}
+
+var _ Provider = (*CodexProvider)(nil)
+var _ NativeProvider = (*CodexProvider)(nil)
+
+type codexRequest struct {
+	Model             string           `json:"model"`
+	Store             bool             `json:"store"`
+	Stream            bool             `json:"stream"`
+	Instructions      string           `json:"instructions"`
+	Input             []any            `json:"input"`
+	Tools             []codexTool      `json:"tools,omitempty"`
+	ToolChoice        string           `json:"tool_choice,omitempty"`
+	ParallelToolCalls bool             `json:"parallel_tool_calls,omitempty"`
+	MaxOutputTokens   int              `json:"max_output_tokens,omitempty"`
+	Temperature       *float64         `json:"temperature,omitempty"`
+	Reasoning         *codexReasoning  `json:"reasoning,omitempty"`
+	Text              codexTextOptions `json:"text"`
+	Include           []string         `json:"include,omitempty"`
+	PromptCacheKey    string           `json:"prompt_cache_key,omitempty"`
+	headers           map[string]string
+}
+
+type codexTextOptions struct {
+	Verbosity string               `json:"verbosity"`
+	Format    *codexResponseFormat `json:"format,omitempty"`
+}
+
+type codexResponseFormat struct {
+	Type   string          `json:"type"`
+	Name   string          `json:"name"`
+	Schema json.RawMessage `json:"schema"`
+	Strict bool            `json:"strict"`
+}
+
+type codexReasoning struct {
+	Effort  string `json:"effort,omitempty"`
+	Summary string `json:"summary,omitempty"`
+}
+
+type codexTool struct {
+	Type        string          `json:"type"`
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Parameters  json.RawMessage `json:"parameters"`
+	Strict      *bool           `json:"strict"`
+}
+
+type codexResult struct {
+	id         string
+	model      string
+	text       string
+	content    []llm.AssistantContent
+	toolCalls  []llm.ToolCall
+	input      int
+	output     int
+	cacheRead  int
+	cacheWrite int
+	status     string
+	terminal   bool
+}
+
+type codexSSEEvent struct {
+	Type        string          `json:"type"`
+	OutputIndex int             `json:"output_index"`
+	Delta       string          `json:"delta"`
+	Arguments   string          `json:"arguments"`
+	Item        json.RawMessage `json:"item"`
+	Response    json.RawMessage `json:"response"`
+	Error       *struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type codexResponseItem struct {
+	Type             string `json:"type"`
+	ID               string `json:"id"`
+	CallID           string `json:"call_id"`
+	Name             string `json:"name"`
+	Arguments        string `json:"arguments"`
+	EncryptedContent string `json:"encrypted_content"`
+	Summary          []struct {
+		Text string `json:"text"`
+	} `json:"summary"`
+	Content []struct {
+		Type    string `json:"type"`
+		Text    string `json:"text"`
+		Refusal string `json:"refusal"`
+	} `json:"content"`
+}
+
+type codexTerminalResponse struct {
+	ID     string            `json:"id"`
+	Model  string            `json:"model"`
+	Status string            `json:"status"`
+	Output []json.RawMessage `json:"output"`
+	Usage  struct {
+		InputTokens  int `json:"input_tokens"`
+		OutputTokens int `json:"output_tokens"`
+		InputDetails struct {
+			CachedTokens     int `json:"cached_tokens"`
+			CacheWriteTokens int `json:"cache_write_tokens"`
+		} `json:"input_tokens_details"`
+	} `json:"usage"`
+	Error *struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+type codexOutputItem struct {
+	parsed codexResponseItem
+	raw    json.RawMessage
+	done   bool
+}
+
+func (p *CodexProvider) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
+	request, err := buildCodexLegacyRequest(req)
+	if err != nil {
+		return CompletionResponse{}, err
+	}
+	result, err := p.complete(ctx, request, nil)
+	if err != nil {
+		return CompletionResponse{}, err
+	}
+	response := CompletionResponse{
+		Content:      result.text,
+		Model:        result.responseModel(request.Model),
+		InputTokens:  result.input + result.cacheRead + result.cacheWrite,
+		OutputTokens: result.output,
+	}
+	if req.StructuredOutput != nil {
+		response.StructuredOutput = json.RawMessage(result.text)
+	}
+	return response, nil
+}
+
+func (p *CodexProvider) StreamComplete(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, error) {
+	request, err := buildCodexLegacyRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	response, err := p.openResponse(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	chunks := make(chan StreamChunk)
+	go func() {
+		defer close(chunks)
+		defer func() { _ = response.Body.Close() }()
+		_, parseErr := parseCodexStream(response.Body, func(delta string) {
+			select {
+			case chunks <- StreamChunk{Content: delta}:
+			case <-ctx.Done():
+			}
+		})
+		if parseErr != nil {
+			select {
+			case chunks <- StreamChunk{Error: parseErr, Done: true}:
+			case <-ctx.Done():
+			}
+			return
+		}
+		select {
+		case chunks <- StreamChunk{Done: true}:
+		case <-ctx.Done():
+		}
+	}()
+	return chunks, nil
+}
+
+func (p *CodexProvider) CompleteNative(ctx context.Context, model string, c llm.Context, opts *llm.StreamOptions) (llm.AssistantMessage, error) {
+	request, err := buildCodexNativeRequest(model, c, opts)
+	if err != nil {
+		return llm.AssistantMessage{}, err
+	}
+	result, err := p.complete(ctx, request, nil)
+	if err != nil {
+		return llm.AssistantMessage{}, err
+	}
+	content := result.content
+	if len(content) == 0 && result.text != "" {
+		content = []llm.AssistantContent{llm.TextContent{Text: result.text}}
+	}
+	stopReason := llm.StopReasonStop
+	if len(result.toolCalls) > 0 {
+		stopReason = llm.StopReasonToolUse
+	} else if result.status == "incomplete" {
+		stopReason = llm.StopReasonLength
+	}
+	return llm.AssistantMessage{
+		Content:       content,
+		API:           "openai-codex-responses",
+		Provider:      "openai-codex",
+		Model:         request.Model,
+		ResponseModel: result.responseModel(request.Model),
+		ResponseID:    result.id,
+		Usage: llm.Usage{
+			Input:       result.input,
+			Output:      result.output,
+			CacheRead:   result.cacheRead,
+			CacheWrite:  result.cacheWrite,
+			TotalTokens: result.input + result.cacheRead + result.cacheWrite + result.output,
+		},
+		StopReason: stopReason,
+		Timestamp:  time.Now(),
+	}, nil
+}
+
+func (p *CodexProvider) Models() []ModelInfo {
+	return []ModelInfo{{
+		ID:          defaultCodexModel,
+		Name:        "GPT-5.4 Codex",
+		MaxTokens:   128000,
+		Description: "OpenAI Codex through a ChatGPT subscription",
+	}}
+}
+
+func (p *CodexProvider) HealthCheck(ctx context.Context) error {
+	_, _, err := p.credentials(ctx)
+	return err
+}
+
+func (p *CodexProvider) complete(ctx context.Context, request codexRequest, onText func(string)) (codexResult, error) {
+	response, err := p.openResponse(ctx, request)
+	if err != nil {
+		return codexResult{}, err
+	}
+	defer func() { _ = response.Body.Close() }()
+	return parseCodexStream(response.Body, onText)
+}
+
+func (p *CodexProvider) openResponse(ctx context.Context, request codexRequest) (*http.Response, error) {
+	body, err := json.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("marshal Codex request: %w", err)
+	}
+	token, accountID, err := p.credentials(ctx)
+	if err != nil {
+		return nil, err
+	}
+	response, err := p.post(ctx, body, request, token, accountID)
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode != http.StatusUnauthorized && response.StatusCode != http.StatusForbidden {
+		return codexHTTPResponse(response)
+	}
+	_ = response.Body.Close()
+
+	if err := p.refreshCredentials(ctx, token, true); err != nil {
+		return nil, fmt.Errorf("Codex authentication rejected and token refresh failed: %w", err)
+	}
+	token, accountID, err = p.credentials(ctx)
+	if err != nil {
+		return nil, err
+	}
+	response, err = p.post(ctx, body, request, token, accountID)
+	if err != nil {
+		return nil, err
+	}
+	return codexHTTPResponse(response)
+}
+
+func (p *CodexProvider) post(ctx context.Context, body []byte, codexRequest codexRequest, token, accountID string) (*http.Response, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, codexResponsesURL(p.baseURL), bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create Codex request: %w", err)
+	}
+	for name, value := range codexRequest.headers {
+		request.Header.Set(name, value)
+	}
+	request.Header.Set("Authorization", "Bearer "+token)
+	request.Header.Set("chatgpt-account-id", accountID)
+	request.Header.Set("originator", "pi")
+	request.Header.Set("OpenAI-Beta", "responses=experimental")
+	request.Header.Set("Accept", "text/event-stream")
+	request.Header.Set("Content-Type", "application/json")
+	if codexRequest.PromptCacheKey != "" {
+		request.Header.Set("session-id", codexRequest.PromptCacheKey)
+		request.Header.Set("x-client-request-id", codexRequest.PromptCacheKey)
+	}
+	response, err := p.client.Do(request)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		return nil, fmt.Errorf("send Codex request: %w", err)
+	}
+	return response, nil
+}
+
+func codexHTTPResponse(response *http.Response) (*http.Response, error) {
+	if response.StatusCode >= 200 && response.StatusCode < 300 {
+		return response, nil
+	}
+	defer func() { _ = response.Body.Close() }()
+	_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 64<<10))
+	return nil, fmt.Errorf("Codex API returned status %d", response.StatusCode)
+}
+
+func (p *CodexProvider) credentials(ctx context.Context) (string, string, error) {
+	p.mu.Lock()
+	token := p.accessToken
+	expired := !p.expiresAt.IsZero() && !time.Now().Add(30*time.Second).Before(p.expiresAt)
+	p.mu.Unlock()
+	if expired {
+		if err := p.refreshCredentials(ctx, token, false); err != nil {
+			return "", "", err
+		}
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.accessToken, p.accountID, nil
+}
+
+func (p *CodexProvider) refreshCredentials(ctx context.Context, staleToken string, force bool) error {
+	p.mu.Lock()
+	if p.accessToken != staleToken {
+		p.mu.Unlock()
+		return nil
+	}
+	if !force && (p.expiresAt.IsZero() || time.Now().Add(30*time.Second).Before(p.expiresAt)) {
+		p.mu.Unlock()
+		return nil
+	}
+	if p.refreshing != nil {
+		done := p.refreshing
+		p.mu.Unlock()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-done:
+		}
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		if p.accessToken != staleToken {
+			return nil
+		}
+		return p.refreshErr
+	}
+	if p.refreshToken == "" {
+		p.mu.Unlock()
+		return errors.New("Codex refresh token is unavailable")
+	}
+	done := make(chan struct{})
+	p.refreshing = done
+	refreshToken := p.refreshToken
+	p.mu.Unlock()
+
+	credentials, err := p.requestTokenRefresh(ctx, refreshToken)
+
+	p.mu.Lock()
+	if err == nil {
+		p.accessToken = credentials.accessToken
+		p.refreshToken = credentials.refreshToken
+		p.expiresAt = credentials.expiresAt
+		if !p.explicitAccountID {
+			p.accountID = credentials.accountID
+		}
+	}
+	p.refreshErr = err
+	p.refreshing = nil
+	close(done)
+	p.mu.Unlock()
+	return err
+}
+
+type codexCredentials struct {
+	accessToken  string
+	refreshToken string
+	accountID    string
+	expiresAt    time.Time
+}
+
+func (p *CodexProvider) requestTokenRefresh(ctx context.Context, refreshToken string) (codexCredentials, error) {
+	form := url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {refreshToken},
+		"client_id":     {codexOAuthClientID},
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(p.authBaseURL, "/")+"/oauth/token", strings.NewReader(form.Encode()))
+	if err != nil {
+		return codexCredentials{}, errors.New("create Codex token refresh request")
+	}
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	response, err := p.client.Do(request)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return codexCredentials{}, ctxErr
+		}
+		return codexCredentials{}, errors.New("send Codex token refresh request")
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return codexCredentials{}, fmt.Errorf("Codex token refresh returned status %d", response.StatusCode)
+	}
+	var decoded struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		ExpiresIn    int    `json:"expires_in"`
+	}
+	if err := json.NewDecoder(io.LimitReader(response.Body, 1<<20)).Decode(&decoded); err != nil {
+		return codexCredentials{}, errors.New("decode Codex token refresh response")
+	}
+	if decoded.AccessToken == "" || decoded.RefreshToken == "" || decoded.ExpiresIn <= 0 {
+		return codexCredentials{}, errors.New("Codex token refresh response is missing required fields")
+	}
+	accountID, _, err := codexJWTMetadata(decoded.AccessToken)
+	if !p.explicitAccountID && (err != nil || accountID == "") {
+		return codexCredentials{}, errors.New("failed to extract Codex account ID from refreshed access token")
+	}
+	return codexCredentials{
+		accessToken:  decoded.AccessToken,
+		refreshToken: decoded.RefreshToken,
+		accountID:    accountID,
+		expiresAt:    time.Now().Add(time.Duration(decoded.ExpiresIn) * time.Second),
+	}, nil
+}
+
+func buildCodexLegacyRequest(req CompletionRequest) (codexRequest, error) {
+	model := strings.TrimSpace(req.Model)
+	if model == "" {
+		model = defaultCodexModel
+	}
+	request := newCodexRequest(model)
+	request.MaxOutputTokens = req.MaxTokens
+	if req.Temperature > 0 {
+		temperature := req.Temperature
+		request.Temperature = &temperature
+	}
+	var instructions []string
+	assistantIndex := 0
+	for i, message := range req.Messages {
+		switch message.Role {
+		case "system", "developer":
+			if len(message.ImageURLs) > 0 {
+				return codexRequest{}, fmt.Errorf("Codex system message at index %d cannot contain images", i)
+			}
+			if message.Content != "" {
+				instructions = append(instructions, message.Content)
+			}
+		case "user":
+			content := codexUserContent(message.Content, message.ImageURLs)
+			if len(content) > 0 {
+				request.Input = append(request.Input, map[string]any{"role": "user", "content": content})
+			}
+		case "assistant":
+			if len(message.ImageURLs) > 0 {
+				return codexRequest{}, fmt.Errorf("Codex assistant message at index %d cannot contain images", i)
+			}
+			request.Input = append(request.Input, codexAssistantInput(message.Content, assistantIndex))
+			assistantIndex++
+		default:
+			return codexRequest{}, fmt.Errorf("unsupported Codex message role at index %d", i)
+		}
+	}
+	request.Instructions = codexInstructions(instructions)
+	if err := applyCodexStructuredOutput(&request, req.StructuredOutput); err != nil {
+		return codexRequest{}, err
+	}
+	return request, nil
+}
+
+func buildCodexNativeRequest(model string, c llm.Context, opts *llm.StreamOptions) (codexRequest, error) {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		model = defaultCodexModel
+	}
+	request := newCodexRequest(model)
+	var instructions []string
+	if c.SystemPrompt != "" {
+		instructions = append(instructions, c.SystemPrompt)
+	}
+	assistantIndex := 0
+	for _, message := range c.Messages {
+		switch typed := message.(type) {
+		case llm.SystemMessage:
+			if typed.Content != "" {
+				instructions = append(instructions, typed.Content)
+			}
+		case llm.UserMessage:
+			content, err := codexNativeUserContent(typed.Content)
+			if err != nil {
+				return codexRequest{}, err
+			}
+			if len(content) > 0 {
+				request.Input = append(request.Input, map[string]any{"role": "user", "content": content})
+			}
+		case llm.AssistantMessage:
+			for _, block := range typed.Content {
+				switch value := block.(type) {
+				case llm.TextContent:
+					request.Input = append(request.Input, codexAssistantInput(value.Text, assistantIndex))
+					assistantIndex++
+				case llm.ToolCall:
+					arguments, err := json.Marshal(value.Arguments)
+					if err != nil {
+						return codexRequest{}, fmt.Errorf("Codex tool call %q arguments: %w", value.Name, err)
+					}
+					if value.Arguments == nil {
+						arguments = []byte("{}")
+					}
+					callID, itemID, _ := strings.Cut(value.ID, "|")
+					item := map[string]any{
+						"type":      "function_call",
+						"call_id":   callID,
+						"name":      value.Name,
+						"arguments": string(arguments),
+					}
+					if itemID != "" {
+						item["id"] = itemID
+					}
+					request.Input = append(request.Input, item)
+				case llm.ThinkingContent:
+					if value.Signature == "" {
+						continue
+					}
+					item, err := parseCodexReasoningSignature(value.Signature)
+					if err != nil {
+						return codexRequest{}, err
+					}
+					request.Input = append(request.Input, item)
+				default:
+					return codexRequest{}, fmt.Errorf("unsupported Codex assistant content type %T", block)
+				}
+			}
+		case llm.ToolResultMessage:
+			output, err := nativeOpenAIToolResultText(typed)
+			if err != nil {
+				return codexRequest{}, err
+			}
+			callID, _, _ := strings.Cut(typed.ToolCallID, "|")
+			request.Input = append(request.Input, map[string]any{
+				"type":    "function_call_output",
+				"call_id": callID,
+				"output":  output,
+			})
+		default:
+			return codexRequest{}, fmt.Errorf("unsupported Codex message type %T", message)
+		}
+	}
+	request.Instructions = codexInstructions(instructions)
+	tools, err := buildCodexTools(c.Tools)
+	if err != nil {
+		return codexRequest{}, err
+	}
+	request.Tools = tools
+	if len(tools) > 0 {
+		request.ToolChoice = "auto"
+		request.ParallelToolCalls = true
+	}
+	if opts != nil {
+		request.MaxOutputTokens = opts.MaxTokens
+		request.Temperature = opts.Temperature
+		if opts.ReasoningEffort != "" {
+			request.Reasoning = &codexReasoning{Effort: string(opts.ReasoningEffort), Summary: "auto"}
+		}
+		if opts.StructuredOutput != nil {
+			spec := &StructuredOutputSpec{
+				Name:       opts.StructuredOutput.Name,
+				JSONSchema: append(json.RawMessage(nil), opts.StructuredOutput.JSONSchema...),
+				Strict:     opts.StructuredOutput.Strict,
+			}
+			if err := applyCodexStructuredOutput(&request, spec); err != nil {
+				return codexRequest{}, err
+			}
+		}
+		if opts.CacheRetention != llm.CacheRetentionNone {
+			request.PromptCacheKey = opts.SessionID
+		}
+		request.headers = opts.Headers
+	}
+	return request, nil
+}
+
+func newCodexRequest(model string) codexRequest {
+	return codexRequest{
+		Model:   model,
+		Store:   false,
+		Stream:  true,
+		Text:    codexTextOptions{Verbosity: "low"},
+		Include: []string{"reasoning.encrypted_content"},
+	}
+}
+
+func codexInstructions(instructions []string) string {
+	if len(instructions) == 0 {
+		return "You are a helpful assistant."
+	}
+	return strings.Join(instructions, "\n\n")
+}
+
+func codexUserContent(text string, imageURLs []string) []any {
+	content := make([]any, 0, 1+len(imageURLs))
+	if text != "" {
+		content = append(content, map[string]any{"type": "input_text", "text": text})
+	}
+	for _, imageURL := range imageURLs {
+		if imageURL != "" {
+			content = append(content, map[string]any{"type": "input_image", "image_url": imageURL, "detail": "auto"})
+		}
+	}
+	return content
+}
+
+func codexNativeUserContent(content []llm.UserContent) ([]any, error) {
+	projected := make([]any, 0, len(content))
+	for _, block := range content {
+		switch value := block.(type) {
+		case llm.TextContent:
+			projected = append(projected, map[string]any{"type": "input_text", "text": value.Text})
+		case llm.ImageURLContent:
+			projected = append(projected, map[string]any{"type": "input_image", "image_url": value.URL, "detail": "auto"})
+		case llm.ImageContent:
+			if _, err := base64.StdEncoding.DecodeString(value.Data); err != nil {
+				return nil, errors.New("Codex user message contains invalid image data")
+			}
+			projected = append(projected, map[string]any{
+				"type":      "input_image",
+				"image_url": "data:" + value.MimeType + ";base64," + value.Data,
+				"detail":    "auto",
+			})
+		default:
+			return nil, fmt.Errorf("unsupported Codex user content type %T", block)
+		}
+	}
+	return projected, nil
+}
+
+func codexAssistantInput(text string, index int) map[string]any {
+	return map[string]any{
+		"type":   "message",
+		"id":     fmt.Sprintf("msg_pai_%d", index),
+		"role":   "assistant",
+		"status": "completed",
+		"content": []any{
+			map[string]any{"type": "output_text", "text": text, "annotations": []any{}},
+		},
+	}
+}
+
+func parseCodexReasoningSignature(signature string) (json.RawMessage, error) {
+	if !json.Valid([]byte(signature)) {
+		return nil, errors.New("Codex reasoning signature is invalid JSON")
+	}
+	var item map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(signature), &item); err != nil || item == nil {
+		return nil, errors.New("Codex reasoning signature must be a JSON object")
+	}
+	var itemType string
+	if err := json.Unmarshal(item["type"], &itemType); err != nil || itemType != "reasoning" {
+		return nil, errors.New("Codex reasoning signature must contain a reasoning output item")
+	}
+	var id string
+	if err := json.Unmarshal(item["id"], &id); err != nil || id == "" {
+		return nil, errors.New("Codex reasoning signature must contain an item ID")
+	}
+	return append(json.RawMessage(nil), signature...), nil
+}
+
+func buildCodexTools(tools []llm.Tool) ([]codexTool, error) {
+	projected := make([]codexTool, len(tools))
+	for i, tool := range tools {
+		var parameters map[string]any
+		if err := json.Unmarshal(tool.Parameters, &parameters); err != nil || parameters == nil {
+			return nil, fmt.Errorf("Codex tool %q parameters must be a JSON object", tool.Name)
+		}
+		projected[i] = codexTool{
+			Type:        "function",
+			Name:        tool.Name,
+			Description: tool.Description,
+			Parameters:  append(json.RawMessage(nil), tool.Parameters...),
+			Strict:      nil,
+		}
+	}
+	return projected, nil
+}
+
+func applyCodexStructuredOutput(request *codexRequest, spec *StructuredOutputSpec) error {
+	if spec == nil {
+		return nil
+	}
+	if spec.Name == "" {
+		return errors.New("structured output name is required")
+	}
+	if len(spec.JSONSchema) == 0 || !json.Valid(spec.JSONSchema) {
+		return errors.New("structured output JSON schema is required")
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(spec.JSONSchema, &schema); err != nil || schema == nil {
+		return errors.New("structured output JSON schema must be an object")
+	}
+	request.Text.Format = &codexResponseFormat{
+		Type:   "json_schema",
+		Name:   spec.Name,
+		Schema: append(json.RawMessage(nil), spec.JSONSchema...),
+		Strict: spec.Strict,
+	}
+	return nil
+}
+
+func parseCodexStream(reader io.Reader, onText func(string)) (codexResult, error) {
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 64<<10), 4<<20)
+	var dataLines []string
+	result := codexResult{}
+	toolArguments := make(map[int]string)
+	outputItems := make(map[int]codexOutputItem)
+	dispatch := func() error {
+		if len(dataLines) == 0 {
+			return nil
+		}
+		data := strings.Join(dataLines, "\n")
+		dataLines = dataLines[:0]
+		if data == "[DONE]" {
+			return nil
+		}
+		var event codexSSEEvent
+		if err := json.Unmarshal([]byte(data), &event); err != nil {
+			return errors.New("decode Codex SSE event")
+		}
+		switch event.Type {
+		case "response.output_text.delta", "response.refusal.delta":
+			result.text += event.Delta
+			if onText != nil && event.Delta != "" {
+				onText(event.Delta)
+			}
+		case "response.output_item.added":
+			item, err := parseCodexOutputItem(event.Item)
+			if err != nil {
+				return errors.New("decode Codex output item")
+			}
+			outputItems[event.OutputIndex] = item
+			if item.parsed.Type == "function_call" {
+				toolArguments[event.OutputIndex] = item.parsed.Arguments
+			}
+		case "response.function_call_arguments.delta":
+			toolArguments[event.OutputIndex] += event.Delta
+		case "response.function_call_arguments.done":
+			toolArguments[event.OutputIndex] = event.Arguments
+		case "response.output_item.done":
+			item, err := parseCodexOutputItem(event.Item)
+			if err != nil {
+				return errors.New("decode Codex completed output item")
+			}
+			item.done = true
+			outputItems[event.OutputIndex] = item
+			if item.parsed.Type == "message" {
+				finalText := codexItemText(item.parsed)
+				if onText != nil && strings.HasPrefix(finalText, result.text) {
+					if delta := strings.TrimPrefix(finalText, result.text); delta != "" {
+						onText(delta)
+					}
+				}
+				result.text = finalText
+			} else if item.parsed.Type == "function_call" {
+				if item.parsed.Arguments != "" {
+					toolArguments[event.OutputIndex] = item.parsed.Arguments
+				}
+			}
+		case "response.completed", "response.done", "response.incomplete":
+			var terminal codexTerminalResponse
+			if err := json.Unmarshal(event.Response, &terminal); err != nil {
+				return errors.New("decode Codex terminal response")
+			}
+			if err := applyCodexTerminal(&result, terminal, outputItems, toolArguments); err != nil {
+				return err
+			}
+		case "response.failed":
+			var terminal codexTerminalResponse
+			_ = json.Unmarshal(event.Response, &terminal)
+			if terminal.Error != nil && terminal.Error.Code != "" {
+				return fmt.Errorf("Codex response failed (%s)", terminal.Error.Code)
+			}
+			return errors.New("Codex response failed")
+		case "error":
+			code := event.Code
+			if code == "" && event.Error != nil {
+				code = event.Error.Code
+			}
+			if code != "" {
+				return fmt.Errorf("Codex stream error (%s)", code)
+			}
+			return errors.New("Codex stream error")
+		}
+		return nil
+	}
+	for scanner.Scan() {
+		line := strings.TrimSuffix(scanner.Text(), "\r")
+		if line == "" {
+			if err := dispatch(); err != nil {
+				return codexResult{}, err
+			}
+			continue
+		}
+		if strings.HasPrefix(line, "data:") {
+			dataLines = append(dataLines, strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return codexResult{}, fmt.Errorf("read Codex SSE stream: %w", err)
+	}
+	if err := dispatch(); err != nil {
+		return codexResult{}, err
+	}
+	if !result.terminal {
+		return codexResult{}, errors.New("Codex SSE stream ended before a terminal response")
+	}
+	return result, nil
+}
+
+func applyCodexTerminal(result *codexResult, terminal codexTerminalResponse, items map[int]codexOutputItem, arguments map[int]string) error {
+	result.id = terminal.ID
+	result.model = terminal.Model
+	result.status = terminal.Status
+	result.cacheRead = terminal.Usage.InputDetails.CachedTokens
+	result.cacheWrite = terminal.Usage.InputDetails.CacheWriteTokens
+	result.input = max(0, terminal.Usage.InputTokens-result.cacheRead-result.cacheWrite)
+	result.output = terminal.Usage.OutputTokens
+	result.terminal = true
+	if result.text == "" {
+		for _, raw := range terminal.Output {
+			item, err := parseCodexOutputItem(raw)
+			if err != nil {
+				return errors.New("decode Codex terminal output item")
+			}
+			if item.parsed.Type == "message" {
+				result.text += codexItemText(item.parsed)
+			}
+		}
+	}
+	for i, raw := range terminal.Output {
+		terminalItem, err := parseCodexOutputItem(raw)
+		if err != nil {
+			return errors.New("decode Codex terminal output item")
+		}
+		if current, ok := items[i]; ok && current.done && current.parsed.Type == "reasoning" && terminalItem.parsed.Type == "reasoning" {
+			terminalItem, err = backfillCodexReasoningItem(current, terminalItem)
+			if err != nil {
+				return err
+			}
+		}
+		items[i] = terminalItem
+		if terminalItem.parsed.Type == "function_call" && terminalItem.parsed.Arguments != "" {
+			arguments[i] = terminalItem.parsed.Arguments
+		}
+	}
+	indexes := make([]int, 0, len(items))
+	for index := range items {
+		indexes = append(indexes, index)
+	}
+	sort.Ints(indexes)
+	for _, i := range indexes {
+		item := items[i]
+		switch item.parsed.Type {
+		case "reasoning":
+			signature, err := codexReasoningSignature(item)
+			if err != nil {
+				return err
+			}
+			result.content = append(result.content, llm.ThinkingContent{
+				Thinking:  codexReasoningText(item.parsed),
+				Signature: signature,
+			})
+			continue
+		case "message":
+			if text := codexItemText(item.parsed); text != "" {
+				result.content = append(result.content, llm.TextContent{Text: text})
+			}
+			continue
+		case "function_call":
+		default:
+			continue
+		}
+		var decoded map[string]any
+		encoded := arguments[i]
+		if strings.TrimSpace(encoded) == "" {
+			encoded = "{}"
+		}
+		if err := json.Unmarshal([]byte(encoded), &decoded); err != nil || decoded == nil {
+			return fmt.Errorf("Codex tool call %q returned invalid arguments", item.parsed.Name)
+		}
+		callID := item.parsed.CallID
+		if callID == "" {
+			callID = item.parsed.ID
+		}
+		if item.parsed.ID != "" && item.parsed.ID != callID {
+			callID += "|" + item.parsed.ID
+		}
+		call := llm.ToolCall{
+			ID:        callID,
+			Name:      item.parsed.Name,
+			Arguments: decoded,
+		}
+		result.toolCalls = append(result.toolCalls, call)
+		result.content = append(result.content, call)
+	}
+	if terminal.Status == "failed" || terminal.Status == "cancelled" {
+		return fmt.Errorf("Codex response ended with status %s", terminal.Status)
+	}
+	return nil
+}
+
+func parseCodexOutputItem(raw json.RawMessage) (codexOutputItem, error) {
+	if len(raw) == 0 || !json.Valid(raw) {
+		return codexOutputItem{}, errors.New("invalid Codex output item")
+	}
+	var parsed codexResponseItem
+	if err := json.Unmarshal(raw, &parsed); err != nil || parsed.Type == "" {
+		return codexOutputItem{}, errors.New("invalid Codex output item")
+	}
+	return codexOutputItem{
+		parsed: parsed,
+		raw:    append(json.RawMessage(nil), raw...),
+	}, nil
+}
+
+func backfillCodexReasoningItem(streamed, terminal codexOutputItem) (codexOutputItem, error) {
+	if streamed.parsed.EncryptedContent != "" || terminal.parsed.EncryptedContent == "" {
+		return streamed, nil
+	}
+	var streamedFields, terminalFields map[string]json.RawMessage
+	if err := json.Unmarshal(streamed.raw, &streamedFields); err != nil {
+		return codexOutputItem{}, errors.New("decode streamed Codex reasoning item")
+	}
+	if err := json.Unmarshal(terminal.raw, &terminalFields); err != nil {
+		return codexOutputItem{}, errors.New("decode terminal Codex reasoning item")
+	}
+	encryptedContent, ok := terminalFields["encrypted_content"]
+	if !ok {
+		return streamed, nil
+	}
+	streamedFields["encrypted_content"] = encryptedContent
+	raw, err := json.Marshal(streamedFields)
+	if err != nil {
+		return codexOutputItem{}, errors.New("encode Codex reasoning signature")
+	}
+	backfilled, err := parseCodexOutputItem(raw)
+	backfilled.done = true
+	return backfilled, err
+}
+
+func codexReasoningSignature(item codexOutputItem) (string, error) {
+	if item.parsed.Type != "reasoning" || item.parsed.ID == "" {
+		return "", errors.New("Codex reasoning output item is not replayable")
+	}
+	if _, err := parseCodexReasoningSignature(string(item.raw)); err != nil {
+		return "", err
+	}
+	return string(item.raw), nil
+}
+
+func codexReasoningText(item codexResponseItem) string {
+	var parts []string
+	for _, summary := range item.Summary {
+		if summary.Text != "" {
+			parts = append(parts, summary.Text)
+		}
+	}
+	if len(parts) == 0 {
+		for _, content := range item.Content {
+			if content.Text != "" {
+				parts = append(parts, content.Text)
+			}
+		}
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+func codexItemText(item codexResponseItem) string {
+	var text strings.Builder
+	for _, content := range item.Content {
+		if content.Type == "output_text" {
+			text.WriteString(content.Text)
+		} else if content.Type == "refusal" {
+			text.WriteString(content.Refusal)
+		}
+	}
+	return text.String()
+}
+
+func (r codexResult) responseModel(requestModel string) string {
+	if r.model != "" {
+		return r.model
+	}
+	return requestModel
+}
+
+func codexResponsesURL(baseURL string) string {
+	normalized := strings.TrimRight(baseURL, "/")
+	if strings.HasSuffix(normalized, "/codex/responses") {
+		return normalized
+	}
+	if strings.HasSuffix(normalized, "/codex") {
+		return normalized + "/responses"
+	}
+	return normalized + "/codex/responses"
+}
+
+func codexJWTMetadata(token string) (string, time.Time, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return "", time.Time{}, errors.New("failed to extract Codex account ID from access token")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", time.Time{}, errors.New("failed to extract Codex account ID from access token")
+	}
+	var claims struct {
+		Auth struct {
+			AccountID string `json:"chatgpt_account_id"`
+		} `json:"https://api.openai.com/auth"`
+		ExpiresAt json.Number `json:"exp"`
+	}
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.UseNumber()
+	if err := decoder.Decode(&claims); err != nil {
+		return "", time.Time{}, errors.New("failed to decode Codex access token")
+	}
+	var expiresAt time.Time
+	if claims.ExpiresAt != "" {
+		seconds, err := claims.ExpiresAt.Int64()
+		if err != nil {
+			return "", time.Time{}, errors.New("invalid Codex access token expiry")
+		}
+		expiresAt = time.Unix(seconds, 0)
+	}
+	return claims.Auth.AccountID, expiresAt, nil
+}

--- a/internal/ai/provider_codex.go
+++ b/internal/ai/provider_codex.go
@@ -334,8 +334,35 @@ func (p *CodexProvider) Models() []ModelInfo {
 }
 
 func (p *CodexProvider) HealthCheck(ctx context.Context) error {
-	_, _, err := p.credentials(ctx)
-	return err
+	token, accountID, err := p.credentials(ctx)
+	if err != nil {
+		return err
+	}
+	response, err := p.getModels(ctx, token, accountID)
+	if err != nil {
+		return err
+	}
+	if response.StatusCode == http.StatusUnauthorized || response.StatusCode == http.StatusForbidden {
+		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 64<<10))
+		_ = response.Body.Close()
+		if err := p.refreshCredentials(ctx, token, true); err != nil {
+			return fmt.Errorf("codex authentication rejected and token refresh failed: %w", err)
+		}
+		token, accountID, err = p.credentials(ctx)
+		if err != nil {
+			return err
+		}
+		response, err = p.getModels(ctx, token, accountID)
+		if err != nil {
+			return err
+		}
+	}
+	defer func() { _ = response.Body.Close() }()
+	_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 64<<10))
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return fmt.Errorf("codex models API returned status %d", response.StatusCode)
+	}
+	return nil
 }
 
 func (p *CodexProvider) complete(ctx context.Context, request codexRequest, onText func(string)) (codexResult, error) {
@@ -363,6 +390,7 @@ func (p *CodexProvider) openResponse(ctx context.Context, request codexRequest) 
 	if response.StatusCode != http.StatusUnauthorized && response.StatusCode != http.StatusForbidden {
 		return codexHTTPResponse(response)
 	}
+	_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 64<<10))
 	_ = response.Body.Close()
 
 	if err := p.refreshCredentials(ctx, token, true); err != nil {
@@ -407,6 +435,25 @@ func (p *CodexProvider) post(ctx context.Context, body []byte, codexRequest code
 	return response, nil
 }
 
+func (p *CodexProvider) getModels(ctx context.Context, token, accountID string) (*http.Response, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, codexModelsURL(p.baseURL), nil)
+	if err != nil {
+		return nil, fmt.Errorf("create Codex models request: %w", err)
+	}
+	request.Header.Set("Authorization", "Bearer "+token)
+	request.Header.Set("chatgpt-account-id", accountID)
+	request.Header.Set("originator", "pi")
+	request.Header.Set("Accept", "application/json")
+	response, err := p.client.Do(request)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		return nil, fmt.Errorf("send Codex models request: %w", err)
+	}
+	return response, nil
+}
+
 func codexHTTPResponse(response *http.Response) (*http.Response, error) {
 	if response.StatusCode >= 200 && response.StatusCode < 300 {
 		return response, nil
@@ -432,55 +479,65 @@ func (p *CodexProvider) credentials(ctx context.Context) (string, string, error)
 }
 
 func (p *CodexProvider) refreshCredentials(ctx context.Context, staleToken string, force bool) error {
-	p.mu.Lock()
-	if p.accessToken != staleToken {
-		p.mu.Unlock()
-		return nil
-	}
-	if !force && (p.expiresAt.IsZero() || time.Now().Add(30*time.Second).Before(p.expiresAt)) {
-		p.mu.Unlock()
-		return nil
-	}
-	if p.refreshing != nil {
-		done := p.refreshing
-		p.mu.Unlock()
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-done:
-		}
+	for {
 		p.mu.Lock()
-		defer p.mu.Unlock()
 		if p.accessToken != staleToken {
+			p.mu.Unlock()
 			return nil
 		}
-		return p.refreshErr
-	}
-	if p.refreshToken == "" {
-		p.mu.Unlock()
-		return errors.New("codex refresh token is unavailable")
-	}
-	done := make(chan struct{})
-	p.refreshing = done
-	refreshToken := p.refreshToken
-	p.mu.Unlock()
-
-	credentials, err := p.requestTokenRefresh(ctx, refreshToken)
-
-	p.mu.Lock()
-	if err == nil {
-		p.accessToken = credentials.accessToken
-		p.refreshToken = credentials.refreshToken
-		p.expiresAt = credentials.expiresAt
-		if !p.explicitAccountID {
-			p.accountID = credentials.accountID
+		if !force && (p.expiresAt.IsZero() || time.Now().Add(30*time.Second).Before(p.expiresAt)) {
+			p.mu.Unlock()
+			return nil
 		}
+		if p.refreshing != nil {
+			done := p.refreshing
+			p.mu.Unlock()
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-done:
+			}
+			p.mu.Lock()
+			tokenChanged := p.accessToken != staleToken
+			refreshErr := p.refreshErr
+			p.mu.Unlock()
+			if tokenChanged || refreshErr == nil {
+				return nil
+			}
+			if errors.Is(refreshErr, context.Canceled) || errors.Is(refreshErr, context.DeadlineExceeded) {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				continue
+			}
+			return refreshErr
+		}
+		if p.refreshToken == "" {
+			p.mu.Unlock()
+			return errors.New("codex refresh token is unavailable")
+		}
+		done := make(chan struct{})
+		p.refreshing = done
+		refreshToken := p.refreshToken
+		p.mu.Unlock()
+
+		credentials, err := p.requestTokenRefresh(ctx, refreshToken)
+
+		p.mu.Lock()
+		if err == nil {
+			p.accessToken = credentials.accessToken
+			p.refreshToken = credentials.refreshToken
+			p.expiresAt = credentials.expiresAt
+			if !p.explicitAccountID {
+				p.accountID = credentials.accountID
+			}
+		}
+		p.refreshErr = err
+		p.refreshing = nil
+		close(done)
+		p.mu.Unlock()
+		return err
 	}
-	p.refreshErr = err
-	p.refreshing = nil
-	close(done)
-	p.mu.Unlock()
-	return err
 }
 
 type codexCredentials struct {
@@ -520,18 +577,28 @@ func (p *CodexProvider) requestTokenRefresh(ctx context.Context, refreshToken st
 	if err := json.NewDecoder(io.LimitReader(response.Body, 1<<20)).Decode(&decoded); err != nil {
 		return codexCredentials{}, errors.New("decode Codex token refresh response")
 	}
-	if decoded.AccessToken == "" || decoded.RefreshToken == "" || decoded.ExpiresIn <= 0 {
-		return codexCredentials{}, errors.New("codex token refresh response is missing required fields")
+	if decoded.AccessToken == "" {
+		return codexCredentials{}, errors.New("codex token refresh response is missing an access token")
 	}
-	accountID, _, err := codexJWTMetadata(decoded.AccessToken)
+	if decoded.RefreshToken == "" {
+		decoded.RefreshToken = refreshToken
+	}
+	accountID, tokenExpiresAt, err := codexJWTMetadata(decoded.AccessToken)
 	if !p.explicitAccountID && (err != nil || accountID == "") {
 		return codexCredentials{}, errors.New("failed to extract Codex account ID from refreshed access token")
+	}
+	expiresAt := tokenExpiresAt
+	if decoded.ExpiresIn > 0 {
+		expiresAt = time.Now().Add(time.Duration(decoded.ExpiresIn) * time.Second)
+	}
+	if expiresAt.IsZero() {
+		return codexCredentials{}, errors.New("codex token refresh response is missing an expiry")
 	}
 	return codexCredentials{
 		accessToken:  decoded.AccessToken,
 		refreshToken: decoded.RefreshToken,
 		accountID:    accountID,
-		expiresAt:    time.Now().Add(time.Duration(decoded.ExpiresIn) * time.Second),
+		expiresAt:    expiresAt,
 	}, nil
 }
 
@@ -547,7 +614,6 @@ func buildCodexLegacyRequest(req CompletionRequest) (codexRequest, error) {
 		request.Temperature = &temperature
 	}
 	var instructions []string
-	assistantIndex := 0
 	for i, message := range req.Messages {
 		switch message.Role {
 		case "system", "developer":
@@ -566,8 +632,7 @@ func buildCodexLegacyRequest(req CompletionRequest) (codexRequest, error) {
 			if len(message.ImageURLs) > 0 {
 				return codexRequest{}, fmt.Errorf("codex assistant message at index %d cannot contain images", i)
 			}
-			request.Input = append(request.Input, codexAssistantInput(message.Content, assistantIndex))
-			assistantIndex++
+			request.Input = append(request.Input, codexAssistantInput(message.Content))
 		default:
 			return codexRequest{}, fmt.Errorf("unsupported Codex message role at index %d", i)
 		}
@@ -589,7 +654,6 @@ func buildCodexNativeRequest(model string, c llm.Context, opts *llm.StreamOption
 	if c.SystemPrompt != "" {
 		instructions = append(instructions, c.SystemPrompt)
 	}
-	assistantIndex := 0
 	for _, message := range c.Messages {
 		switch typed := message.(type) {
 		case llm.SystemMessage:
@@ -608,8 +672,7 @@ func buildCodexNativeRequest(model string, c llm.Context, opts *llm.StreamOption
 			for _, block := range typed.Content {
 				switch value := block.(type) {
 				case llm.TextContent:
-					request.Input = append(request.Input, codexAssistantInput(value.Text, assistantIndex))
-					assistantIndex++
+					request.Input = append(request.Input, codexAssistantInput(value.Text))
 				case llm.ToolCall:
 					arguments, err := json.Marshal(value.Arguments)
 					if err != nil {
@@ -745,14 +808,11 @@ func codexNativeUserContent(content []llm.UserContent) ([]any, error) {
 	return projected, nil
 }
 
-func codexAssistantInput(text string, index int) map[string]any {
+func codexAssistantInput(text string) map[string]any {
 	return map[string]any{
-		"type":   "message",
-		"id":     fmt.Sprintf("msg_pai_%d", index),
-		"role":   "assistant",
-		"status": "completed",
+		"role": "assistant",
 		"content": []any{
-			map[string]any{"type": "output_text", "text": text, "annotations": []any{}},
+			map[string]any{"type": "input_text", "text": text},
 		},
 	}
 }
@@ -824,6 +884,7 @@ func parseCodexStream(reader io.Reader, onText func(string)) (codexResult, error
 	result := codexResult{}
 	toolArguments := make(map[int]string)
 	outputItems := make(map[int]codexOutputItem)
+	messageText := make(map[int]string)
 	dispatch := func() error {
 		if len(dataLines) == 0 {
 			return nil
@@ -839,7 +900,7 @@ func parseCodexStream(reader io.Reader, onText func(string)) (codexResult, error
 		}
 		switch event.Type {
 		case "response.output_text.delta", "response.refusal.delta":
-			result.text += event.Delta
+			messageText[event.OutputIndex] += event.Delta
 			if onText != nil && event.Delta != "" {
 				onText(event.Delta)
 			}
@@ -866,12 +927,9 @@ func parseCodexStream(reader io.Reader, onText func(string)) (codexResult, error
 			switch item.parsed.Type {
 			case "message":
 				finalText := codexItemText(item.parsed)
-				if onText != nil && strings.HasPrefix(finalText, result.text) {
-					if delta := strings.TrimPrefix(finalText, result.text); delta != "" {
-						onText(delta)
-					}
+				if err := recordCodexMessageText(messageText, event.OutputIndex, finalText, onText); err != nil {
+					return err
 				}
-				result.text = finalText
 			case "function_call":
 				if item.parsed.Arguments != "" {
 					toolArguments[event.OutputIndex] = item.parsed.Arguments
@@ -882,7 +940,7 @@ func parseCodexStream(reader io.Reader, onText func(string)) (codexResult, error
 			if err := json.Unmarshal(event.Response, &terminal); err != nil {
 				return errors.New("decode Codex terminal response")
 			}
-			if err := applyCodexTerminal(&result, terminal, outputItems, toolArguments); err != nil {
+			if err := applyCodexTerminal(&result, terminal, outputItems, toolArguments, messageText, onText); err != nil {
 				return err
 			}
 		case "response.failed":
@@ -928,7 +986,14 @@ func parseCodexStream(reader io.Reader, onText func(string)) (codexResult, error
 	return result, nil
 }
 
-func applyCodexTerminal(result *codexResult, terminal codexTerminalResponse, items map[int]codexOutputItem, arguments map[int]string) error {
+func applyCodexTerminal(
+	result *codexResult,
+	terminal codexTerminalResponse,
+	items map[int]codexOutputItem,
+	arguments map[int]string,
+	messageText map[int]string,
+	onText func(string),
+) error {
 	result.id = terminal.ID
 	result.model = terminal.Model
 	result.status = terminal.Status
@@ -937,17 +1002,6 @@ func applyCodexTerminal(result *codexResult, terminal codexTerminalResponse, ite
 	result.input = max(0, terminal.Usage.InputTokens-result.cacheRead-result.cacheWrite)
 	result.output = terminal.Usage.OutputTokens
 	result.terminal = true
-	if result.text == "" {
-		for _, raw := range terminal.Output {
-			item, err := parseCodexOutputItem(raw)
-			if err != nil {
-				return errors.New("decode Codex terminal output item")
-			}
-			if item.parsed.Type == "message" {
-				result.text += codexItemText(item.parsed)
-			}
-		}
-	}
 	for i, raw := range terminal.Output {
 		terminalItem, err := parseCodexOutputItem(raw)
 		if err != nil {
@@ -960,15 +1014,28 @@ func applyCodexTerminal(result *codexResult, terminal codexTerminalResponse, ite
 			}
 		}
 		items[i] = terminalItem
+		if terminalItem.parsed.Type == "message" {
+			if err := recordCodexMessageText(messageText, i, codexItemText(terminalItem.parsed), onText); err != nil {
+				return err
+			}
+		}
 		if terminalItem.parsed.Type == "function_call" && terminalItem.parsed.Arguments != "" {
 			arguments[i] = terminalItem.parsed.Arguments
 		}
 	}
-	indexes := make([]int, 0, len(items))
+	indexSet := make(map[int]struct{}, len(items)+len(messageText))
 	for index := range items {
+		indexSet[index] = struct{}{}
+	}
+	for index := range messageText {
+		indexSet[index] = struct{}{}
+	}
+	indexes := make([]int, 0, len(indexSet))
+	for index := range indexSet {
 		indexes = append(indexes, index)
 	}
 	sort.Ints(indexes)
+	result.text = ""
 	for _, i := range indexes {
 		item := items[i]
 		switch item.parsed.Type {
@@ -983,11 +1050,19 @@ func applyCodexTerminal(result *codexResult, terminal codexTerminalResponse, ite
 			})
 			continue
 		case "message":
-			if text := codexItemText(item.parsed); text != "" {
-				result.content = append(result.content, llm.TextContent{Text: text})
+			finalText := codexItemText(item.parsed)
+			if finalText == "" {
+				finalText = messageText[i]
+			}
+			result.text += finalText
+			if finalText != "" {
+				result.content = append(result.content, llm.TextContent{Text: finalText})
 			}
 			continue
 		case "function_call":
+		case "":
+			result.text += messageText[i]
+			continue
 		default:
 			continue
 		}
@@ -1017,6 +1092,23 @@ func applyCodexTerminal(result *codexResult, terminal codexTerminalResponse, ite
 	if terminal.Status == "failed" || terminal.Status == "cancelled" {
 		return fmt.Errorf("codex response ended with status %s", terminal.Status)
 	}
+	return nil
+}
+
+func recordCodexMessageText(messageText map[int]string, index int, finalText string, onText func(string)) error {
+	streamedText := messageText[index]
+	if finalText == "" {
+		return nil
+	}
+	if !strings.HasPrefix(finalText, streamedText) {
+		return fmt.Errorf("codex message output %d does not match streamed text", index)
+	}
+	if onText != nil {
+		if delta := strings.TrimPrefix(finalText, streamedText); delta != "" {
+			onText(delta)
+		}
+	}
+	messageText[index] = finalText
 	return nil
 }
 
@@ -1062,6 +1154,9 @@ func backfillCodexReasoningItem(streamed, terminal codexOutputItem) (codexOutput
 func codexReasoningSignature(item codexOutputItem) (string, error) {
 	if item.parsed.Type != "reasoning" || item.parsed.ID == "" {
 		return "", errors.New("codex reasoning output item is not replayable")
+	}
+	if item.parsed.EncryptedContent == "" {
+		return "", nil
 	}
 	if _, err := parseCodexReasoningSignature(string(item.raw)); err != nil {
 		return "", err
@@ -1115,6 +1210,15 @@ func codexResponsesURL(baseURL string) string {
 		return normalized + "/responses"
 	}
 	return normalized + "/codex/responses"
+}
+
+func codexModelsURL(baseURL string) string {
+	normalized := strings.TrimRight(baseURL, "/")
+	normalized = strings.TrimSuffix(normalized, "/responses")
+	if strings.HasSuffix(normalized, "/codex") {
+		return normalized + "/models"
+	}
+	return normalized + "/codex/models"
 }
 
 func codexJWTMetadata(token string) (string, time.Time, error) {

--- a/internal/ai/provider_codex.go
+++ b/internal/ai/provider_codex.go
@@ -80,7 +80,7 @@ func WithCodexAuthBaseURL(baseURL string) CodexOption {
 func NewCodexProvider(accessToken string, opts ...CodexOption) (*CodexProvider, error) {
 	accessToken = strings.TrimSpace(accessToken)
 	if accessToken == "" {
-		return nil, errors.New("Codex access token is required")
+		return nil, errors.New("codex access token is required")
 	}
 	p := &CodexProvider{
 		accessToken: accessToken,
@@ -92,13 +92,13 @@ func NewCodexProvider(accessToken string, opts ...CodexOption) (*CodexProvider, 
 		opt(p)
 	}
 	if p.client == nil {
-		return nil, errors.New("Codex HTTP client is required")
+		return nil, errors.New("codex HTTP client is required")
 	}
 	if p.baseURL == "" {
-		return nil, errors.New("Codex base URL is required")
+		return nil, errors.New("codex base URL is required")
 	}
 	if p.authBaseURL == "" {
-		return nil, errors.New("Codex auth base URL is required")
+		return nil, errors.New("codex auth base URL is required")
 	}
 
 	accountID, expiresAt, err := codexJWTMetadata(accessToken)
@@ -366,7 +366,7 @@ func (p *CodexProvider) openResponse(ctx context.Context, request codexRequest) 
 	_ = response.Body.Close()
 
 	if err := p.refreshCredentials(ctx, token, true); err != nil {
-		return nil, fmt.Errorf("Codex authentication rejected and token refresh failed: %w", err)
+		return nil, fmt.Errorf("codex authentication rejected and token refresh failed: %w", err)
 	}
 	token, accountID, err = p.credentials(ctx)
 	if err != nil {
@@ -413,7 +413,7 @@ func codexHTTPResponse(response *http.Response) (*http.Response, error) {
 	}
 	defer func() { _ = response.Body.Close() }()
 	_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 64<<10))
-	return nil, fmt.Errorf("Codex API returned status %d", response.StatusCode)
+	return nil, fmt.Errorf("codex API returned status %d", response.StatusCode)
 }
 
 func (p *CodexProvider) credentials(ctx context.Context) (string, string, error) {
@@ -458,7 +458,7 @@ func (p *CodexProvider) refreshCredentials(ctx context.Context, staleToken strin
 	}
 	if p.refreshToken == "" {
 		p.mu.Unlock()
-		return errors.New("Codex refresh token is unavailable")
+		return errors.New("codex refresh token is unavailable")
 	}
 	done := make(chan struct{})
 	p.refreshing = done
@@ -510,7 +510,7 @@ func (p *CodexProvider) requestTokenRefresh(ctx context.Context, refreshToken st
 	}
 	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		return codexCredentials{}, fmt.Errorf("Codex token refresh returned status %d", response.StatusCode)
+		return codexCredentials{}, fmt.Errorf("codex token refresh returned status %d", response.StatusCode)
 	}
 	var decoded struct {
 		AccessToken  string `json:"access_token"`
@@ -521,7 +521,7 @@ func (p *CodexProvider) requestTokenRefresh(ctx context.Context, refreshToken st
 		return codexCredentials{}, errors.New("decode Codex token refresh response")
 	}
 	if decoded.AccessToken == "" || decoded.RefreshToken == "" || decoded.ExpiresIn <= 0 {
-		return codexCredentials{}, errors.New("Codex token refresh response is missing required fields")
+		return codexCredentials{}, errors.New("codex token refresh response is missing required fields")
 	}
 	accountID, _, err := codexJWTMetadata(decoded.AccessToken)
 	if !p.explicitAccountID && (err != nil || accountID == "") {
@@ -552,7 +552,7 @@ func buildCodexLegacyRequest(req CompletionRequest) (codexRequest, error) {
 		switch message.Role {
 		case "system", "developer":
 			if len(message.ImageURLs) > 0 {
-				return codexRequest{}, fmt.Errorf("Codex system message at index %d cannot contain images", i)
+				return codexRequest{}, fmt.Errorf("codex system message at index %d cannot contain images", i)
 			}
 			if message.Content != "" {
 				instructions = append(instructions, message.Content)
@@ -564,7 +564,7 @@ func buildCodexLegacyRequest(req CompletionRequest) (codexRequest, error) {
 			}
 		case "assistant":
 			if len(message.ImageURLs) > 0 {
-				return codexRequest{}, fmt.Errorf("Codex assistant message at index %d cannot contain images", i)
+				return codexRequest{}, fmt.Errorf("codex assistant message at index %d cannot contain images", i)
 			}
 			request.Input = append(request.Input, codexAssistantInput(message.Content, assistantIndex))
 			assistantIndex++
@@ -613,7 +613,7 @@ func buildCodexNativeRequest(model string, c llm.Context, opts *llm.StreamOption
 				case llm.ToolCall:
 					arguments, err := json.Marshal(value.Arguments)
 					if err != nil {
-						return codexRequest{}, fmt.Errorf("Codex tool call %q arguments: %w", value.Name, err)
+						return codexRequest{}, fmt.Errorf("codex tool call %q arguments: %w", value.Name, err)
 					}
 					if value.Arguments == nil {
 						arguments = []byte("{}")
@@ -731,7 +731,7 @@ func codexNativeUserContent(content []llm.UserContent) ([]any, error) {
 			projected = append(projected, map[string]any{"type": "input_image", "image_url": value.URL, "detail": "auto"})
 		case llm.ImageContent:
 			if _, err := base64.StdEncoding.DecodeString(value.Data); err != nil {
-				return nil, errors.New("Codex user message contains invalid image data")
+				return nil, errors.New("codex user message contains invalid image data")
 			}
 			projected = append(projected, map[string]any{
 				"type":      "input_image",
@@ -759,19 +759,19 @@ func codexAssistantInput(text string, index int) map[string]any {
 
 func parseCodexReasoningSignature(signature string) (json.RawMessage, error) {
 	if !json.Valid([]byte(signature)) {
-		return nil, errors.New("Codex reasoning signature is invalid JSON")
+		return nil, errors.New("codex reasoning signature is invalid JSON")
 	}
 	var item map[string]json.RawMessage
 	if err := json.Unmarshal([]byte(signature), &item); err != nil || item == nil {
-		return nil, errors.New("Codex reasoning signature must be a JSON object")
+		return nil, errors.New("codex reasoning signature must be a JSON object")
 	}
 	var itemType string
 	if err := json.Unmarshal(item["type"], &itemType); err != nil || itemType != "reasoning" {
-		return nil, errors.New("Codex reasoning signature must contain a reasoning output item")
+		return nil, errors.New("codex reasoning signature must contain a reasoning output item")
 	}
 	var id string
 	if err := json.Unmarshal(item["id"], &id); err != nil || id == "" {
-		return nil, errors.New("Codex reasoning signature must contain an item ID")
+		return nil, errors.New("codex reasoning signature must contain an item ID")
 	}
 	return append(json.RawMessage(nil), signature...), nil
 }
@@ -781,7 +781,7 @@ func buildCodexTools(tools []llm.Tool) ([]codexTool, error) {
 	for i, tool := range tools {
 		var parameters map[string]any
 		if err := json.Unmarshal(tool.Parameters, &parameters); err != nil || parameters == nil {
-			return nil, fmt.Errorf("Codex tool %q parameters must be a JSON object", tool.Name)
+			return nil, fmt.Errorf("codex tool %q parameters must be a JSON object", tool.Name)
 		}
 		projected[i] = codexTool{
 			Type:        "function",
@@ -863,7 +863,8 @@ func parseCodexStream(reader io.Reader, onText func(string)) (codexResult, error
 			}
 			item.done = true
 			outputItems[event.OutputIndex] = item
-			if item.parsed.Type == "message" {
+			switch item.parsed.Type {
+			case "message":
 				finalText := codexItemText(item.parsed)
 				if onText != nil && strings.HasPrefix(finalText, result.text) {
 					if delta := strings.TrimPrefix(finalText, result.text); delta != "" {
@@ -871,7 +872,7 @@ func parseCodexStream(reader io.Reader, onText func(string)) (codexResult, error
 					}
 				}
 				result.text = finalText
-			} else if item.parsed.Type == "function_call" {
+			case "function_call":
 				if item.parsed.Arguments != "" {
 					toolArguments[event.OutputIndex] = item.parsed.Arguments
 				}
@@ -888,18 +889,18 @@ func parseCodexStream(reader io.Reader, onText func(string)) (codexResult, error
 			var terminal codexTerminalResponse
 			_ = json.Unmarshal(event.Response, &terminal)
 			if terminal.Error != nil && terminal.Error.Code != "" {
-				return fmt.Errorf("Codex response failed (%s)", terminal.Error.Code)
+				return fmt.Errorf("codex response failed (%s)", terminal.Error.Code)
 			}
-			return errors.New("Codex response failed")
+			return errors.New("codex response failed")
 		case "error":
 			code := event.Code
 			if code == "" && event.Error != nil {
 				code = event.Error.Code
 			}
 			if code != "" {
-				return fmt.Errorf("Codex stream error (%s)", code)
+				return fmt.Errorf("codex stream error (%s)", code)
 			}
-			return errors.New("Codex stream error")
+			return errors.New("codex stream error")
 		}
 		return nil
 	}
@@ -922,7 +923,7 @@ func parseCodexStream(reader io.Reader, onText func(string)) (codexResult, error
 		return codexResult{}, err
 	}
 	if !result.terminal {
-		return codexResult{}, errors.New("Codex SSE stream ended before a terminal response")
+		return codexResult{}, errors.New("codex SSE stream ended before a terminal response")
 	}
 	return result, nil
 }
@@ -996,7 +997,7 @@ func applyCodexTerminal(result *codexResult, terminal codexTerminalResponse, ite
 			encoded = "{}"
 		}
 		if err := json.Unmarshal([]byte(encoded), &decoded); err != nil || decoded == nil {
-			return fmt.Errorf("Codex tool call %q returned invalid arguments", item.parsed.Name)
+			return fmt.Errorf("codex tool call %q returned invalid arguments", item.parsed.Name)
 		}
 		callID := item.parsed.CallID
 		if callID == "" {
@@ -1014,7 +1015,7 @@ func applyCodexTerminal(result *codexResult, terminal codexTerminalResponse, ite
 		result.content = append(result.content, call)
 	}
 	if terminal.Status == "failed" || terminal.Status == "cancelled" {
-		return fmt.Errorf("Codex response ended with status %s", terminal.Status)
+		return fmt.Errorf("codex response ended with status %s", terminal.Status)
 	}
 	return nil
 }
@@ -1060,7 +1061,7 @@ func backfillCodexReasoningItem(streamed, terminal codexOutputItem) (codexOutput
 
 func codexReasoningSignature(item codexOutputItem) (string, error) {
 	if item.parsed.Type != "reasoning" || item.parsed.ID == "" {
-		return "", errors.New("Codex reasoning output item is not replayable")
+		return "", errors.New("codex reasoning output item is not replayable")
 	}
 	if _, err := parseCodexReasoningSignature(string(item.raw)); err != nil {
 		return "", err
@@ -1088,9 +1089,10 @@ func codexReasoningText(item codexResponseItem) string {
 func codexItemText(item codexResponseItem) string {
 	var text strings.Builder
 	for _, content := range item.Content {
-		if content.Type == "output_text" {
+		switch content.Type {
+		case "output_text":
 			text.WriteString(content.Text)
-		} else if content.Type == "refusal" {
+		case "refusal":
 			text.WriteString(content.Refusal)
 		}
 	}

--- a/internal/ai/provider_codex_test.go
+++ b/internal/ai/provider_codex_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -92,6 +93,84 @@ func TestCodexProviderCompleteUsesCodexResponsesProtocol(t *testing.T) {
 		content[1].(map[string]any)["type"] != "input_image" ||
 		content[1].(map[string]any)["image_url"] != "https://example.test/diagram.png" {
 		t.Fatalf("multimodal content = %#v", content)
+	}
+}
+
+func TestCodexProviderProjectsAssistantHistoryAsInputMessage(t *testing.T) {
+	var captured map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeCodexSSE(w, `{"type":"response.completed","response":{"id":"resp","status":"completed"}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	provider, err := NewCodexProvider("opaque", WithCodexAccountID("account-123"), WithCodexBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("NewCodexProvider() error = %v", err)
+	}
+	_, err = provider.Complete(context.Background(), CompletionRequest{Messages: []Message{
+		{Role: "user", Content: "First"},
+		{Role: "assistant", Content: "Prior answer"},
+		{Role: "user", Content: "Follow up"},
+	}})
+	if err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+
+	input := captured["input"].([]any)
+	assistant := input[1].(map[string]any)
+	if assistant["role"] != "assistant" || assistant["type"] != nil || assistant["id"] != nil || assistant["status"] != nil {
+		t.Fatalf("assistant input = %#v", assistant)
+	}
+	content := assistant["content"].([]any)
+	if len(content) != 1 ||
+		content[0].(map[string]any)["type"] != "input_text" ||
+		content[0].(map[string]any)["text"] != "Prior answer" {
+		t.Fatalf("assistant content = %#v", content)
+	}
+}
+
+func TestCodexProviderHealthCheckValidatesCredentialsWithModelsEndpoint(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		statusCode int
+		wantErr    bool
+	}{
+		{name: "accepted", statusCode: http.StatusOK},
+		{name: "rejected", statusCode: http.StatusUnauthorized, wantErr: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/backend-api/codex/models" {
+					t.Errorf("path = %q", r.URL.Path)
+				}
+				if r.Method != http.MethodGet {
+					t.Errorf("method = %q", r.Method)
+				}
+				if r.Header.Get("Authorization") != "Bearer access-token" ||
+					r.Header.Get("chatgpt-account-id") != "account-123" ||
+					r.Header.Get("originator") != "pi" {
+					t.Errorf("headers = %#v", r.Header)
+				}
+				w.WriteHeader(test.statusCode)
+				_, _ = w.Write([]byte(`{"models":[]}`))
+			}))
+			t.Cleanup(server.Close)
+			provider, err := NewCodexProvider(
+				"access-token",
+				WithCodexAccountID("account-123"),
+				WithCodexBaseURL(server.URL+"/backend-api"),
+			)
+			if err != nil {
+				t.Fatalf("NewCodexProvider() error = %v", err)
+			}
+			err = provider.HealthCheck(context.Background())
+			if (err != nil) != test.wantErr {
+				t.Fatalf("HealthCheck() error = %v, wantErr %v", err, test.wantErr)
+			}
+		})
 	}
 }
 
@@ -232,6 +311,72 @@ func TestCodexProviderCompleteNativePreservesToolContinuation(t *testing.T) {
 	}
 }
 
+func TestCodexProviderOmitsUnencryptedReasoningFromContinuation(t *testing.T) {
+	var mu sync.Mutex
+	var requests []map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		mu.Lock()
+		requests = append(requests, request)
+		requestNumber := len(requests)
+		mu.Unlock()
+		if requestNumber == 1 {
+			writeCodexSSE(w,
+				`{"type":"response.output_item.done","output_index":0,"item":{"type":"reasoning","id":"rs-no-encryption","summary":[{"type":"summary_text","text":"Need a tool."}]}}`,
+				`{"type":"response.output_item.done","output_index":1,"item":{"type":"function_call","id":"fc-1","call_id":"call-1","name":"lookup","arguments":"{}"}}`,
+				`{"type":"response.completed","response":{"id":"resp-tool","status":"completed"}}`,
+			)
+			return
+		}
+		writeCodexSSE(w,
+			`{"type":"response.output_item.done","output_index":0,"item":{"type":"message","id":"msg-1","content":[{"type":"output_text","text":"Done."}]}}`,
+			`{"type":"response.completed","response":{"id":"resp-final","status":"completed"}}`,
+		)
+	}))
+	t.Cleanup(server.Close)
+
+	provider, err := NewCodexProvider("opaque", WithCodexAccountID("account-123"), WithCodexBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("NewCodexProvider() error = %v", err)
+	}
+	tool := llm.Tool{Name: "lookup", Parameters: json.RawMessage(`{"type":"object","additionalProperties":false}`)}
+	first, err := provider.CompleteNative(context.Background(), "gpt-codex-test", llm.Context{
+		Messages: []llm.Message{llm.UserMessage{Content: []llm.UserContent{llm.TextContent{Text: "Look up"}}}},
+		Tools:    []llm.Tool{tool},
+	}, nil)
+	if err != nil {
+		t.Fatalf("first CompleteNative() error = %v", err)
+	}
+	thinking, ok := first.Content[0].(llm.ThinkingContent)
+	if !ok || thinking.Thinking != "Need a tool." || thinking.Signature != "" {
+		t.Fatalf("thinking = %#v", first.Content[0])
+	}
+	call := requireContractToolCall(t, first)
+	_, err = provider.CompleteNative(context.Background(), "gpt-codex-test", llm.Context{
+		Messages: []llm.Message{
+			llm.UserMessage{Content: []llm.UserContent{llm.TextContent{Text: "Look up"}}},
+			first,
+			llm.ToolResultMessage{ToolCallID: call.ID, ToolName: call.Name, Content: []llm.UserContent{llm.TextContent{Text: "Result"}}},
+		},
+		Tools: []llm.Tool{tool},
+	}, nil)
+	if err != nil {
+		t.Fatalf("continuation CompleteNative() error = %v", err)
+	}
+
+	mu.Lock()
+	continuation := requests[1]["input"].([]any)
+	mu.Unlock()
+	for _, raw := range continuation {
+		if raw.(map[string]any)["type"] == "reasoning" {
+			t.Fatalf("continuation replays unencrypted reasoning: %#v", continuation)
+		}
+	}
+}
+
 func TestCodexProviderRejectsMalformedReasoningSignatures(t *testing.T) {
 	var requests atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -265,6 +410,102 @@ func TestCodexProviderRejectsMalformedReasoningSignatures(t *testing.T) {
 	}
 	if requests.Load() != 0 {
 		t.Fatalf("HTTP requests = %d, want 0", requests.Load())
+	}
+}
+
+func TestCodexProviderRefreshWaiterRecoversFromLeaderCancellation(t *testing.T) {
+	expired := codexTestJWT(t, "account-old", time.Now().Add(-time.Hour))
+	refreshed := codexTestJWT(t, "account-new", time.Now().Add(time.Hour))
+	firstRefreshStarted := make(chan struct{})
+	releaseFirstRefresh := make(chan struct{})
+	var refreshes atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth/token":
+			if refreshes.Add(1) == 1 {
+				close(firstRefreshStarted)
+				select {
+				case <-r.Context().Done():
+				case <-releaseFirstRefresh:
+				}
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token":  refreshed,
+				"refresh_token": "refresh-new",
+				"expires_in":    3600,
+			})
+		case "/codex/responses":
+			assertCodexHeaders(t, r, refreshed, "account-new")
+			writeCodexSSE(w, `{"type":"response.completed","response":{"id":"resp","status":"completed"}}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	provider, err := NewCodexProvider(
+		expired,
+		WithCodexRefreshToken("refresh-old"),
+		WithCodexBaseURL(server.URL),
+		WithCodexAuthBaseURL(server.URL),
+	)
+	if err != nil {
+		t.Fatalf("NewCodexProvider() error = %v", err)
+	}
+	leaderCtx, cancelLeader := context.WithCancel(context.Background())
+	leaderErr := make(chan error, 1)
+	go func() {
+		_, err := provider.Complete(leaderCtx, CompletionRequest{Messages: []Message{{Role: "user", Content: "Hi"}}})
+		leaderErr <- err
+	}()
+	<-firstRefreshStarted
+	waiterErr := make(chan error, 1)
+	go func() {
+		_, err := provider.Complete(context.Background(), CompletionRequest{Messages: []Message{{Role: "user", Content: "Hi"}}})
+		waiterErr <- err
+	}()
+	time.Sleep(20 * time.Millisecond)
+	cancelLeader()
+	close(releaseFirstRefresh)
+
+	if err := <-leaderErr; !errors.Is(err, context.Canceled) {
+		t.Fatalf("leader error = %v, want context canceled", err)
+	}
+	if err := <-waiterErr; err != nil {
+		t.Fatalf("waiter Complete() error = %v", err)
+	}
+	if refreshes.Load() != 2 {
+		t.Fatalf("refreshes = %d, want 2", refreshes.Load())
+	}
+}
+
+func TestCodexProviderRefreshRetainsUnrotatedTokenAndUsesJWTExpiry(t *testing.T) {
+	refreshed := codexTestJWT(t, "account-new", time.Now().Add(time.Hour))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/oauth/token" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"access_token": refreshed})
+	}))
+	t.Cleanup(server.Close)
+
+	provider, err := NewCodexProvider(
+		codexTestJWT(t, "account-old", time.Now().Add(-time.Hour)),
+		WithCodexRefreshToken("refresh-old"),
+		WithCodexAuthBaseURL(server.URL),
+	)
+	if err != nil {
+		t.Fatalf("NewCodexProvider() error = %v", err)
+	}
+	credentials, err := provider.requestTokenRefresh(context.Background(), "refresh-old")
+	if err != nil {
+		t.Fatalf("requestTokenRefresh() error = %v", err)
+	}
+	if credentials.accessToken != refreshed || credentials.refreshToken != "refresh-old" ||
+		credentials.expiresAt.Before(time.Now().Add(50*time.Minute)) {
+		t.Fatalf("credentials = %#v", credentials)
 	}
 }
 
@@ -403,6 +644,46 @@ func TestCodexProviderStreamCompleteEmitsSSEDeltas(t *testing.T) {
 	}
 	if text.String() != "Hello world" || !done {
 		t.Fatalf("text = %q, done = %v", text.String(), done)
+	}
+}
+
+func TestCodexProviderPreservesMultipleMessageOutputItems(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeCodexSSE(w,
+			`{"type":"response.output_text.delta","output_index":0,"delta":"Al"}`,
+			`{"type":"response.output_item.done","output_index":0,"item":{"type":"message","id":"msg-1","content":[{"type":"output_text","text":"Alpha"}]}}`,
+			`{"type":"response.output_text.delta","output_index":1,"delta":"Be"}`,
+			`{"type":"response.output_item.done","output_index":1,"item":{"type":"message","id":"msg-2","content":[{"type":"output_text","text":"Beta"}]}}`,
+			`{"type":"response.completed","response":{"id":"resp","status":"completed"}}`,
+		)
+	}))
+	t.Cleanup(server.Close)
+	provider, err := NewCodexProvider("opaque", WithCodexAccountID("account-123"), WithCodexBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("NewCodexProvider() error = %v", err)
+	}
+
+	response, err := provider.Complete(context.Background(), CompletionRequest{Messages: []Message{{Role: "user", Content: "Hi"}}})
+	if err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	if response.Content != "AlphaBeta" {
+		t.Fatalf("Complete() content = %q", response.Content)
+	}
+
+	chunks, err := provider.StreamComplete(context.Background(), CompletionRequest{Messages: []Message{{Role: "user", Content: "Hi"}}})
+	if err != nil {
+		t.Fatalf("StreamComplete() error = %v", err)
+	}
+	var text strings.Builder
+	for chunk := range chunks {
+		if chunk.Error != nil {
+			t.Fatalf("stream error = %v", chunk.Error)
+		}
+		text.WriteString(chunk.Content)
+	}
+	if text.String() != "AlphaBeta" {
+		t.Fatalf("stream content = %q", text.String())
 	}
 }
 

--- a/internal/ai/provider_codex_test.go
+++ b/internal/ai/provider_codex_test.go
@@ -1,0 +1,441 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ai
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/p-n-ai/pai-bot/internal/llm"
+)
+
+func TestCodexProviderCompleteUsesCodexResponsesProtocol(t *testing.T) {
+	var captured map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/codex/responses" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		assertCodexHeaders(t, r, "access-token", "account-123")
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeCodexSSE(w,
+			`{"type":"response.output_item.added","output_index":0,"item":{"type":"message","id":"msg-1","content":[]}}`,
+			`{"type":"response.output_text.delta","output_index":0,"delta":"{\"answer\":"}`,
+			`{"type":"response.output_text.delta","output_index":0,"delta":"\"Use the diagram.\"}"}`,
+			`{"type":"response.output_item.done","output_index":0,"item":{"type":"message","id":"msg-1","content":[{"type":"output_text","text":"{\"answer\":\"Use the diagram.\"}"}]}}`,
+			`{"type":"response.completed","response":{"id":"resp-1","model":"gpt-codex-test","status":"completed","usage":{"input_tokens":12,"output_tokens":4,"total_tokens":16,"input_tokens_details":{"cached_tokens":3}}}}`,
+		)
+	}))
+	t.Cleanup(server.Close)
+
+	provider, err := NewCodexProvider(
+		"access-token",
+		WithCodexAccountID("account-123"),
+		WithCodexBaseURL(server.URL),
+		WithCodexHTTPClient(server.Client()),
+	)
+	if err != nil {
+		t.Fatalf("NewCodexProvider() error = %v", err)
+	}
+	response, err := provider.Complete(context.Background(), CompletionRequest{
+		Model: "gpt-codex-test",
+		Messages: []Message{
+			{Role: "system", Content: "Tutor policy"},
+			{Role: "user", Content: "Explain this", ImageURLs: []string{"https://example.test/diagram.png"}},
+		},
+		MaxTokens:   64,
+		Temperature: 0.25,
+		StructuredOutput: &StructuredOutputSpec{
+			Name:       "tutor_response",
+			JSONSchema: json.RawMessage(`{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"],"additionalProperties":false}`),
+			Strict:     true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	if response.Content != `{"answer":"Use the diagram."}` || string(response.StructuredOutput) != response.Content {
+		t.Fatalf("response = %#v", response)
+	}
+	if response.Model != "gpt-codex-test" || response.InputTokens != 12 || response.OutputTokens != 4 {
+		t.Fatalf("response metadata = %#v", response)
+	}
+
+	if captured["store"] != false || captured["stream"] != true || captured["instructions"] != "Tutor policy" {
+		t.Fatalf("request flags = %#v", captured)
+	}
+	if captured["max_output_tokens"] != float64(64) || captured["temperature"] != 0.25 {
+		t.Fatalf("request generation options = %#v", captured)
+	}
+	text := captured["text"].(map[string]any)
+	format := text["format"].(map[string]any)
+	if text["verbosity"] != "low" || format["type"] != "json_schema" || format["name"] != "tutor_response" || format["strict"] != true {
+		t.Fatalf("text options = %#v", text)
+	}
+	input := captured["input"].([]any)
+	if len(input) != 1 {
+		t.Fatalf("input = %#v", input)
+	}
+	content := input[0].(map[string]any)["content"].([]any)
+	if content[0].(map[string]any)["type"] != "input_text" ||
+		content[1].(map[string]any)["type"] != "input_image" ||
+		content[1].(map[string]any)["image_url"] != "https://example.test/diagram.png" {
+		t.Fatalf("multimodal content = %#v", content)
+	}
+}
+
+func TestCodexProviderCompleteNativePreservesToolContinuation(t *testing.T) {
+	var mu sync.Mutex
+	var requests []map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		mu.Lock()
+		requests = append(requests, request)
+		requestNumber := len(requests)
+		mu.Unlock()
+		if requestNumber == 1 {
+			writeCodexSSE(w,
+				`{"type":"response.output_item.done","output_index":0,"item":{"type":"reasoning","id":"rs-1","status":"completed","summary":[{"type":"summary_text","text":"I should create the focused page."}]}}`,
+				`{"type":"response.output_item.added","output_index":1,"item":{"type":"function_call","id":"fc-1","call_id":"call-page-1","name":"create_focused_page","arguments":""}}`,
+				`{"type":"response.function_call_arguments.delta","output_index":1,"delta":"{\"message\":\"Steady progress.\"}"}`,
+				`{"type":"response.output_item.done","output_index":1,"item":{"type":"function_call","id":"fc-1","call_id":"call-page-1","name":"create_focused_page","arguments":"{\"message\":\"Steady progress.\"}"}}`,
+				`{"type":"response.completed","response":{"id":"resp-tool","model":"gpt-codex-test","status":"completed","output":[{"type":"reasoning","id":"rs-1","encrypted_content":"encrypted-reasoning"},{"type":"function_call","id":"fc-1","call_id":"call-page-1","name":"create_focused_page","arguments":"{\"message\":\"Steady progress.\"}"}],"usage":{"input_tokens":15,"output_tokens":5,"total_tokens":20,"input_tokens_details":{"cached_tokens":4,"cache_write_tokens":2}}}}`,
+			)
+			return
+		}
+		writeCodexSSE(w,
+			`{"type":"response.output_item.done","output_index":0,"item":{"type":"message","id":"msg-final","content":[{"type":"output_text","text":"Page ready."}]}}`,
+			`{"type":"response.completed","response":{"id":"resp-final","model":"gpt-codex-test","status":"completed","usage":{"input_tokens":20,"output_tokens":3}}}`,
+		)
+	}))
+	t.Cleanup(server.Close)
+
+	provider, err := NewCodexProvider("opaque-token", WithCodexAccountID("account-123"), WithCodexBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("NewCodexProvider() error = %v", err)
+	}
+	tool := llm.Tool{
+		Name:        "create_focused_page",
+		Description: "Create one focused page.",
+		Parameters:  json.RawMessage(`{"type":"object","properties":{"message":{"type":"string"}},"required":["message"],"additionalProperties":false}`),
+	}
+	initial := llm.Context{
+		SystemPrompt: "Tutor policy",
+		Messages: []llm.Message{llm.UserMessage{Content: []llm.UserContent{
+			llm.TextContent{Text: "Show progress"},
+			llm.ImageContent{MimeType: "image/png", Data: "AAEC"},
+		}}},
+		Tools: []llm.Tool{tool},
+	}
+	first, err := provider.CompleteNative(context.Background(), "gpt-codex-test", initial, &llm.StreamOptions{MaxTokens: 128})
+	if err != nil {
+		t.Fatalf("first CompleteNative() error = %v", err)
+	}
+	call := requireContractToolCall(t, first)
+	if call.ID != "call-page-1|fc-1" || call.Name != tool.Name || call.Arguments["message"] != "Steady progress." {
+		t.Fatalf("tool call = %#v", call)
+	}
+	if len(first.Content) != 2 {
+		t.Fatalf("first content = %#v", first.Content)
+	}
+	thinking, ok := first.Content[0].(llm.ThinkingContent)
+	if !ok || thinking.Thinking != "I should create the focused page." {
+		t.Fatalf("thinking = %#v", first.Content[0])
+	}
+	var reasoningSignature map[string]any
+	if err := json.Unmarshal([]byte(thinking.Signature), &reasoningSignature); err != nil {
+		t.Fatalf("decode reasoning signature: %v", err)
+	}
+	if reasoningSignature["type"] != "reasoning" || reasoningSignature["id"] != "rs-1" ||
+		reasoningSignature["encrypted_content"] != "encrypted-reasoning" ||
+		reasoningSignature["status"] != "completed" {
+		t.Fatalf("reasoning signature = %#v", reasoningSignature)
+	}
+	if first.StopReason != llm.StopReasonToolUse ||
+		first.Usage.Input != 9 ||
+		first.Usage.CacheRead != 4 ||
+		first.Usage.CacheWrite != 2 ||
+		first.Usage.Output != 5 ||
+		first.Usage.TotalTokens != 20 {
+		t.Fatalf("first metadata = %#v", first)
+	}
+
+	continuation := llm.Context{
+		SystemPrompt: initial.SystemPrompt,
+		Messages: append(append([]llm.Message(nil), initial.Messages...),
+			first,
+			llm.ToolResultMessage{
+				ToolCallID: call.ID,
+				ToolName:   call.Name,
+				Content:    []llm.UserContent{llm.TextContent{Text: "Created."}},
+			},
+		),
+		Tools: []llm.Tool{tool},
+	}
+	final, err := provider.CompleteNative(context.Background(), "gpt-codex-test", continuation, nil)
+	if err != nil {
+		t.Fatalf("continuation CompleteNative() error = %v", err)
+	}
+	if contractAssistantText(final) != "Page ready." {
+		t.Fatalf("final = %#v", final)
+	}
+
+	mu.Lock()
+	captured := append([]map[string]any(nil), requests...)
+	mu.Unlock()
+	tools := captured[0]["tools"].([]any)
+	if tools[0].(map[string]any)["name"] != tool.Name || tools[0].(map[string]any)["strict"] != nil {
+		t.Fatalf("tools = %#v", tools)
+	}
+	userContent := captured[0]["input"].([]any)[0].(map[string]any)["content"].([]any)
+	if userContent[1].(map[string]any)["image_url"] != "data:image/png;base64,AAEC" {
+		t.Fatalf("image = %#v", userContent[1])
+	}
+	input := captured[1]["input"].([]any)
+	var reasoning, functionCall, functionOutput map[string]any
+	var reasoningIndex, functionCallIndex int
+	for index, raw := range input {
+		item := raw.(map[string]any)
+		switch item["type"] {
+		case "reasoning":
+			reasoning = item
+			reasoningIndex = index
+		case "function_call":
+			functionCall = item
+			functionCallIndex = index
+		case "function_call_output":
+			functionOutput = item
+		}
+	}
+	if reasoning["id"] != "rs-1" || reasoning["encrypted_content"] != "encrypted-reasoning" || reasoningIndex >= functionCallIndex {
+		t.Fatalf("reasoning replay = %#v at %d; function call at %d", reasoning, reasoningIndex, functionCallIndex)
+	}
+	if functionCall["call_id"] != "call-page-1" || functionCall["id"] != "fc-1" || functionCall["name"] != tool.Name {
+		t.Fatalf("function call replay = %#v", functionCall)
+	}
+	if functionOutput["call_id"] != "call-page-1" || functionOutput["output"] != "Created." {
+		t.Fatalf("function output replay = %#v", functionOutput)
+	}
+}
+
+func TestCodexProviderRejectsMalformedReasoningSignatures(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+	provider, err := NewCodexProvider("opaque-token", WithCodexAccountID("account-123"), WithCodexBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("NewCodexProvider() error = %v", err)
+	}
+
+	for name, signature := range map[string]string{
+		"invalid JSON":    "{not-json",
+		"wrong item type": `{"type":"message","id":"msg-1"}`,
+		"missing item ID": `{"type":"reasoning"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := provider.CompleteNative(context.Background(), "gpt-codex-test", llm.Context{
+				Messages: []llm.Message{llm.AssistantMessage{
+					Content: []llm.AssistantContent{llm.ThinkingContent{
+						Thinking:  "prior reasoning",
+						Signature: signature,
+					}},
+				}},
+			}, nil)
+			if err == nil {
+				t.Fatal("CompleteNative() should reject malformed reasoning signature")
+			}
+		})
+	}
+	if requests.Load() != 0 {
+		t.Fatalf("HTTP requests = %d, want 0", requests.Load())
+	}
+}
+
+func TestCodexProviderRefreshesExpiredTokenOnceConcurrently(t *testing.T) {
+	expired := codexTestJWT(t, "account-old", time.Now().Add(-time.Hour))
+	refreshed := codexTestJWT(t, "account-new", time.Now().Add(time.Hour))
+	var refreshes atomic.Int32
+	var completions atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth/token":
+			refreshes.Add(1)
+			if err := r.ParseForm(); err != nil {
+				t.Errorf("parse refresh form: %v", err)
+			}
+			if r.Form.Get("grant_type") != "refresh_token" || r.Form.Get("refresh_token") != "refresh-old" || r.Form.Get("client_id") != codexOAuthClientID {
+				t.Errorf("refresh form = %v", r.Form)
+			}
+			time.Sleep(30 * time.Millisecond)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token":  refreshed,
+				"refresh_token": "refresh-new",
+				"expires_in":    3600,
+			})
+		case "/codex/responses":
+			completions.Add(1)
+			assertCodexHeaders(t, r, refreshed, "account-new")
+			writeCodexSSE(w, `{"type":"response.completed","response":{"id":"resp","model":"gpt-codex-test","status":"completed","usage":{"input_tokens":1,"output_tokens":1}}}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	provider, err := NewCodexProvider(
+		expired,
+		WithCodexRefreshToken("refresh-old"),
+		WithCodexBaseURL(server.URL),
+		WithCodexAuthBaseURL(server.URL),
+	)
+	if err != nil {
+		t.Fatalf("NewCodexProvider() error = %v", err)
+	}
+	const workers = 8
+	start := make(chan struct{})
+	errs := make(chan error, workers)
+	for range workers {
+		go func() {
+			<-start
+			_, err := provider.Complete(context.Background(), CompletionRequest{
+				Model:    "gpt-codex-test",
+				Messages: []Message{{Role: "user", Content: "Hi"}},
+			})
+			errs <- err
+		}()
+	}
+	close(start)
+	for range workers {
+		if err := <-errs; err != nil {
+			t.Fatalf("Complete() error = %v", err)
+		}
+	}
+	if refreshes.Load() != 1 || completions.Load() != workers {
+		t.Fatalf("refreshes = %d, completions = %d", refreshes.Load(), completions.Load())
+	}
+}
+
+func TestCodexProviderRefreshesAndRetriesAfterAuthRejection(t *testing.T) {
+	oldToken := codexTestJWT(t, "account-old", time.Now().Add(time.Hour))
+	newToken := codexTestJWT(t, "account-new", time.Now().Add(2*time.Hour))
+	var refreshes atomic.Int32
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth/token":
+			refreshes.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token":  newToken,
+				"refresh_token": "refresh-new",
+				"expires_in":    7200,
+			})
+		case "/codex/responses":
+			requests.Add(1)
+			if r.Header.Get("Authorization") == "Bearer "+oldToken {
+				http.Error(w, "expired", http.StatusUnauthorized)
+				return
+			}
+			assertCodexHeaders(t, r, newToken, "account-new")
+			writeCodexSSE(w, `{"type":"response.completed","response":{"id":"resp","model":"gpt-codex-test","status":"completed"}}`)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	provider, err := NewCodexProvider(
+		oldToken,
+		WithCodexRefreshToken("refresh-old"),
+		WithCodexBaseURL(server.URL),
+		WithCodexAuthBaseURL(server.URL),
+	)
+	if err != nil {
+		t.Fatalf("NewCodexProvider() error = %v", err)
+	}
+	if _, err := provider.Complete(context.Background(), CompletionRequest{Messages: []Message{{Role: "user", Content: "Hi"}}}); err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	if refreshes.Load() != 1 || requests.Load() != 2 {
+		t.Fatalf("refreshes = %d, requests = %d", refreshes.Load(), requests.Load())
+	}
+}
+
+func TestCodexProviderStreamCompleteEmitsSSEDeltas(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeCodexSSE(w,
+			`{"type":"response.output_text.delta","output_index":0,"delta":"Hello"}`,
+			`{"type":"response.output_text.delta","output_index":0,"delta":" world"}`,
+			`{"type":"response.completed","response":{"id":"resp","model":"gpt-codex-test","status":"completed"}}`,
+		)
+	}))
+	t.Cleanup(server.Close)
+	provider, err := NewCodexProvider("opaque", WithCodexAccountID("account-123"), WithCodexBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("NewCodexProvider() error = %v", err)
+	}
+	chunks, err := provider.StreamComplete(context.Background(), CompletionRequest{Messages: []Message{{Role: "user", Content: "Hi"}}})
+	if err != nil {
+		t.Fatalf("StreamComplete() error = %v", err)
+	}
+	var text strings.Builder
+	var done bool
+	for chunk := range chunks {
+		if chunk.Error != nil {
+			t.Fatalf("stream error = %v", chunk.Error)
+		}
+		text.WriteString(chunk.Content)
+		done = done || chunk.Done
+	}
+	if text.String() != "Hello world" || !done {
+		t.Fatalf("text = %q, done = %v", text.String(), done)
+	}
+}
+
+func assertCodexHeaders(t *testing.T, r *http.Request, token, accountID string) {
+	t.Helper()
+	want := map[string]string{
+		"Authorization":      "Bearer " + token,
+		"chatgpt-account-id": accountID,
+		"originator":         "pi",
+		"OpenAI-Beta":        "responses=experimental",
+		"Accept":             "text/event-stream",
+	}
+	for name, value := range want {
+		if got := r.Header.Get(name); got != value {
+			t.Errorf("%s = %q, want %q", name, got, value)
+		}
+	}
+}
+
+func writeCodexSSE(w http.ResponseWriter, events ...string) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	for _, event := range events {
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", event)
+	}
+}
+
+func codexTestJWT(t *testing.T, accountID string, expiresAt time.Time) string {
+	t.Helper()
+	header, _ := json.Marshal(map[string]any{"alg": "none"})
+	payload, _ := json.Marshal(map[string]any{
+		"https://api.openai.com/auth": map[string]any{"chatgpt_account_id": accountID},
+		"exp":                         expiresAt.Unix(),
+	})
+	return base64.RawURLEncoding.EncodeToString(header) + "." +
+		base64.RawURLEncoding.EncodeToString(payload) + ".signature"
+}


### PR DESCRIPTION
## Summary

- add the Codex Responses protocol provider
- support completions, tools, structured output, multimodal input, reasoning replay, SSE streaming, usage, OAuth refresh, and health checks
- harden continuation identity, stream aggregation, refresh concurrency, and bounded response handling

## Testing

- focused Codex tests, including race detection
- `go test ./... -count=1`
- `go vet ./...`
- `make lint` with 0 issues
- focused integration tests
- `git diff --check` and exact commit range comparison