### PR TITLE
Copy identity preflight into deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -143,7 +143,7 @@ jobs:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_KEY }}
-          source: "docker-compose.yml,docker-compose.prod.yml,deploy/caddy,deploy/docker/Dockerfile.postgres,migrations,scripts/deploy-remote.sh"
+          source: "docker-compose.yml,docker-compose.prod.yml,deploy/caddy,deploy/docker/Dockerfile.postgres,migrations,scripts/deploy-remote.sh,scripts/preflight-conversation-identities.sql"
           target: ${{ secrets.DEPLOY_DIR }}
           strip_components: 0
 


### PR DESCRIPTION
## Summary
- include the provider-qualified identity preflight SQL in the server deployment bundle
- unblock the existing remote deploy script before migrations

## Evidence
Deploy run 30301559868 reclaimed 6.599 GB and pulled images successfully, then failed because `scripts/preflight-conversation-identities.sql` was absent on the server.

## Testing
- parsed `.github/workflows/deploy.yml` with Ruby YAML
- `git diff --check`