### PR TITLE
Reclaim Docker storage before deploy pulls

### DIFF
--- a/scripts/deploy-remote.sh
+++ b/scripts/deploy-remote.sh
@@ -20,6 +20,10 @@ PREV_ADMIN=$(docker inspect --format='{{.Config.Image}}' "$(docker compose -f do
 echo "Previous app: ${PREV_APP:-none}"
 echo "Previous admin: ${PREV_ADMIN:-none}"
 
+echo "--- Reclaiming unused Docker storage ---"
+docker image prune -af
+docker builder prune -af
+
 echo "--- Pulling images ---"
 docker pull "$REGISTRY/pai-bot/app:$TAG"
 docker pull "$REGISTRY/pai-bot/admin:$TAG"


### PR DESCRIPTION
## Summary
- prune unused Docker images before pulling a new release
- prune unused builder cache before pulling a new release
- keep running containers and volumes intact while preventing accumulated SHA-tagged images from exhausting the host disk

## Evidence
Deploy run 30300848280 passed tests and image publishing, then failed while pulling the app image because `/var/lib/containerd` had no space left.

## Testing
- `bash -n scripts/deploy-remote.sh`
- `git diff --check`