### PR TITLE
Focus the admin sign-in experience

### DIFF
--- a/admin-spa/src/components/auth/admin-home-panel.test.tsx
+++ b/admin-spa/src/components/auth/admin-home-panel.test.tsx
@@ -25,6 +25,7 @@ it('keeps signed-out navigation free of duplicate sign in links', () => {
   expect(
     screen.queryByRole('link', { name: /sign in/i }),
   ).not.toBeInTheDocument()
+  expect(screen.queryByRole('navigation')).not.toBeInTheDocument()
 })
 
 it('renders no signed-in interstitial because the route redirects instead', () => {

--- a/admin-spa/src/components/auth/admin-home-panel.test.tsx
+++ b/admin-spa/src/components/auth/admin-home-panel.test.tsx
@@ -17,6 +17,12 @@ it('keeps signed-out navigation free of duplicate sign in links', () => {
   render(<AdminHomePanel auth={anonymousAuth} nextPath='/dashboard' />)
 
   expect(
+    screen.getByRole('heading', { name: 'Sign in to P&AI Bot' }),
+  ).toBeInTheDocument()
+  expect(
+    screen.getByText('Enter your school email and password.'),
+  ).toBeInTheDocument()
+  expect(
     screen.queryByRole('link', { name: /sign in/i }),
   ).not.toBeInTheDocument()
 })

--- a/admin-spa/src/components/auth/admin-home-panel.tsx
+++ b/admin-spa/src/components/auth/admin-home-panel.tsx
@@ -1,13 +1,13 @@
-import {
-  ArrowRightIcon,
-  GraduationCapIcon,
-  SchoolIcon,
-  ShieldCheckIcon,
-} from 'lucide-react'
-
 import type { AuthState } from '@/auth-provider'
 import type { AuthSession } from '@/lib/auth-types'
 import { LoginForm } from '@/components/auth/login-form'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
 
 export function AdminHomePanel({
   auth,
@@ -23,8 +23,8 @@ export function AdminHomePanel({
   }
 
   return (
-    <section className='h-svh overflow-hidden bg-[#f7f5ef] px-4 text-slate-text sm:px-6 lg:px-8'>
-      <div className='mx-auto grid h-svh max-w-[1180px] grid-rows-[64px_minmax(0,1fr)] font-inter'>
+    <section className='min-h-svh overflow-y-auto bg-background px-4 text-foreground sm:px-6'>
+      <div className='mx-auto grid min-h-svh max-w-md grid-rows-[64px_1fr] font-inter'>
         <LoginNav />
         <AdminEntryPanel
           nextPath={nextPath}
@@ -40,18 +40,15 @@ function noopAuthenticated() {}
 function LoginNav() {
   return (
     <nav
-      className='flex min-h-0 items-center justify-between gap-6 border-b border-stone-border/80 font-inter'
+      className='flex items-center border-b border-border/70'
       aria-label='Admin entry'
     >
-      <a
-        className='inline-flex items-center gap-2 text-[15px] font-semibold tracking-[0.003em] text-slate-text no-underline'
-        href='/'
-      >
-        <span className='grid size-8 place-items-center rounded-[7px] bg-slate-text text-[13px] font-bold text-cloud-white'>
+      <div className='inline-flex items-center gap-2.5 text-sm font-semibold tracking-tight'>
+        <span className='grid size-8 place-items-center rounded-lg bg-primary text-xs font-bold text-primary-foreground'>
           P
         </span>
         <span>P&AI Bot</span>
-      </a>
+      </div>
     </nav>
   )
 }
@@ -65,67 +62,27 @@ function AdminEntryPanel({
 }) {
   return (
     <section
-      className='grid min-h-0 items-center py-5'
+      className='grid items-center py-10 sm:py-14'
       aria-label='Admin sign in'
       id='sign-in'
     >
-      <div className='grid w-full items-center gap-7 lg:grid-cols-[minmax(0,1fr)_minmax(360px,432px)] lg:gap-12'>
-        <div className='hidden max-w-[560px] lg:block'>
-          <p className='m-0 max-w-[10ch] font-roobert text-[64px] leading-[0.92] font-semibold tracking-[-0.025em] text-slate-text xl:text-[76px]'>
-            Start with the right class.
-          </p>
-          <div className='mt-8 grid max-w-[520px] gap-3'>
-            <EntryPromise
-              Icon={GraduationCapIcon}
-              text='Teachers see class mastery and student detail first.'
-            />
-            <EntryPromise
-              Icon={SchoolIcon}
-              text='Admins manage classes, users, invites, budgets, exports, and setup.'
-            />
-            <EntryPromise
-              Icon={ShieldCheckIcon}
-              text='One session cookie; backend RBAC still gates every admin API.'
-            />
-          </div>
-        </div>
-
-        <div className='mx-auto w-full max-w-[432px]'>
-          <div className='mb-5 text-center lg:text-left'>
-            <h1 className='m-0 font-roobert text-[32px] leading-[1.08] font-semibold tracking-[-0.018em] text-slate-text sm:text-[38px] lg:text-[34px]'>
-              Welcome back.
-            </h1>
-            <p className='mx-auto mt-3 mb-0 max-w-[34ch] text-[14px] leading-[1.56] tracking-[0.003em] text-ash-gray sm:text-[15px] lg:mx-0'>
-              Review classes and decide who needs help next.
-            </p>
-          </div>
-
-          <div className='grid gap-4 rounded-[18px] border border-[#dfd8cd] bg-cloud-white p-5 shadow-[0_22px_70px_rgba(31,28,24,0.10)] sm:p-6'>
+      <div className='w-full'>
+        <Card className='gap-6 rounded-3xl py-7 shadow-lg'>
+          <CardHeader className='gap-2 px-5 text-center sm:px-7'>
+            <CardTitle>
+              <h1 className='m-0 font-roobert text-4xl leading-tight font-semibold tracking-tight text-balance sm:text-[2.75rem]'>
+                Sign in to P&AI Bot
+              </h1>
+            </CardTitle>
+            <CardDescription className='text-sm leading-relaxed text-pretty sm:text-base'>
+              Enter your school email and password.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className='px-5 sm:px-7'>
             <LoginForm nextPath={nextPath} onAuthenticated={onAuthenticated} />
-          </div>
-        </div>
+          </CardContent>
+        </Card>
       </div>
     </section>
-  )
-}
-
-function EntryPromise({
-  Icon,
-  text,
-}: {
-  Icon: typeof GraduationCapIcon
-  text: string
-}) {
-  return (
-    <div className='flex items-center gap-3 rounded-[12px] border border-[#ded6ca] bg-[#fffdf9]/75 p-3 text-[14px] leading-5 text-[#39342f] shadow-[0_1px_0_rgba(31,28,24,0.04)]'>
-      <span className='grid size-9 shrink-0 place-items-center rounded-[9px] bg-[#14251c] text-cloud-white'>
-        <Icon aria-hidden='true' className='size-4' />
-      </span>
-      <span>{text}</span>
-      <ArrowRightIcon
-        aria-hidden='true'
-        className='ml-auto size-4 shrink-0 text-ash-gray'
-      />
-    </div>
   )
 }

--- a/admin-spa/src/components/auth/admin-home-panel.tsx
+++ b/admin-spa/src/components/auth/admin-home-panel.tsx
@@ -25,7 +25,7 @@ export function AdminHomePanel({
   return (
     <section className='min-h-svh overflow-y-auto bg-background px-4 text-foreground sm:px-6'>
       <div className='mx-auto grid min-h-svh max-w-md grid-rows-[64px_1fr] font-inter'>
-        <LoginNav />
+        <LoginHeader />
         <AdminEntryPanel
           nextPath={nextPath}
           onAuthenticated={onAuthenticated}
@@ -37,19 +37,16 @@ export function AdminHomePanel({
 
 function noopAuthenticated() {}
 
-function LoginNav() {
+function LoginHeader() {
   return (
-    <nav
-      className='flex items-center border-b border-border/70'
-      aria-label='Admin entry'
-    >
+    <header className='flex items-center border-b border-border/70'>
       <div className='inline-flex items-center gap-2.5 text-sm font-semibold tracking-tight'>
         <span className='grid size-8 place-items-center rounded-lg bg-primary text-xs font-bold text-primary-foreground'>
           P
         </span>
         <span>P&AI Bot</span>
       </div>
-    </nav>
+    </header>
   )
 }
 

--- a/admin-spa/src/components/auth/login-form.test.tsx
+++ b/admin-spa/src/components/auth/login-form.test.tsx
@@ -90,16 +90,16 @@ describe('LoginForm', () => {
     )
   })
 
-  it('shows the source-admin email divider when the server enables Google sign-in', async () => {
+  it('shows the email divider when the server enables Google sign-in', async () => {
     readAuthCapabilities.mockResolvedValue({ google_login: true })
 
     render(<LoginForm onAuthenticated={vi.fn()} />)
 
     expect(
-      await screen.findByRole('button', { name: 'Continue with Google' }),
+      await screen.findByRole('button', { name: 'Sign in with Google' }),
     ).toBeInTheDocument()
     expect(screen.getByText('G')).toHaveAttribute('aria-hidden', 'true')
-    expect(screen.getByText('or use email')).toBeInTheDocument()
+    expect(screen.getByText('or sign in with email')).toBeInTheDocument()
   })
 
   it('keeps password sign-in available when capabilities cannot be loaded', async () => {
@@ -111,7 +111,7 @@ describe('LoginForm', () => {
       expect(readAuthCapabilities).toHaveBeenCalledOnce()
     })
     expect(
-      screen.queryByRole('button', { name: 'Continue with Google' }),
+      screen.queryByRole('button', { name: 'Sign in with Google' }),
     ).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Sign in' })).toBeEnabled()
   })
@@ -124,7 +124,7 @@ describe('LoginForm', () => {
     render(<LoginForm onAuthenticated={vi.fn()} nextPath='/dashboard' />)
 
     fireEvent.click(
-      await screen.findByRole('button', { name: 'Continue with Google' }),
+      await screen.findByRole('button', { name: 'Sign in with Google' }),
     )
 
     expect(buildGoogleLoginURL).toHaveBeenCalledWith('/dashboard')
@@ -132,9 +132,31 @@ describe('LoginForm', () => {
       '/api/auth/google/start?next=%2Fdashboard',
     )
     expect(
-      screen.getByRole('button', { name: 'Redirecting to Google...' }),
+      screen.getByRole('button', { name: 'Sign in with Google' }),
     ).toBeDisabled()
     expect(screen.getByRole('button', { name: 'Sign in' })).toBeDisabled()
+    expect(screen.getByLabelText('Email')).toBeDisabled()
+    expect(screen.getByLabelText('Password')).toBeDisabled()
+  })
+
+  it('shows password progress and disables the form while signing in', async () => {
+    loginWithPassword.mockReturnValue(new Promise(() => {}))
+
+    render(<LoginForm onAuthenticated={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Email'), {
+      target: { value: 'teacher@school.edu' },
+    })
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'secret' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }))
+
+    expect(
+      await screen.findByRole('button', { name: 'Sign in' }),
+    ).toBeDisabled()
+    expect(screen.getByLabelText('Email')).toBeDisabled()
+    expect(screen.getByLabelText('Password')).toBeDisabled()
   })
 
   it('retries password login with the selected school when tenant selection is required', async () => {

--- a/admin-spa/src/components/auth/login-form.tsx
+++ b/admin-spa/src/components/auth/login-form.tsx
@@ -1,12 +1,18 @@
 import { useCallback, useEffect, useId, useState } from 'react'
-import { Building2Icon, LockKeyholeIcon } from 'lucide-react'
+import { Building2Icon } from 'lucide-react'
 import type { FormEvent } from 'react'
 
 import type { AuthSession, SchoolChoice } from '@/lib/auth-types'
 import { AuthErrorAlert } from '@/components/shared/auth-error-alert'
 import { Button } from '@/components/ui/button'
+import {
+  Field,
+  FieldGroup,
+  FieldLabel,
+  FieldSeparator,
+} from '@/components/ui/field'
 import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
+import { Spinner } from '@/components/ui/spinner'
 import {
   Select,
   SelectContent,
@@ -88,8 +94,8 @@ export function LoginForm({
           setError(
             readAuthDisplayError(
               caught,
-              'Login failed',
-              "We couldn't reach the sign-in service. Check your connection and try again.",
+              'Sign-in failed',
+              'Unable to reach the sign-in service. Check your connection and try again.',
             ),
           )
         })
@@ -119,40 +125,50 @@ export function LoginForm({
 
   return (
     <form
-      className='flex flex-col gap-4 font-inter'
+      aria-busy={isPending || isGooglePending}
+      className='flex flex-col gap-5'
       id='sign-in-form'
       onSubmit={submit}
     >
-      <GoogleLoginButton
-        isPending={isPending || isGooglePending}
-        isRedirecting={isGooglePending}
-        onClick={startGoogleLogin}
-        visible={showGoogleLogin}
-      />
-      <GoogleLoginDivider visible={showGoogleLogin} />
+      <FieldGroup>
+        <GoogleLoginButton
+          isPending={isPending || isGooglePending}
+          isRedirecting={isGooglePending}
+          onClick={startGoogleLogin}
+          visible={showGoogleLogin}
+        />
+        <LoginDivider visible={showGoogleLogin} />
 
-      <LoginCredentialsFields email={email} password={password} />
-      <SchoolSelect
-        choices={tenantChoices}
-        id={schoolID}
-        onChange={setTenantID}
-        value={tenantID}
-      />
+        <LoginCredentialsFields
+          disabled={isPending || isGooglePending}
+          email={email}
+          password={password}
+        />
+        <SchoolSelect
+          choices={tenantChoices}
+          disabled={isPending || isGooglePending}
+          id={schoolID}
+          onChange={setTenantID}
+          value={tenantID}
+        />
 
-      <AuthErrorAlert message={error} title='Sign-in failed.' />
+        <AuthErrorAlert message={error} title='Sign-in failed.' />
 
-      <PasswordLoginButton
-        isDisabled={isPending || isGooglePending}
-        isPending={isPending}
-      />
+        <PasswordLoginButton
+          isDisabled={isPending || isGooglePending}
+          isPending={isPending}
+        />
+      </FieldGroup>
     </form>
   )
 }
 
 function LoginCredentialsFields({
+  disabled,
   email,
   password,
 }: {
+  disabled: boolean
   email: ReturnType<typeof useInputValue>
   password: ReturnType<typeof useInputValue>
 }) {
@@ -161,41 +177,39 @@ function LoginCredentialsFields({
 
   return (
     <>
-      <div className='flex flex-col gap-1.5'>
-        <Label
-          className='text-[12px] font-semibold tracking-[0.03em] text-slate-text'
+      <Field data-disabled={disabled}>
+        <FieldLabel
+          className='text-sm font-medium text-foreground'
           htmlFor={emailID}
         >
           Email
-        </Label>
+        </FieldLabel>
         <Input
-          autoComplete='email'
-          className='h-11 rounded-[10px] border-[#d9d3ca] bg-[#fffdf9] px-3 text-[14px] text-slate-text placeholder:text-ash-gray focus-visible:border-[#2f6f5b] focus-visible:ring-2 focus-visible:ring-[#bedbcf]'
+          autoComplete='username'
+          className='h-11 rounded-xl px-3 text-base sm:text-sm'
+          disabled={disabled}
           id={emailID}
           name='email'
           onChange={email.handleChange}
-          placeholder='teacher@school.edu'
+          placeholder='name@school.edu'
           required
+          spellCheck={false}
           type='email'
           value={email.value}
         />
-      </div>
+      </Field>
 
-      <div className='flex flex-col gap-1.5'>
-        <div className='flex items-center justify-between gap-3'>
-          <Label
-            className='text-[12px] font-semibold tracking-[0.03em] text-slate-text'
-            htmlFor={passwordID}
-          >
-            Password
-          </Label>
-          <span className='text-[12px] font-medium text-ash-gray'>
-            Invite-issued account
-          </span>
-        </div>
+      <Field data-disabled={disabled}>
+        <FieldLabel
+          className='text-sm font-medium text-foreground'
+          htmlFor={passwordID}
+        >
+          Password
+        </FieldLabel>
         <Input
           autoComplete='current-password'
-          className='h-11 rounded-[10px] border-[#d9d3ca] bg-[#fffdf9] px-3 text-[14px] text-slate-text placeholder:text-ash-gray focus-visible:border-[#2f6f5b] focus-visible:ring-2 focus-visible:ring-[#bedbcf]'
+          className='h-11 rounded-xl px-3 text-base sm:text-sm'
+          disabled={disabled}
           id={passwordID}
           name='password'
           onChange={password.handleChange}
@@ -204,7 +218,7 @@ function LoginCredentialsFields({
           type='password'
           value={password.value}
         />
-      </div>
+      </Field>
     </>
   )
 }
@@ -218,27 +232,24 @@ function PasswordLoginButton({
 }) {
   return (
     <Button
-      className='mt-1 h-11 rounded-[10px] bg-[#17211b] px-4 text-[14px] font-semibold text-cloud-white shadow-[0_10px_24px_rgba(23,33,27,0.18)] hover:bg-[#235f72]'
+      className='h-11 rounded-xl px-4 font-semibold'
       disabled={isDisabled}
       type='submit'
     >
-      {isPending ? 'Signing in...' : 'Sign in'}
+      {isPending ? (
+        <Spinner aria-hidden='true' data-icon='inline-start' />
+      ) : null}
+      Sign in
     </Button>
   )
 }
 
-function GoogleLoginDivider({ visible }: { visible: boolean }) {
+function LoginDivider({ visible }: { visible: boolean }) {
   if (!visible) {
     return null
   }
 
-  return (
-    <div className='flex items-center gap-3 text-[11px] font-bold tracking-[0.12em] text-ash-gray uppercase'>
-      <span className='h-px flex-1 bg-stone-border' aria-hidden='true' />
-      <span>or use email</span>
-      <span className='h-px flex-1 bg-stone-border' aria-hidden='true' />
-    </div>
-  )
+  return <FieldSeparator>or sign in with email</FieldSeparator>
 }
 
 function GoogleLoginButton({
@@ -258,30 +269,37 @@ function GoogleLoginButton({
 
   return (
     <Button
-      className='min-h-11 w-full rounded-[10px] border-[#d9d3ca] bg-cloud-white text-[14px] font-semibold text-slate-text shadow-subtle hover:bg-[#f7f5ef]'
+      className='min-h-11 w-full rounded-xl font-semibold'
       disabled={isPending}
       onClick={onClick}
       type='button'
       variant='outline'
     >
-      <span
-        aria-hidden='true'
-        className='inline-grid size-4 place-items-center text-sm leading-none font-extrabold text-[#4285f4]'
-      >
-        G
-      </span>
-      {isRedirecting ? 'Redirecting to Google...' : 'Continue with Google'}
+      {isRedirecting ? (
+        <Spinner aria-hidden='true' data-icon='inline-start' />
+      ) : (
+        <span
+          aria-hidden='true'
+          className='inline-grid size-4 place-items-center text-sm leading-none font-extrabold'
+          data-icon='inline-start'
+        >
+          G
+        </span>
+      )}
+      Sign in with Google
     </Button>
   )
 }
 
 function SchoolSelect({
   choices,
+  disabled,
   id,
   onChange,
   value,
 }: {
   choices: Array<SchoolChoice>
+  disabled: boolean
   id: string
   onChange: (value: string) => void
   value: string
@@ -291,19 +309,27 @@ function SchoolSelect({
   }
 
   return (
-    <div className='rounded-[12px] border border-[#d9d3ca] bg-[#f7fbf8] p-3'>
-      <div className='mb-3 flex gap-2 text-[13px] leading-5 text-[#445c4d]'>
+    <Field
+      className='rounded-xl border border-border bg-muted/50 p-3'
+      data-disabled={disabled}
+    >
+      <div className='mb-3 flex gap-2 text-sm leading-5 text-muted-foreground'>
         <Building2Icon aria-hidden='true' className='mt-0.5 size-4 shrink-0' />
         <p className='m-0'>
-          This email belongs to more than one school. Choose the workspace for
-          this session.
+          This email belongs to more than one school. Choose where you want to
+          sign in.
         </p>
       </div>
-      <Label className='text-[12px] font-semibold' htmlFor={id}>
+      <FieldLabel className='text-xs font-semibold' htmlFor={id}>
         School
-      </Label>
-      <Select onValueChange={onChange} required value={value}>
-        <SelectTrigger className='mt-1.5 h-11 rounded-[10px]' id={id}>
+      </FieldLabel>
+      <Select
+        disabled={disabled}
+        onValueChange={onChange}
+        required
+        value={value}
+      >
+        <SelectTrigger className='mt-1.5 h-11 rounded-xl' id={id}>
           <SelectValue placeholder='Choose school' />
         </SelectTrigger>
         <SelectContent>
@@ -314,10 +340,6 @@ function SchoolSelect({
           ))}
         </SelectContent>
       </Select>
-      <p className='mt-2 mb-0 flex items-start gap-2 text-[12px] leading-5 text-ash-gray'>
-        <LockKeyholeIcon aria-hidden='true' className='mt-0.5 size-3.5' />
-        Your role and tenant access are checked again by the backend.
-      </p>
-    </div>
+    </Field>
   )
 }


### PR DESCRIPTION
## Summary
- replace the split marketing/login layout with a focused, centered sign-in card
- keep email/password primary and preserve capability-gated Google sign-in
- improve pending-state accessibility, tenant selection copy, and control disabling
- remove implementation details from user-facing sign-in copy

## Testing
- pnpm --dir admin-spa exec vitest run src/components/auth/admin-home-panel.test.tsx src/components/auth/login-form.test.tsx
- pnpm --dir admin-spa exec eslint src/components/auth/admin-home-panel.tsx src/components/auth/admin-home-panel.test.tsx src/components/auth/login-form.tsx src/components/auth/login-form.test.tsx
- pnpm --dir admin-spa typecheck
- pnpm --dir admin-spa build
- git diff --check origin/main...HEAD