### PR TITLE
Add Telegram onboarding reply keyboards

### DIFF
--- a/internal/agent/engine_test.go
+++ b/internal/agent/engine_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -187,6 +188,31 @@ func TestEngine_ProcessMessage_StartCommand_CreatesOnboardingConversation(t *tes
 	}
 	if conv.State != "onboarding_language" {
 		t.Fatalf("conversation state = %q, want onboarding_language", conv.State)
+	}
+}
+
+func TestEngine_ProcessMessage_StartCommand_RendersTelegramLanguageChoices(t *testing.T) {
+	engine := agent.NewEngine(agent.EngineConfig{
+		AIRouter: mockRouter(ai.NewMockProvider("")),
+		Store:    agent.NewMemoryStore(),
+	})
+	inbound := chat.InboundMessage{
+		Channel:   "telegram",
+		UserID:    "u-start-keyboard",
+		Text:      "/start",
+		FirstName: "Aina",
+	}
+	response, err := engine.ProcessMessage(t.Context(), inbound)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outbound, ok := chat.RenderTurn(inbound, response, "", chat.TelegramInlineKeyboardContext{})
+	if !ok {
+		t.Fatal("RenderTurn() omitted onboarding response")
+	}
+	want := [][]string{{"English", "Bahasa Melayu", "中文"}}
+	if !reflect.DeepEqual(outbound.ReplyKeyboard, want) {
+		t.Fatalf("ReplyKeyboard = %#v, want %#v", outbound.ReplyKeyboard, want)
 	}
 }
 

--- a/internal/chat/reply_keyboard.go
+++ b/internal/chat/reply_keyboard.go
@@ -3,8 +3,43 @@
 
 package chat
 
+import "strings"
+
 // BuildTelegramReplyKeyboard returns Telegram reply keyboard rows inferred from
 // the outgoing message text. Returns nil when no keyboard is needed.
-func BuildTelegramReplyKeyboard(_ string) [][]string {
+func BuildTelegramReplyKeyboard(text string) [][]string {
+	normalized := strings.ToLower(text)
+	if containsAny(normalized,
+		"choose your preferred session language",
+		"choose your language",
+		"bahasa pilihan anda",
+		"请选择本次学习语言",
+		"请选择你的语言",
+		"couldn't determine your preferred language",
+		"belum pasti bahasa pilihan anda",
+		"还不能确定你的语言偏好",
+	) {
+		return [][]string{{"English", "Bahasa Melayu", "中文"}}
+	}
+	if containsAny(normalized,
+		"what form are you in now",
+		"which form are you in now",
+		"tingkatan berapa anda sekarang",
+		"你现在是几年级",
+		"couldn't determine your form",
+		"belum pasti tingkatan anda",
+		"还不能确定你的年级",
+	) {
+		return [][]string{{"1", "2", "3"}}
+	}
 	return nil
+}
+
+func containsAny(text string, phrases ...string) bool {
+	for _, phrase := range phrases {
+		if strings.Contains(text, phrase) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/chat/reply_keyboard_test.go
+++ b/internal/chat/reply_keyboard_test.go
@@ -4,6 +4,7 @@
 package chat_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/p-n-ai/pai-bot/internal/chat"
@@ -16,10 +17,35 @@ func TestBuildTelegramReplyKeyboard_RatingPrompt(t *testing.T) {
 	}
 }
 
-func TestBuildTelegramReplyKeyboard_OnboardingPrompt(t *testing.T) {
-	got := chat.BuildTelegramReplyKeyboard("Tingkatan berapa anda sekarang?\nBalas dengan: 1, 2, atau 3.")
-	if got != nil {
-		t.Fatalf("BuildTelegramReplyKeyboard() = %#v, want nil for onboarding prompt", got)
+func TestBuildTelegramReplyKeyboard_OnboardingLanguagePrompts(t *testing.T) {
+	for _, prompt := range []string{
+		"Choose your preferred session language:\n- English\n- Bahasa Melayu\n- 中文",
+		"Choose your language:\n- English\n- Bahasa Melayu\n- 中文",
+		"Bahasa pilihan anda untuk sesi ini?\n- English\n- Bahasa Melayu\n- 中文",
+		"请选择本次学习语言：\n- English\n- Bahasa Melayu\n- 中文",
+		"请选择你的语言：\n- English\n- Bahasa Melayu\n- 中文",
+		"I couldn't determine your preferred language. Please reply with: English, Bahasa Melayu, or 中文.",
+	} {
+		got := chat.BuildTelegramReplyKeyboard(prompt)
+		want := [][]string{{"English", "Bahasa Melayu", "中文"}}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("BuildTelegramReplyKeyboard(%q) = %#v, want %#v", prompt, got, want)
+		}
+	}
+}
+
+func TestBuildTelegramReplyKeyboard_OnboardingFormPrompts(t *testing.T) {
+	for _, prompt := range []string{
+		"What form are you in now?\nReply with: 1, 2, or 3.",
+		"Tingkatan berapa anda sekarang?\nBalas dengan: 1, 2, atau 3.",
+		"你现在是几年级？\n请回复：1、2 或 3。",
+		"I couldn't determine your form. Reply with 1, 2, or 3.",
+	} {
+		got := chat.BuildTelegramReplyKeyboard(prompt)
+		want := [][]string{{"1", "2", "3"}}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("BuildTelegramReplyKeyboard(%q) = %#v, want %#v", prompt, got, want)
+		}
 	}
 }
 

--- a/internal/chat/telegram.go
+++ b/internal/chat/telegram.go
@@ -121,7 +121,7 @@ func (t *TelegramChannel) SendMessage(ctx context.Context, userID string, msg Ou
 			}
 			params.Set("reply_markup", string(b))
 		}
-		if len(msg.ReplyKeyboard) > 0 {
+		if len(msg.ReplyKeyboard) > 0 && telegramReplyKeyboardAllowed(chatID) {
 			replyMarkup := map[string]any{
 				"keyboard":          msg.ReplyKeyboard,
 				"resize_keyboard":   true,
@@ -160,6 +160,10 @@ func (t *TelegramChannel) SendMessage(ctx context.Context, userID string, msg Ou
 	}
 
 	return nil
+}
+
+func telegramReplyKeyboardAllowed(chatID string) bool {
+	return !strings.HasPrefix(chatID, "-")
 }
 
 func (t *TelegramChannel) Start(ctx context.Context, handler func(InboundMessage)) error {

--- a/internal/chat/telegram.go
+++ b/internal/chat/telegram.go
@@ -123,9 +123,9 @@ func (t *TelegramChannel) SendMessage(ctx context.Context, userID string, msg Ou
 		}
 		if len(msg.ReplyKeyboard) > 0 {
 			replyMarkup := map[string]any{
-				"keyboard":        msg.ReplyKeyboard,
-				"resize_keyboard": true,
-				"is_persistent":   true,
+				"keyboard":          msg.ReplyKeyboard,
+				"resize_keyboard":   true,
+				"one_time_keyboard": true,
 			}
 			b, err := json.Marshal(replyMarkup)
 			if err != nil {

--- a/internal/chat/telegram_transport_test.go
+++ b/internal/chat/telegram_transport_test.go
@@ -270,6 +270,48 @@ func TestTelegramChannel_SendMessage_UsesOneTimeOnboardingKeyboard(t *testing.T)
 	}
 }
 
+func TestTelegramChannel_SendMessage_OmitsReplyKeyboardFromGroupTopic(t *testing.T) {
+	var values url.Values
+	transport := telegramRoundTripperFunc(func(request *http.Request) (*http.Response, error) {
+		body, err := io.ReadAll(request.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		values, err = url.ParseQuery(string(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+			Header:     make(http.Header),
+		}, nil
+	})
+
+	channel, err := NewTelegramChannel("test-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	channel.client.Transport = transport
+	if err := channel.SendMessage(
+		t.Context(),
+		"telegram:-100123:42",
+		OutboundMessage{
+			Text:          "Which form are you in now?",
+			ReplyKeyboard: [][]string{{"1", "2", "3"}},
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := values.Get("message_thread_id"); got != "42" {
+		t.Fatalf("message_thread_id = %q, want 42", got)
+	}
+	if got := values.Get("reply_markup"); got != "" {
+		t.Fatalf("reply_markup = %q, want omitted for a group topic", got)
+	}
+}
+
 func TestTelegramChannel_DoesNotBuildRatingUI(t *testing.T) {
 	for _, text := range []string{
 		"Nilai penerangan saya (1-5)",

--- a/internal/chat/telegram_transport_test.go
+++ b/internal/chat/telegram_transport_test.go
@@ -16,6 +16,12 @@ import (
 	"testing"
 )
 
+type telegramRoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f telegramRoundTripperFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
 func TestTelegramChannelSendMessageHonorsCanceledContext(t *testing.T) {
 	var requests atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -217,6 +223,50 @@ func TestTelegramChannel_SendMessage_QuizInlineKeyboardPayload(t *testing.T) {
 		if button.Text != want[i].text || button.CallbackData != want[i].data {
 			t.Fatalf("button[%d] = %#v, want text=%q callback_data=%q", i, button, want[i].text, want[i].data)
 		}
+	}
+}
+
+func TestTelegramChannel_SendMessage_UsesOneTimeOnboardingKeyboard(t *testing.T) {
+	var values url.Values
+	transport := telegramRoundTripperFunc(func(request *http.Request) (*http.Response, error) {
+		body, err := io.ReadAll(request.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		values, err = url.ParseQuery(string(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+			Header:     make(http.Header),
+		}, nil
+	})
+
+	channel, err := NewTelegramChannel("test-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	channel.client.Transport = transport
+	if err := channel.SendMessage(t.Context(), "123", OutboundMessage{
+		Text:          "Which form are you in now?",
+		ReplyKeyboard: [][]string{{"1", "2", "3"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var markup struct {
+		Keyboard        [][]string `json:"keyboard"`
+		ResizeKeyboard  bool       `json:"resize_keyboard"`
+		OneTimeKeyboard bool       `json:"one_time_keyboard"`
+		IsPersistent    bool       `json:"is_persistent"`
+	}
+	if err := json.Unmarshal([]byte(values.Get("reply_markup")), &markup); err != nil {
+		t.Fatal(err)
+	}
+	if len(markup.Keyboard) != 1 || !markup.ResizeKeyboard || !markup.OneTimeKeyboard || markup.IsPersistent {
+		t.Fatalf("reply markup = %#v", markup)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add localized one-tap language and form choices during Telegram onboarding
- use one-time reply keyboards so onboarding controls do not persist into normal chat
- cover command rendering and Telegram payload behavior

## Testing
- GOCACHE=/private/tmp/pai-bot-upstream-onboarding-gocache go test ./internal/chat ./internal/agent -count=1
- git diff --check origin/main...HEAD