### PR TITLE
Fix E2E PostgreSQL extension setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: >-
-      github.event_name != 'pull_request' &&
       (needs.changes.outputs.admin == 'true' ||
       needs.changes.outputs.backend == 'true')
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
               - '.golangci.yml'
               - 'migrations/**'
               - 'oss/**'
+              - 'deploy/docker/Dockerfile.postgres'
               - '.github/workflows/ci.yml'
             docker:
               - 'cmd/**'
@@ -182,20 +183,6 @@ jobs:
       needs.changes.outputs.backend == 'true')
 
     services:
-      postgres:
-        image: postgres:17-alpine
-        env:
-          POSTGRES_USER: pai
-          POSTGRES_PASSWORD: pai
-          POSTGRES_DB: pai
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U pai"
-          --health-interval 5s
-          --health-timeout 3s
-          --health-retries 5
-
       dragonfly:
         image: docker.dragonflydb.io/dragonflydb/dragonfly
         ports:
@@ -210,6 +197,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+
+      - name: Start PostgreSQL with required extensions
+        run: docker compose up --build --detach --wait postgres
 
       - uses: pnpm/action-setup@v4
         with:

--- a/admin-spa/src/routes/_authenticated/-dashboard-child-routes.test.tsx
+++ b/admin-spa/src/routes/_authenticated/-dashboard-child-routes.test.tsx
@@ -69,7 +69,7 @@ afterEach(() => {
 
 describe('dashboard child routes', () => {
   it.each([
-    ['/dashboard/classes', 'Class management'],
+    ['/dashboard/classes', 'Classes'],
     ['/dashboard/metrics', 'AI usage'],
     ['/dashboard/ai-usage', 'AI usage'],
   ])('mounts the child page for %s', async (path, heading) => {

--- a/admin/e2e/authenticated.spec.ts
+++ b/admin/e2e/authenticated.spec.ts
@@ -30,57 +30,36 @@ test.describe("admin authenticated routes @backend", () => {
     "Set E2E_AUTH_ENABLED=true, E2E_ADMIN_EMAIL, and E2E_ADMIN_PASSWORD to run authenticated E2E tests.",
   );
 
-  test("redirects authenticated users away from /login", async ({ page }) => {
+  test("renders authenticated routes", async ({ page }) => {
     await loginAsAdmin(page);
-    await page.goto("/login");
-    await expect(page).toHaveURL(/\/setup\/onboard$/);
-  });
 
-  test("renders /dashboard", async ({ page }) => {
-    await loginAsAdmin(page);
-    await page.goto("/dashboard");
-    await expect(page).toHaveURL(/\/dashboard$/);
-  });
+    await test.step("redirects authenticated users away from /login", async () => {
+      await page.goto("/login");
+      await expect(page).toHaveURL(/\/setup\/onboard$/);
+    });
 
-  test("renders /dashboard/ai-usage", async ({ page }) => {
-    await loginAsAdmin(page);
-    await page.goto("/dashboard/ai-usage");
-    await expect(page).toHaveURL(/\/dashboard\/ai-usage$/);
-  });
+    const routes = [
+      { path: "/dashboard", expected: /\/dashboard$/ },
+      { path: "/dashboard/ai-usage", expected: /\/dashboard\/ai-usage$/ },
+      { path: "/dashboard/metrics", expected: /\/dashboard\/ai-usage$/ },
+      { path: "/dashboard/classes", expected: /\/dashboard\/classes$/ },
+      {
+        path: "/students/test-student-id",
+        expected: /\/students\/test-student-id$/,
+      },
+      {
+        path: "/parents/test-parent-id",
+        expected: /\/parents\/test-parent-id$/,
+      },
+      { path: "/settings/users", expected: /\/settings\/users$/ },
+      { path: "/export", expected: /\/export$/ },
+    ] as const;
 
-  test("redirects /dashboard/metrics to /dashboard/ai-usage", async ({ page }) => {
-    await loginAsAdmin(page);
-    await page.goto("/dashboard/metrics");
-    await expect(page).toHaveURL(/\/dashboard\/ai-usage$/);
-  });
-
-  test("renders /dashboard/classes", async ({ page }) => {
-    await loginAsAdmin(page);
-    await page.goto("/dashboard/classes");
-    await expect(page).toHaveURL(/\/dashboard\/classes$/);
-  });
-
-  test("renders /students/:id route shell", async ({ page }) => {
-    await loginAsAdmin(page);
-    await page.goto("/students/test-student-id");
-    await expect(page).toHaveURL(/\/students\/test-student-id$/);
-  });
-
-  test("renders /parents/:id route shell", async ({ page }) => {
-    await loginAsAdmin(page);
-    await page.goto("/parents/test-parent-id");
-    await expect(page).toHaveURL(/\/parents\/test-parent-id$/);
-  });
-
-  test("renders /settings/users for admin-level roles", async ({ page }) => {
-    await loginAsAdmin(page);
-    await page.goto("/settings/users");
-    await expect(page).toHaveURL(/\/settings\/users$/);
-  });
-
-  test("renders /export for admin-level roles", async ({ page }) => {
-    await loginAsAdmin(page);
-    await page.goto("/export");
-    await expect(page).toHaveURL(/\/export$/);
+    for (const route of routes) {
+      await test.step(`renders ${route.path}`, async () => {
+        await page.goto(route.path);
+        await expect(page).toHaveURL(route.expected);
+      });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- start the repository PostgreSQL image in backend E2E so migrations have the `graph` and `vector` extensions
- run backend E2E for relevant pull requests so migration failures are caught before merge
- rerun backend CI when the PostgreSQL Dockerfile changes
- update the authenticated classes-route regression expectation to the merged `Classes` heading
- reuse one authenticated session across route E2E steps so the suite respects the backend auth rate limit

## Verification
- `git diff --check`
- `pnpm exec vitest run src/routes/_authenticated/-dashboard-child-routes.test.tsx`
- `pnpm lint`
- authenticated Playwright test discovery
- GitHub backend E2E built the custom PostgreSQL image and completed all migrations successfully; final rerun pending