### PR TITLE
feat(ai): make Codex device login the primary chat provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,7 +60,7 @@ LEARN_AI_DEFAULT_PROVIDER=
 LEARN_AI_MOCK_RESPONSE=
 LEARN_AI_OPENAI_API_KEY=
 LEARN_AI_OPENAI_MODEL=
-# Enable authenticated Admin device authorization for a local, single-user server.
+# Enable authenticated Admin device authorization for a self-hosted server.
 LEARN_AI_CODEX_ENABLED=false
 # Optional isolated server-owned Codex home.
 LEARN_AI_CODEX_HOME=

--- a/.env.example
+++ b/.env.example
@@ -60,11 +60,15 @@ LEARN_AI_DEFAULT_PROVIDER=
 LEARN_AI_MOCK_RESPONSE=
 LEARN_AI_OPENAI_API_KEY=
 LEARN_AI_OPENAI_MODEL=
-# ChatGPT subscription credentials; account ID is optional when embedded in the access-token JWT.
+# Enable authenticated Admin device authorization for a local, single-user server.
+LEARN_AI_CODEX_ENABLED=false
+# Optional isolated server-owned Codex home.
+LEARN_AI_CODEX_HOME=
+# Legacy manual credentials remain supported; Admin device authorization is preferred.
 LEARN_AI_CODEX_ACCESS_TOKEN=
 LEARN_AI_CODEX_REFRESH_TOKEN=
 LEARN_AI_CODEX_ACCOUNT_ID=
-LEARN_AI_CODEX_MODEL=
+LEARN_AI_CODEX_MODEL=gpt-5.4
 LEARN_AI_ANTHROPIC_API_KEY=
 LEARN_AI_ANTHROPIC_MODEL=
 LEARN_AI_DEEPSEEK_API_KEY=

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -171,6 +171,9 @@ jobs:
               "LEARN_AI_DEEPSEEK_API_KEY=${DEEPSEEK_KEY}" \
               "LEARN_AI_GOOGLE_API_KEY=${GOOGLE_KEY}" \
               "LEARN_AI_OPENROUTER_API_KEY=${OPENROUTER_KEY}" \
+              "LEARN_AI_CODEX_ENABLED=true" \
+              "LEARN_AI_CODEX_HOME=/var/lib/pai-bot/codex" \
+              "LEARN_AI_CODEX_MODEL=gpt-5.4" \
               "LEARN_AI_OLLAMA_ENABLED=false" \
               "LEARN_TENANT_MODE=single" \
               "LEARN_CURRICULUM_PATH=./oss" \

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Get P&AI running in under 5 minutes.
 
 - [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/) (v2+)
 - Credentials for an external chat adapter if you want to receive messages outside local development. Production requires at least one of Telegram, WhatsApp, Slack, Discord, or Microsoft Teams.
-- At least one AI provider API key (OpenAI, Anthropic, or use free self-hosted Ollama)
+- At least one AI provider: an API key, free self-hosted Ollama, or a local Codex CLI login
 
 ### 1. Clone and configure
 
@@ -77,7 +77,12 @@ Edit `.env` with your credentials:
 # Optional external chat adapter
 LEARN_TELEGRAM_BOT_TOKEN=your-telegram-bot-token
 
-# AI Providers (at least one required)
+# Preferred: connect your ChatGPT subscription from Admin → AI settings
+LEARN_AI_DEFAULT_PROVIDER=codex
+LEARN_AI_CODEX_ENABLED=true
+LEARN_AI_CODEX_MODEL=gpt-5.4
+
+# Or use OpenRouter
 LEARN_AI_DEFAULT_PROVIDER=openrouter
 LEARN_AI_OPENROUTER_API_KEY=sk-or-v1-...
 LEARN_AI_OPENROUTER_MODEL=qwen/qwen3-max
@@ -120,6 +125,16 @@ just seed-docker
 ```
 
 When the backend is running in Docker, make sure `.env` uses Compose service names such as `postgres` and `dragonfly` instead of `localhost`. The `app` service already reads `.env`, so school admins can choose AI provider and default model purely with Docker env vars. For Ollama, Compose overrides `LEARN_AI_OLLAMA_URL` inside the app container to `http://ollama:11434`.
+
+The Codex provider is for a local, single-user server. Sign in to Admin with the existing email/password flow, choose **Connect Codex** in AI settings, open the displayed OpenAI verification page, and enter the one-time device code. PaiBot uses the structured `codex app-server` account API, which owns login and automatic token refresh inside an isolated server-owned Codex home. PaiBot never reads the operator's personal `~/.codex` login.
+
+```env
+LEARN_AI_CODEX_ENABLED=true
+# Optional; defaults to the OS config directory under pai-bot/codex.
+LEARN_AI_CODEX_HOME=/var/lib/pai-bot/codex
+```
+
+The Codex CLI must be installed and on the backend process `PATH`. The backend user also needs write access to `LEARN_AI_CODEX_HOME`.
 
 ### 3. Pull a free AI model (optional)
 
@@ -214,6 +229,7 @@ Open `http://localhost:8080/docs` for the Scalar-powered API reference. The raw 
 │  │  ┌─────────┐  │ │ Service  │ │  + Dragonfly  │   │
 │  │  │OpenAI   │  │ │  (OSS)   │ │               │   │
 │  │  │Anthropic│  │ └──────────┘ └───────────────┘   │
+│  │  │Codex    │  │                                  │
 │  │  │Ollama   │  │                                  │
 │  │  │Custom   │  │                                  │
 │  │  └─────────┘  │                                  │
@@ -233,7 +249,7 @@ Open `http://localhost:8080/docs` for the Scalar-powered API reference. The raw 
 | **Backend** | Go 1.25+ | Concurrent chat and scheduling services ship as a single binary. |
 | **Database** | PostgreSQL 17 | Standard, portable. Every cloud has managed Postgres. |
 | **Cache** | Dragonfly | Redis-compatible, multi-threaded, 80% less memory. |
-| **AI Providers** | OpenAI, Anthropic, Ollama, OpenRouter | Provider-agnostic gateway. Swap models without code changes. |
+| **AI Providers** | OpenAI, Anthropic, Codex, Ollama, OpenRouter | Provider-agnostic gateway. Swap models without code changes. |
 | **Chat** | Telegram, WhatsApp, Slack, Discord, Microsoft Teams, WebSocket | One gateway preserves provider identity, thread routes, delivery IDs, and adapter lifecycle. |
 | **Admin Panel** | Next.js 16, TypeScript, TanStack Query, shadcn/ui | Teacher dashboards, parent views, school admin. |
 | **Curriculum** | [Open School Syllabus](https://github.com/p-n-ai/oss) | Structured YAML curriculum consumed by the agent. |
@@ -268,7 +284,8 @@ pai-bot/
 │   │   ├── provider_anthropic.go    # Anthropic Claude
 │   │   ├── provider_google.go       # Google Gemini
 │   │   ├── provider_ollama.go       # Self-hosted (Llama, Qwen, etc.)
-│   │   └── provider_openrouter_llm_adapter.go   # 100+ models via OpenRouter
+│   │   ├── provider_openrouter_llm_adapter.go   # 100+ models via OpenRouter
+│   │   └── provider_codex.go         # Codex through a server-owned app-server login
 │   ├── agent/                       # Agent Engine
 │   │   ├── engine.go                # Conversation state machine
 │   │   ├── scheduler.go             # Proactive nudge scheduler
@@ -347,10 +364,11 @@ P&AI is not locked to any AI model. Configure one or more providers:
 | **Google Gemini** | Gemini 3 Flash Preview, Gemini 3 Pro Preview | Paid API | Set `LEARN_AI_GOOGLE_API_KEY` and optionally `LEARN_AI_GOOGLE_MODEL` |
 | **Ollama** | Qwen3, Qwen3 14B, Qwen3 30B | Free (self-hosted) | Set `LEARN_AI_OLLAMA_ENABLED=true` and optionally `LEARN_AI_OLLAMA_MODEL` |
 | **OpenRouter** | Qwen3 Max, Qwen3 Coder Next, 100+ others | Varies | Set `LEARN_AI_OPENROUTER_API_KEY` and optionally `LEARN_AI_OPENROUTER_MODEL` |
+| **Codex** | GPT-5.6 Sol | ChatGPT subscription | Install the Codex CLI, then connect from Admin → AI settings |
 
 DeepSeek uses the OpenAI-compatible API format — no extra code, just a different API key and base URL. Its official `deepseek-chat` alias already tracks the current DeepSeek-V3.2 non-thinking model. Gemini 3 models are the latest family, but note that the current Flash/Pro API IDs are preview models. Preview Gemini IDs can have different or tighter rate limits, so for steadier production behavior it is usually safer to set `LEARN_AI_GOOGLE_MODEL` to a non-preview model name such as `gemini-2.5-flash`. Qwen, Kimi, and other models are accessible via OpenRouter or self-hosted via Ollama.
 
-To prefer one provider first, set `LEARN_AI_DEFAULT_PROVIDER` to one of: `openai`, `anthropic`, `deepseek`, `google`, `ollama`, `openrouter`.
+To prefer one provider first, set `LEARN_AI_DEFAULT_PROVIDER` to one of: `openai`, `anthropic`, `deepseek`, `google`, `ollama`, `openrouter`, `codex`.
 
 The AI Gateway automatically routes by task type:
 
@@ -460,7 +478,7 @@ Configuration is environment-driven. Core app variables use `LEARN_`; auth varia
 | `LEARN_WHATSAPP_VERIFY_TOKEN` | With Cloud API | — | Token used to verify the Cloud API webhook |
 | `LEARN_DATABASE_URL` | No | `postgres://pai:pai@localhost:5432/pai` | PostgreSQL connection string |
 | `LEARN_CACHE_URL` | No | `redis://localhost:6379` | Dragonfly/Redis connection |
-| `LEARN_AI_DEFAULT_PROVIDER` | No | — | Preferred provider to try first (`openai`, `anthropic`, `deepseek`, `google`, `ollama`, `openrouter`) |
+| `LEARN_AI_DEFAULT_PROVIDER` | No | — | Preferred provider to try first (`openai`, `anthropic`, `deepseek`, `google`, `ollama`, `openrouter`, `codex`) |
 | `LEARN_AI_OPENAI_API_KEY` | No | — | OpenAI API key |
 | `LEARN_AI_OPENAI_MODEL` | No | — | Default OpenAI model when request model is not set |
 | `LEARN_AI_ANTHROPIC_API_KEY` | No | — | Anthropic API key |
@@ -471,6 +489,12 @@ Configuration is environment-driven. Core app variables use `LEARN_`; auth varia
 | `LEARN_AI_GOOGLE_MODEL` | No | — | Default Google model when request model is not set |
 | `LEARN_AI_OPENROUTER_API_KEY` | No | — | OpenRouter API key (100+ models) |
 | `LEARN_AI_OPENROUTER_MODEL` | No | — | Default OpenRouter model when request model is not set |
+| `LEARN_AI_CODEX_ENABLED` | No | `false` | Enable authenticated Admin device authorization for the local Codex provider |
+| `LEARN_AI_CODEX_HOME` | No | OS config directory under `pai-bot/codex` | Isolated server-owned Codex credential directory |
+| `LEARN_AI_CODEX_ACCESS_TOKEN` | No | — | Legacy manual Codex access token; Admin device authorization is preferred |
+| `LEARN_AI_CODEX_REFRESH_TOKEN` | No | — | Legacy manual Codex refresh token |
+| `LEARN_AI_CODEX_ACCOUNT_ID` | No | — | Legacy manual ChatGPT account ID |
+| `LEARN_AI_CODEX_MODEL` | No | `gpt-5.4` | Default Codex model |
 | `LEARN_AI_OLLAMA_ENABLED` | No | `false` | Enable self-hosted Ollama |
 | `LEARN_AI_OLLAMA_URL` | No | `http://localhost:11434` | Ollama server URL |
 | `LEARN_AI_OLLAMA_MODEL` | No | — | Default Ollama model when request model is not set |

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ just seed-docker
 
 When the backend is running in Docker, make sure `.env` uses Compose service names such as `postgres` and `dragonfly` instead of `localhost`. The `app` service already reads `.env`, so school admins can choose AI provider and default model purely with Docker env vars. For Ollama, Compose overrides `LEARN_AI_OLLAMA_URL` inside the app container to `http://ollama:11434`.
 
-The Codex provider is for a local, single-user server. Sign in to Admin with the existing email/password flow, choose **Connect Codex** in AI settings, open the displayed OpenAI verification page, and enter the one-time device code. PaiBot uses the structured `codex app-server` account API, which owns login and automatic token refresh inside an isolated server-owned Codex home. PaiBot never reads the operator's personal `~/.codex` login.
+The Codex provider is for a self-hosted server with trusted administrators. Sign in to Admin with the existing email/password flow, choose **Connect Codex** in AI settings, open the displayed OpenAI verification page, and enter the one-time device code. The browser can be on a different machine from the server: Codex completes authorization through the device flow and stores the resulting login in an isolated server-owned Codex home. PaiBot uses the structured `codex app-server` account API and never reads the operator's personal `~/.codex` login.
 
 ```env
 LEARN_AI_CODEX_ENABLED=true
@@ -134,7 +134,7 @@ LEARN_AI_CODEX_ENABLED=true
 LEARN_AI_CODEX_HOME=/var/lib/pai-bot/codex
 ```
 
-The Codex CLI must be installed and on the backend process `PATH`. The backend user also needs write access to `LEARN_AI_CODEX_HOME`.
+The production app image includes a pinned Codex CLI. Docker Compose mounts `LEARN_AI_CODEX_HOME` from the persistent `codex-data` volume, so the login survives container replacement. When running the backend outside that image, install the Codex CLI on the backend `PATH` and give the backend user write access to `LEARN_AI_CODEX_HOME`.
 
 ### 3. Pull a free AI model (optional)
 

--- a/admin-spa/src/components/settings/ai-settings-panel.test.tsx
+++ b/admin-spa/src/components/settings/ai-settings-panel.test.tsx
@@ -16,9 +16,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { AISettingsPanel } from './ai-settings-panel'
 import type * as AdminAPI from '@/lib/admin-api'
 import type { AISettings } from '@/lib/ai-settings-types'
+import { AdminAPIError } from '@/lib/admin-api'
 import { aiSettingsFixture } from '@/lib/ai-settings-types.test'
 
 const getAISettings = vi.hoisted(() => vi.fn())
+const getCodexAuthStatus = vi.hoisted(() => vi.fn())
+const startCodexDeviceAuth = vi.hoisted(() => vi.fn())
 const updateAISettings = vi.hoisted(() => vi.fn())
 
 vi.mock('@/lib/admin-api', async (importOriginal) => {
@@ -27,6 +30,8 @@ vi.mock('@/lib/admin-api', async (importOriginal) => {
   return {
     ...actual,
     getAISettings,
+    getCodexAuthStatus,
+    startCodexDeviceAuth,
     updateAISettings,
   }
 })
@@ -50,11 +55,74 @@ function deferred<T>() {
 describe('AISettingsPanel', () => {
   beforeEach(() => {
     getAISettings.mockReset()
+    getCodexAuthStatus.mockReset()
+    getCodexAuthStatus.mockResolvedValue({
+      state: 'disconnected',
+      verificationUrl: '',
+      userCode: '',
+      message: '',
+    })
+    startCodexDeviceAuth.mockReset()
     updateAISettings.mockReset()
   })
 
   afterEach(() => {
     cleanup()
+  })
+
+  it('starts Codex device login and shows the one-time code', async () => {
+    getAISettings.mockResolvedValue(aiSettingsFixture)
+    startCodexDeviceAuth.mockResolvedValue({
+      state: 'awaiting_authorization',
+      verificationUrl: 'https://auth.openai.com/codex/device',
+      userCode: 'ABCD-1234',
+      message: '',
+    })
+
+    render(<AISettingsPanel />)
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Connect Codex' }),
+    )
+
+    expect(await screen.findByText('ABCD-1234')).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: 'Open Codex verification' }),
+    ).toHaveAttribute('href', 'https://auth.openai.com/codex/device')
+    expect(startCodexDeviceAuth).toHaveBeenCalledOnce()
+  })
+
+  it('allows an existing server login to be renewed with device auth', async () => {
+    getAISettings.mockResolvedValue(aiSettingsFixture)
+    getCodexAuthStatus.mockResolvedValue({
+      state: 'connected',
+      verificationUrl: '',
+      userCode: '',
+      message: '',
+    })
+
+    render(<AISettingsPanel />)
+
+    expect(
+      await screen.findByRole('button', { name: 'Reconnect Codex' }),
+    ).toBeEnabled()
+  })
+
+  it('hides Codex setup when the server feature is disabled', async () => {
+    getAISettings.mockResolvedValue(aiSettingsFixture)
+    getCodexAuthStatus.mockRejectedValue(
+      new AdminAPIError('Request failed: 404', 404),
+    )
+
+    render(<AISettingsPanel />)
+
+    await screen.findByText('Default provider')
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(
+      screen.queryByRole('button', { name: 'Connect Codex' }),
+    ).not.toBeInTheDocument()
   })
 
   it('saves a new key, clears the input, and shows the masked state', async () => {

--- a/admin-spa/src/components/settings/ai-settings-panel.tsx
+++ b/admin-spa/src/components/settings/ai-settings-panel.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import type { ChangeEvent, FormEvent, ReactNode } from 'react'
 
 import type { AISettings, UpdateAISettingsInput } from '@/lib/ai-settings-types'
+import type { CodexAuthStatus } from '@/lib/codex-auth-types'
 import { AuthErrorAlert } from '@/components/shared/auth-error-alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -16,7 +17,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { getAISettings, updateAISettings } from '@/lib/admin-api'
+import {
+  AdminAPIError,
+  getAISettings,
+  getCodexAuthStatus,
+  startCodexDeviceAuth,
+  updateAISettings,
+} from '@/lib/admin-api'
 import { useSubmitStatus } from '@/hooks/use-submit-status'
 
 type PanelState =
@@ -26,12 +33,21 @@ type PanelState =
 
 type SubmitStatus = ReturnType<typeof useSubmitStatus>
 type SubmitSection = 'provider' | 'model' | 'key' | 'flags'
+type CodexState =
+  | { status: 'loading' }
+  | { status: 'unavailable' }
+  | { status: 'error'; message: string }
+  | { status: 'ready'; auth: CodexAuthStatus }
 
 export function AISettingsPanel() {
   const [state, setState] = useState<PanelState>({ status: 'loading' })
   const [model, setModel] = useState('')
   const [keyInput, setKeyInput] = useState('')
   const [isReplacingKey, setIsReplacingKey] = useState(false)
+  const [codexState, setCodexState] = useState<CodexState>({
+    status: 'loading',
+  })
+  const [isStartingCodex, setIsStartingCodex] = useState(false)
   const requestSeq = useRef(0)
   const sectionSeq = useRef<Record<string, number>>({})
   const providerSubmit = useSubmitStatus('')
@@ -54,6 +70,58 @@ export function AISettingsPanel() {
               : 'AI settings could not be loaded.',
         })
       })
+  }, [])
+
+  const loadCodexStatus = useCallback(() => {
+    return getCodexAuthStatus()
+      .then((auth) => setCodexState({ status: 'ready', auth }))
+      .catch((caught: unknown) => {
+        if (caught instanceof AdminAPIError && caught.status === 404) {
+          setCodexState({ status: 'unavailable' })
+          return
+        }
+        setCodexState({
+          status: 'error',
+          message:
+            caught instanceof Error
+              ? caught.message
+              : 'Codex login status could not be loaded.',
+        })
+      })
+  }, [])
+
+  useEffect(() => {
+    loadCodexStatus()
+  }, [loadCodexStatus])
+
+  useEffect(() => {
+    if (
+      codexState.status !== 'ready' ||
+      (codexState.auth.state !== 'starting' &&
+        codexState.auth.state !== 'awaiting_authorization')
+    ) {
+      return
+    }
+    const timer = window.setInterval(() => {
+      loadCodexStatus()
+    }, 1500)
+    return () => window.clearInterval(timer)
+  }, [codexState, loadCodexStatus])
+
+  const handleStartCodex = useCallback(() => {
+    setIsStartingCodex(true)
+    startCodexDeviceAuth()
+      .then((auth) => setCodexState({ status: 'ready', auth }))
+      .catch((caught: unknown) => {
+        setCodexState({
+          status: 'error',
+          message:
+            caught instanceof Error
+              ? caught.message
+              : 'Codex device login could not be started.',
+        })
+      })
+      .finally(() => setIsStartingCodex(false))
   }, [])
 
   const submitSettings = useCallback(
@@ -206,6 +274,11 @@ export function AISettingsPanel() {
         onProviderChange={handleProviderChange}
         settings={settings}
       />
+      <CodexAuthSection
+        isStarting={isStartingCodex}
+        onStart={handleStartCodex}
+        state={codexState}
+      />
       <OpenRouterSection
         keyError={keySubmit.error}
         isKeyPending={keySubmit.isPending}
@@ -234,6 +307,89 @@ export function AISettingsPanel() {
         sources={settings.sources.flags}
       />
     </div>
+  )
+}
+
+function CodexAuthSection({
+  isStarting,
+  onStart,
+  state,
+}: {
+  isStarting: boolean
+  onStart: () => void
+  state: CodexState
+}) {
+  if (state.status === 'loading' || state.status === 'unavailable') {
+    return null
+  }
+
+  const auth = state.status === 'ready' ? state.auth : null
+  const awaiting = auth?.state === 'awaiting_authorization'
+  const connected = auth?.state === 'connected'
+
+  return (
+    <SettingsSection
+      description='Connect this server to ChatGPT with Codex device authorization. PaiBot never reads your personal Codex login.'
+      label='Codex login'
+      title='Codex'
+    >
+      <div className='flex flex-wrap items-center gap-3'>
+        <Badge variant={connected ? 'secondary' : 'outline'}>
+          {connected
+            ? 'Connected'
+            : (auth?.state.replaceAll('_', ' ') ?? 'Loading')}
+        </Badge>
+        <Button
+          disabled={
+            isStarting ||
+            auth?.state === 'starting' ||
+            auth?.state === 'awaiting_authorization'
+          }
+          onClick={onStart}
+          type='button'
+        >
+          {connected
+            ? 'Reconnect Codex'
+            : auth?.state === 'failed'
+              ? 'Retry device login'
+              : 'Connect Codex'}
+        </Button>
+      </div>
+      {awaiting ? (
+        <div className='grid gap-3 rounded-md border border-border bg-background p-4'>
+          <p className='m-0 text-sm text-muted-foreground'>
+            Open the verification page, sign in to ChatGPT, then enter this
+            one-time code:
+          </p>
+          <code className='w-fit rounded bg-muted px-3 py-2 text-lg font-semibold tracking-widest text-foreground'>
+            {auth.userCode}
+          </code>
+          <a
+            className='w-fit text-sm font-medium text-primary underline'
+            href={auth.verificationUrl}
+            rel='noreferrer'
+            target='_blank'
+          >
+            Open Codex verification
+          </a>
+        </div>
+      ) : null}
+      {connected ? (
+        <p className='m-0 text-sm text-muted-foreground'>
+          This server is authenticated and Codex is selected automatically.
+        </p>
+      ) : null}
+      <AuthErrorAlert
+        message={
+          state.status === 'error'
+            ? state.message
+            : auth?.state === 'failed'
+              ? auth.message
+              : ''
+        }
+        title='Codex login failed.'
+      />
+    </SettingsSection>
   )
 }
 

--- a/admin-spa/src/lib/admin-api.test.ts
+++ b/admin-spa/src/lib/admin-api.test.ts
@@ -8,6 +8,7 @@ import {
   getAISettings,
   getAIUsage,
   getClassProgress,
+  getCodexAuthStatus,
   getEmbedConfig,
   getGroupDetail,
   getJoinClass,
@@ -24,6 +25,7 @@ import {
   removeEmbedOrigin,
   sendStudentNudge,
   setTeacherResourceActive,
+  startCodexDeviceAuth,
   submitOnboarding,
   updateAISettings,
   updateEmbedConfig,
@@ -389,6 +391,47 @@ describe('admin dashboard API', () => {
 
     await expect(getAISettings(fetcher)).rejects.toThrow(
       'Invalid AI settings response',
+    )
+  })
+
+  it('reads and starts Codex device authorization', async () => {
+    const awaiting = {
+      state: 'awaiting_authorization',
+      verificationUrl: 'https://auth.openai.com/codex/device',
+      userCode: 'ABCD-1234',
+    }
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ state: 'disconnected' })),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify(awaiting)))
+
+    await expect(getCodexAuthStatus(fetcher)).resolves.toEqual({
+      state: 'disconnected',
+      verificationUrl: '',
+      userCode: '',
+      message: '',
+    })
+    await expect(startCodexDeviceAuth(fetcher)).resolves.toEqual({
+      ...awaiting,
+      message: '',
+    })
+
+    expect(fetcher).toHaveBeenNthCalledWith(1, '/api/admin/ai/codex/auth', {
+      credentials: 'include',
+      cache: 'no-store',
+      headers: {},
+    })
+    expect(fetcher).toHaveBeenNthCalledWith(
+      2,
+      '/api/admin/ai/codex/auth/device',
+      {
+        method: 'POST',
+        credentials: 'include',
+        cache: 'no-store',
+        headers: {},
+      },
     )
   })
 

--- a/admin-spa/src/lib/admin-api.ts
+++ b/admin-spa/src/lib/admin-api.ts
@@ -1,5 +1,6 @@
 import { readClassProgress } from './dashboard-types'
 import { readAISettings } from './ai-settings-types'
+import { readCodexAuthStatus } from './codex-auth-types'
 import { isAIUsageSummary } from './ai-usage-types'
 import { isGroupDetail, isGroupRecord } from './group-types'
 import { isInviteRecord, isUserManagementView } from './user-management-types'
@@ -12,6 +13,7 @@ import { readEmbedConfig } from './embed-config-types'
 import { isTeacherResource } from './teacher-resource-types'
 import type { ClassProgress } from './dashboard-types'
 import type { AISettings, UpdateAISettingsInput } from './ai-settings-types'
+import type { CodexAuthStatus } from './codex-auth-types'
 import type { EmbedConfig, UpdateEmbedConfigInput } from './embed-config-types'
 import type {
   AIUsageSummary,
@@ -172,6 +174,32 @@ export async function updateAISettings(
   }
 
   return settings
+}
+
+/** Returns the server-owned Codex device authorization state. */
+export async function getCodexAuthStatus(
+  fetcher: typeof fetch = fetch,
+): Promise<CodexAuthStatus> {
+  const payload = await fetchJSON('/api/admin/ai/codex/auth', fetcher)
+  const status = readCodexAuthStatus(payload)
+  if (!status) {
+    throw new APIContractError('Invalid Codex auth response')
+  }
+  return status
+}
+
+/** Starts Codex device authorization on the server. */
+export async function startCodexDeviceAuth(
+  fetcher: typeof fetch = fetch,
+): Promise<CodexAuthStatus> {
+  const payload = await fetchJSON('/api/admin/ai/codex/auth/device', fetcher, {
+    method: 'POST',
+  })
+  const status = readCodexAuthStatus(payload)
+  if (!status) {
+    throw new APIContractError('Invalid Codex auth response')
+  }
+  return status
 }
 
 export async function getUserManagement(

--- a/admin-spa/src/lib/codex-auth-types.test.ts
+++ b/admin-spa/src/lib/codex-auth-types.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+
+import { readCodexAuthStatus } from './codex-auth-types'
+
+describe('readCodexAuthStatus', () => {
+  it('accepts a bounded device authorization status', () => {
+    expect(
+      readCodexAuthStatus({
+        state: 'awaiting_authorization',
+        verificationUrl: 'https://auth.openai.com/codex/device',
+        userCode: 'ABCD-1234',
+      }),
+    ).toEqual({
+      state: 'awaiting_authorization',
+      verificationUrl: 'https://auth.openai.com/codex/device',
+      userCode: 'ABCD-1234',
+      message: '',
+    })
+  })
+
+  it('rejects unknown states and malformed fields', () => {
+    expect(readCodexAuthStatus({ state: 'authorized' })).toBeNull()
+    expect(
+      readCodexAuthStatus({ state: 'connected', message: { secret: true } }),
+    ).toBeNull()
+  })
+})

--- a/admin-spa/src/lib/codex-auth-types.ts
+++ b/admin-spa/src/lib/codex-auth-types.ts
@@ -1,0 +1,58 @@
+/** State reported by the server-owned Codex device authorization process. */
+export type CodexAuthState =
+  | 'disconnected'
+  | 'starting'
+  | 'awaiting_authorization'
+  | 'connected'
+  | 'failed'
+
+/** Safe status fields exposed by the Codex device authorization API. */
+export interface CodexAuthStatus {
+  state: CodexAuthState
+  verificationUrl: string
+  userCode: string
+  message: string
+}
+
+function readCodexAuthState(value: unknown): CodexAuthState | null {
+  switch (value) {
+    case 'disconnected':
+    case 'starting':
+    case 'awaiting_authorization':
+    case 'connected':
+    case 'failed':
+      return value
+    default:
+      return null
+  }
+}
+
+function readOptionalString(
+  value: object,
+  property: 'verificationUrl' | 'userCode' | 'message',
+): string | null {
+  const field = Reflect.get(value, property)
+  return field === undefined ? '' : typeof field === 'string' ? field : null
+}
+
+/** Parses a Codex status response and normalizes omitted display fields. */
+export function readCodexAuthStatus(value: unknown): CodexAuthStatus | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null
+  }
+
+  const state = readCodexAuthState(Reflect.get(value, 'state'))
+  const verificationUrl = readOptionalString(value, 'verificationUrl')
+  const userCode = readOptionalString(value, 'userCode')
+  const message = readOptionalString(value, 'message')
+  if (
+    state === null ||
+    verificationUrl === null ||
+    userCode === null ||
+    message === null
+  ) {
+    return null
+  }
+
+  return { state, verificationUrl, userCode, message }
+}

--- a/cmd/server/codex_default_test.go
+++ b/cmd/server/codex_default_test.go
@@ -5,10 +5,9 @@ package main
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"testing"
 
+	"github.com/p-n-ai/pai-bot/internal/ai"
 	"github.com/p-n-ai/pai-bot/internal/platform/airouter"
 	"github.com/p-n-ai/pai-bot/internal/platform/codexauth"
 	"github.com/p-n-ai/pai-bot/internal/platform/config"
@@ -24,6 +23,12 @@ type availableCodexAuth struct{}
 
 func (availableCodexAuth) Refresh(context.Context) error { return nil }
 func (availableCodexAuth) Available() bool               { return true }
+func (availableCodexAuth) Complete(
+	context.Context,
+	ai.CompletionRequest,
+) (ai.CompletionResponse, error) {
+	return ai.CompletionResponse{Content: "ok"}, nil
+}
 
 func (m *memoryRuntimeSettingsUpdater) Update(
 	ctx context.Context,
@@ -77,19 +82,15 @@ func TestSuccessfulDeviceAuthRegistersCodexAsDefaultWithoutEnvToggle(t *testing.
 	home := t.TempDir()
 	aiConfig := config.AIConfig{
 		Codex: config.CodexConfig{
-			Enabled:  true,
-			Home:     home,
-			AuthFile: filepath.Join(home, "auth.json"),
-			Model:    "gpt-test",
+			Enabled: true,
+			Home:    home,
+			Model:   "gpt-test",
 		},
 	}
 	codexAuth := availableCodexAuth{}
 	router := airouter.SetupWithCodexAuth(aiConfig, codexAuth)
-	if router.HasProvider() {
-		t.Fatal("Codex registered before device auth")
-	}
-	if err := os.WriteFile(aiConfig.Codex.AuthFile, []byte(`{"auth_mode":"chatgpt","tokens":{"access_token":"test-token","account_id":"test-account"}}`), 0o600); err != nil {
-		t.Fatal(err)
+	if !router.HasProvider() {
+		t.Fatal("Codex app-server provider was not registered")
 	}
 	store := &memoryRuntimeSettingsUpdater{}
 
@@ -115,9 +116,8 @@ func TestSuccessfulDeviceAuthRegistersCodexAsDefaultWithoutEnvToggle(t *testing.
 func TestCanAwaitCodexDeviceAuthRequiresExecutable(t *testing.T) {
 	home := t.TempDir()
 	cfg := &config.Config{AI: config.AIConfig{Codex: config.CodexConfig{
-		Enabled:  true,
-		Home:     home,
-		AuthFile: filepath.Join(home, "auth.json"),
+		Enabled: true,
+		Home:    home,
 	}}}
 
 	unavailable := codexauth.New(t.Context(), cfg.AI.Codex.Home, "", nil)

--- a/cmd/server/codex_default_test.go
+++ b/cmd/server/codex_default_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/p-n-ai/pai-bot/internal/platform/airouter"
+	"github.com/p-n-ai/pai-bot/internal/platform/config"
+	"github.com/p-n-ai/pai-bot/internal/platform/settings"
+)
+
+type memoryRuntimeSettingsUpdater struct {
+	current settings.Settings
+	updates int
+}
+
+type availableCodexAuth struct{}
+
+func (availableCodexAuth) Refresh(context.Context) error { return nil }
+func (availableCodexAuth) Available() bool               { return true }
+
+func (m *memoryRuntimeSettingsUpdater) Update(
+	ctx context.Context,
+	mutate func(settings.Settings) (settings.Settings, error),
+	apply func(settings.Settings),
+) (settings.Settings, error) {
+	if err := ctx.Err(); err != nil {
+		return settings.Settings{}, err
+	}
+	next, err := mutate(m.current)
+	if err != nil {
+		return settings.Settings{}, err
+	}
+	m.current = next
+	m.updates++
+	if apply != nil {
+		apply(next)
+	}
+	return next, nil
+}
+
+func TestMakeCodexDefaultPreservesOtherSettingsAndApplies(t *testing.T) {
+	store := &memoryRuntimeSettingsUpdater{current: settings.Settings{
+		AI: settings.AISettings{
+			DefaultProvider: "openrouter",
+			OpenRouterModel: "existing-model",
+		},
+		Flags: map[string]bool{"turn_hooks": true},
+	}}
+	var applied settings.Settings
+
+	if err := makeCodexDefault(t.Context(), store, func(next settings.Settings) {
+		applied = next
+	}); err != nil {
+		t.Fatalf("makeCodexDefault() error = %v", err)
+	}
+
+	if store.updates != 1 || store.current.AI.DefaultProvider != "codex" {
+		t.Fatalf("updates/settings = %d/%#v", store.updates, store.current)
+	}
+	if store.current.AI.OpenRouterModel != "existing-model" ||
+		!store.current.Flags["turn_hooks"] {
+		t.Fatalf("unrelated settings changed: %#v", store.current)
+	}
+	if applied.AI.DefaultProvider != "codex" {
+		t.Fatalf("applied settings = %#v, want codex default", applied)
+	}
+}
+
+func TestSuccessfulDeviceAuthRegistersCodexAsDefaultWithoutEnvToggle(t *testing.T) {
+	home := t.TempDir()
+	aiConfig := config.AIConfig{
+		Codex: config.CodexConfig{
+			Enabled:  true,
+			Home:     home,
+			AuthFile: filepath.Join(home, "auth.json"),
+			Model:    "gpt-test",
+		},
+	}
+	codexAuth := availableCodexAuth{}
+	router := airouter.SetupWithCodexAuth(aiConfig, codexAuth)
+	if router.HasProvider() {
+		t.Fatal("Codex registered before device auth")
+	}
+	if err := os.WriteFile(aiConfig.Codex.AuthFile, []byte(`{"auth_mode":"chatgpt","tokens":{"access_token":"test-token","account_id":"test-account"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store := &memoryRuntimeSettingsUpdater{}
+
+	err := makeCodexDefault(t.Context(), store, func(next settings.Settings) {
+		airouter.ApplyWithCodexAuth(
+			router,
+			settings.MergeAI(aiConfig, next),
+			codexAuth,
+		)
+	})
+	if err != nil {
+		t.Fatalf("makeCodexDefault() error = %v", err)
+	}
+
+	order := router.ProviderOrder()
+	if store.current.AI.DefaultProvider != "codex" ||
+		len(order) != 1 ||
+		order[0] != "codex" {
+		t.Fatalf("default/order = %q/%v, want codex first", store.current.AI.DefaultProvider, order)
+	}
+}

--- a/cmd/server/codex_default_test.go
+++ b/cmd/server/codex_default_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/p-n-ai/pai-bot/internal/platform/airouter"
+	"github.com/p-n-ai/pai-bot/internal/platform/codexauth"
 	"github.com/p-n-ai/pai-bot/internal/platform/config"
 	"github.com/p-n-ai/pai-bot/internal/platform/settings"
 )
@@ -108,5 +109,24 @@ func TestSuccessfulDeviceAuthRegistersCodexAsDefaultWithoutEnvToggle(t *testing.
 		len(order) != 1 ||
 		order[0] != "codex" {
 		t.Fatalf("default/order = %q/%v, want codex first", store.current.AI.DefaultProvider, order)
+	}
+}
+
+func TestCanAwaitCodexDeviceAuthRequiresExecutable(t *testing.T) {
+	home := t.TempDir()
+	cfg := &config.Config{AI: config.AIConfig{Codex: config.CodexConfig{
+		Enabled:  true,
+		Home:     home,
+		AuthFile: filepath.Join(home, "auth.json"),
+	}}}
+
+	unavailable := codexauth.New(t.Context(), cfg.AI.Codex.Home, "", nil)
+	if canAwaitCodexDeviceAuth(cfg, unavailable) {
+		t.Fatal("canAwaitCodexDeviceAuth() = true without a Codex executable")
+	}
+
+	available := codexauth.New(t.Context(), cfg.AI.Codex.Home, "/test/codex", nil)
+	if !canAwaitCodexDeviceAuth(cfg, available) {
+		t.Fatal("canAwaitCodexDeviceAuth() = false with configured storage and executable")
 	}
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"os/exec"
 	"os/signal"
 	"strings"
 	"sync"
@@ -24,6 +25,7 @@ import (
 	"github.com/p-n-ai/pai-bot/internal/focusedpagedelivery"
 	"github.com/p-n-ai/pai-bot/internal/platform/airouter"
 	"github.com/p-n-ai/pai-bot/internal/platform/cache"
+	"github.com/p-n-ai/pai-bot/internal/platform/codexauth"
 	"github.com/p-n-ai/pai-bot/internal/platform/config"
 	"github.com/p-n-ai/pai-bot/internal/platform/database"
 	"github.com/p-n-ai/pai-bot/internal/platform/featureflags"
@@ -38,6 +40,26 @@ import (
 
 func focusedPageChannelEnabled(devMode bool, msg chat.InboundMessage) bool {
 	return msg.Channel == "telegram" || (devMode && msg.Channel == "websocket")
+}
+
+type runtimeSettingsUpdater interface {
+	Update(
+		context.Context,
+		func(settings.Settings) (settings.Settings, error),
+		func(settings.Settings),
+	) (settings.Settings, error)
+}
+
+func makeCodexDefault(
+	ctx context.Context,
+	store runtimeSettingsUpdater,
+	applySettings func(settings.Settings),
+) error {
+	_, err := store.Update(ctx, func(current settings.Settings) (settings.Settings, error) {
+		current.AI.DefaultProvider = "codex"
+		return current, nil
+	}, applySettings)
+	return err
 }
 
 func main() {
@@ -94,25 +116,33 @@ func main() {
 				slog.Warn("runtime settings unavailable; using env config", "error", err)
 			}
 
+			codexExecutable, _ := exec.LookPath("codex")
+			codexDeviceAuth := codexauth.New(ctx, cfg.AI.Codex.Home, codexExecutable, nil)
+
 			// Initialize AI router with configured providers.
-			lastApplied := settings.MergeAI(cfg.AI, settingsStore.Current())
-			router := airouter.Setup(lastApplied)
+			initialAI := settings.MergeAI(cfg.AI, settingsStore.Current())
+			router := airouter.SetupWithCodexAuth(initialAI, codexDeviceAuth)
 			if !router.HasProvider() {
 				if cfg.Runtime.DevMode {
 					slog.Warn("no AI providers configured; continuing in dev mode without AI-backed chat responses")
+				} else if cfg.CodexDeviceAuthAvailable() {
+					slog.Warn("no AI providers authenticated; continuing so an admin can connect Codex")
 				} else {
 					slog.Error("no AI providers configured")
 					os.Exit(1)
 				}
 			}
 			applySettings := func(st settings.Settings) {
-				// Applies run in commit order under the store's update lock, so a plain lastApplied variable is safe.
 				merged := settings.MergeAI(cfg.AI, st)
-				if merged == lastApplied {
-					return
-				}
-				lastApplied = merged
-				airouter.Apply(router, merged)
+				airouter.ApplyWithCodexAuth(router, merged, codexDeviceAuth)
+			}
+			var adminCodexDeviceAuth server.CodexDeviceAuth
+			if cfg.AI.Codex.Enabled {
+				codexDeviceAuth.SetOnConnected(func(callbackCtx context.Context) error {
+					return makeCodexDefault(callbackCtx, settingsStore, applySettings)
+				})
+				codexDeviceAuth.Initialize()
+				adminCodexDeviceAuth = codexDeviceAuth
 			}
 
 			var warnFlagOverrides sync.Once
@@ -469,7 +499,7 @@ func main() {
 			}
 
 			// HTTP endpoints.
-			apiHandler := server.NewHandlerWithAdminProviderAndTeacherResources(
+			apiHandler := server.NewHandlerWithAdminProviderAndTeacherResourcesAndCodexAuth(
 				server.NewTenantAdminDataSourceProvider(
 					func(tenantID string) server.AdminDataSource {
 						return adminapi.New(db.Pool, tenantID)
@@ -492,6 +522,7 @@ func main() {
 				settingsStore,
 				applySettings,
 				cfg.Tenant.Mode == "multi",
+				adminCodexDeviceAuth,
 			)
 
 			topMux := server.NewTopMux(server.TopMuxOptions{

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -62,6 +62,13 @@ func makeCodexDefault(
 	return err
 }
 
+func canAwaitCodexDeviceAuth(cfg *config.Config, manager *codexauth.Manager) bool {
+	return cfg != nil &&
+		manager != nil &&
+		cfg.CodexDeviceAuthAvailable() &&
+		manager.Available()
+}
+
 func main() {
 	cfg, err := config.Load()
 	if err != nil {
@@ -125,7 +132,7 @@ func main() {
 			if !router.HasProvider() {
 				if cfg.Runtime.DevMode {
 					slog.Warn("no AI providers configured; continuing in dev mode without AI-backed chat responses")
-				} else if cfg.CodexDeviceAuthAvailable() {
+				} else if canAwaitCodexDeviceAuth(cfg, codexDeviceAuth) {
 					slog.Warn("no AI providers authenticated; continuing so an admin can connect Codex")
 				} else {
 					slog.Error("no AI providers configured")

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,4 +1,16 @@
-# Stage 1: Build Go binary
+ARG CODEX_CLI_VERSION=0.145.0
+
+# Package the native Codex binary without carrying Node into the runtime image.
+FROM node:22-alpine AS codex-cli
+ARG CODEX_CLI_VERSION
+RUN npm install --global --omit=dev --no-audit --no-fund "@openai/codex@${CODEX_CLI_VERSION}" \
+    && codex --version \
+    && codex_path="$(find /usr/local/lib/node_modules/@openai/codex -type f -path '*/bin/codex' | head -n 1)" \
+    && test -n "${codex_path}" \
+    && cp "${codex_path}" /codex \
+    && chmod 0755 /codex
+
+# Build the Go binaries.
 FROM golang:1.26-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
@@ -20,5 +32,7 @@ COPY --from=builder /pai-terminal-nudge /pai-terminal-nudge
 COPY --from=builder /pai-seed /pai-seed
 COPY --from=builder /app/oss /oss
 COPY --from=builder /app/migrations /migrations
+COPY --from=codex-cli /codex /usr/local/bin/codex
+RUN codex --version
 EXPOSE 8080
 ENTRYPOINT ["/pai-server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,9 +57,11 @@ services:
       LEARN_DATABASE_URL: postgres://pai:${POSTGRES_PASSWORD:-pai}@postgres:5432/pai?sslmode=disable
       LEARN_CACHE_URL: redis://dragonfly:6379
       LEARN_AI_OLLAMA_URL: http://ollama:11434
+      LEARN_AI_CODEX_HOME: /var/lib/pai-bot/codex
       LEARN_WHATSAPP_MEOW_DB: "file:/data/whatsmeow.db?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)"
     volumes:
       - whatsmeow-data:/data
+      - codex-data:/var/lib/pai-bot/codex
     dns:
       - 8.8.8.8
       - 1.1.1.1
@@ -123,5 +125,6 @@ volumes:
   caddy_data:
   caddy_config:
   ollama-data:
+  codex-data:
   goose-gomod:
   goose-gocache:

--- a/internal/ai/provider_codex.go
+++ b/internal/ai/provider_codex.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -27,12 +28,15 @@ const (
 	defaultCodexAuthBaseURL = "https://auth.openai.com"
 	defaultCodexModel       = "gpt-5.4"
 	codexOAuthClientID      = "app_EMoamEEZ73f0CkXaXp7hrann"
+	maxCodexAuthBytes       = 1 << 20
 )
 
 type CodexProvider struct {
 	baseURL     string
 	authBaseURL string
 	client      *http.Client
+	authFile    string
+	refresher   CodexCredentialRefresher
 
 	mu                sync.Mutex
 	accessToken       string
@@ -42,6 +46,23 @@ type CodexProvider struct {
 	expiresAt         time.Time
 	refreshing        chan struct{}
 	refreshErr        error
+}
+
+// CodexCredentialRefresher asks Codex app-server to refresh its managed
+// ChatGPT login before PaiBot reloads the isolated credential file.
+type CodexCredentialRefresher interface {
+	Refresh(context.Context) error
+}
+
+type codexAuthFile struct {
+	AuthMode string      `json:"auth_mode"`
+	Tokens   codexTokens `json:"tokens"`
+}
+
+type codexTokens struct {
+	AccessToken string `json:"access_token"`
+	AccountID   string `json:"account_id"`
+	IDToken     string `json:"id_token"`
 }
 
 type CodexOption func(*CodexProvider)
@@ -110,6 +131,42 @@ func NewCodexProvider(accessToken string, opts ...CodexOption) (*CodexProvider, 
 	}
 	if err == nil {
 		p.expiresAt = expiresAt
+	}
+	return p, nil
+}
+
+// NewManagedCodexProvider creates a provider backed by a ChatGPT login owned
+// by Codex app-server in an isolated server directory.
+func NewManagedCodexProvider(
+	authFile string,
+	refresher CodexCredentialRefresher,
+	opts ...CodexOption,
+) (*CodexProvider, error) {
+	authFile = strings.TrimSpace(authFile)
+	if authFile == "" {
+		return nil, errors.New("codex managed auth is not configured")
+	}
+	if refresher == nil {
+		return nil, errors.New("codex managed login refresh is unavailable")
+	}
+	p := &CodexProvider{
+		authFile:    authFile,
+		refresher:   refresher,
+		baseURL:     defaultCodexBaseURL,
+		authBaseURL: defaultCodexAuthBaseURL,
+		client:      http.DefaultClient,
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	if p.client == nil {
+		return nil, errors.New("codex HTTP client is required")
+	}
+	if p.baseURL == "" {
+		return nil, errors.New("codex base URL is required")
+	}
+	if _, err := p.readManagedCredentials(); err != nil {
+		return nil, err
 	}
 	return p, nil
 }
@@ -464,6 +521,17 @@ func codexHTTPResponse(response *http.Response) (*http.Response, error) {
 }
 
 func (p *CodexProvider) credentials(ctx context.Context) (string, string, error) {
+	if p.authFile != "" {
+		if err := p.refresher.Refresh(ctx); err != nil {
+			return "", "", errors.New("refresh Codex managed login")
+		}
+		credentials, err := p.readManagedCredentials()
+		if err != nil {
+			return "", "", err
+		}
+		return credentials.accessToken, credentials.accountID, nil
+	}
+
 	p.mu.Lock()
 	token := p.accessToken
 	expired := !p.expiresAt.IsZero() && !time.Now().Add(30*time.Second).Before(p.expiresAt)
@@ -479,6 +547,13 @@ func (p *CodexProvider) credentials(ctx context.Context) (string, string, error)
 }
 
 func (p *CodexProvider) refreshCredentials(ctx context.Context, staleToken string, force bool) error {
+	if p.authFile != "" {
+		if err := p.refresher.Refresh(ctx); err != nil {
+			return errors.New("refresh Codex managed login")
+		}
+		return nil
+	}
+
 	for {
 		p.mu.Lock()
 		if p.accessToken != staleToken {
@@ -545,6 +620,57 @@ type codexCredentials struct {
 	refreshToken string
 	accountID    string
 	expiresAt    time.Time
+}
+
+func (p *CodexProvider) readManagedCredentials() (codexCredentials, error) {
+	file, err := os.Open(p.authFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return codexCredentials{}, errors.New("Codex login is not connected; connect it in Admin")
+		}
+		return codexCredentials{}, errors.New("read Codex managed login")
+	}
+	defer func() { _ = file.Close() }()
+
+	data, err := io.ReadAll(io.LimitReader(file, maxCodexAuthBytes+1))
+	if err != nil {
+		return codexCredentials{}, errors.New("read Codex managed login")
+	}
+	if len(data) > maxCodexAuthBytes {
+		return codexCredentials{}, errors.New("Codex managed login is too large")
+	}
+	var auth codexAuthFile
+	if err := json.Unmarshal(data, &auth); err != nil {
+		return codexCredentials{}, errors.New("Codex managed login is malformed")
+	}
+	if !strings.EqualFold(strings.TrimSpace(auth.AuthMode), "chatgpt") {
+		return codexCredentials{}, errors.New("Codex ChatGPT login is not connected; connect it in Admin")
+	}
+	accessToken := strings.TrimSpace(auth.Tokens.AccessToken)
+	if accessToken == "" {
+		return codexCredentials{}, errors.New("Codex ChatGPT login has no access token; reconnect it in Admin")
+	}
+	accountID := strings.TrimSpace(auth.Tokens.AccountID)
+	tokenAccountID, expiresAt, tokenErr := codexJWTMetadata(accessToken)
+	if accountID == "" && tokenErr == nil {
+		accountID = tokenAccountID
+	}
+	if accountID == "" && strings.TrimSpace(auth.Tokens.IDToken) != "" {
+		if idTokenAccountID, _, err := codexJWTMetadata(strings.TrimSpace(auth.Tokens.IDToken)); err == nil {
+			accountID = idTokenAccountID
+		}
+	}
+	if accountID == "" {
+		return codexCredentials{}, errors.New("Codex ChatGPT login has no account ID; reconnect it in Admin")
+	}
+	if tokenErr == nil && !expiresAt.IsZero() && !time.Now().Add(30*time.Second).Before(expiresAt) {
+		return codexCredentials{}, errors.New("Codex login is expired; reconnect it in Admin")
+	}
+	return codexCredentials{
+		accessToken: accessToken,
+		accountID:   accountID,
+		expiresAt:   expiresAt,
+	}, nil
 }
 
 func (p *CodexProvider) requestTokenRefresh(ctx context.Context, refreshToken string) (codexCredentials, error) {

--- a/internal/ai/provider_codex.go
+++ b/internal/ai/provider_codex.go
@@ -14,7 +14,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -28,15 +27,12 @@ const (
 	defaultCodexAuthBaseURL = "https://auth.openai.com"
 	defaultCodexModel       = "gpt-5.4"
 	codexOAuthClientID      = "app_EMoamEEZ73f0CkXaXp7hrann"
-	maxCodexAuthBytes       = 1 << 20
 )
 
 type CodexProvider struct {
 	baseURL     string
 	authBaseURL string
 	client      *http.Client
-	authFile    string
-	refresher   CodexCredentialRefresher
 
 	mu                sync.Mutex
 	accessToken       string
@@ -46,23 +42,6 @@ type CodexProvider struct {
 	expiresAt         time.Time
 	refreshing        chan struct{}
 	refreshErr        error
-}
-
-// CodexCredentialRefresher asks Codex app-server to refresh its managed
-// ChatGPT login before PaiBot reloads the isolated credential file.
-type CodexCredentialRefresher interface {
-	Refresh(context.Context) error
-}
-
-type codexAuthFile struct {
-	AuthMode string      `json:"auth_mode"`
-	Tokens   codexTokens `json:"tokens"`
-}
-
-type codexTokens struct {
-	AccessToken string `json:"access_token"`
-	AccountID   string `json:"account_id"`
-	IDToken     string `json:"id_token"`
 }
 
 type CodexOption func(*CodexProvider)
@@ -131,42 +110,6 @@ func NewCodexProvider(accessToken string, opts ...CodexOption) (*CodexProvider, 
 	}
 	if err == nil {
 		p.expiresAt = expiresAt
-	}
-	return p, nil
-}
-
-// NewManagedCodexProvider creates a provider backed by a ChatGPT login owned
-// by Codex app-server in an isolated server directory.
-func NewManagedCodexProvider(
-	authFile string,
-	refresher CodexCredentialRefresher,
-	opts ...CodexOption,
-) (*CodexProvider, error) {
-	authFile = strings.TrimSpace(authFile)
-	if authFile == "" {
-		return nil, errors.New("codex managed auth is not configured")
-	}
-	if refresher == nil {
-		return nil, errors.New("codex managed login refresh is unavailable")
-	}
-	p := &CodexProvider{
-		authFile:    authFile,
-		refresher:   refresher,
-		baseURL:     defaultCodexBaseURL,
-		authBaseURL: defaultCodexAuthBaseURL,
-		client:      http.DefaultClient,
-	}
-	for _, opt := range opts {
-		opt(p)
-	}
-	if p.client == nil {
-		return nil, errors.New("codex HTTP client is required")
-	}
-	if p.baseURL == "" {
-		return nil, errors.New("codex base URL is required")
-	}
-	if _, err := p.readManagedCredentials(); err != nil {
-		return nil, err
 	}
 	return p, nil
 }
@@ -521,17 +464,6 @@ func codexHTTPResponse(response *http.Response) (*http.Response, error) {
 }
 
 func (p *CodexProvider) credentials(ctx context.Context) (string, string, error) {
-	if p.authFile != "" {
-		if err := p.refresher.Refresh(ctx); err != nil {
-			return "", "", errors.New("refresh Codex managed login")
-		}
-		credentials, err := p.readManagedCredentials()
-		if err != nil {
-			return "", "", err
-		}
-		return credentials.accessToken, credentials.accountID, nil
-	}
-
 	p.mu.Lock()
 	token := p.accessToken
 	expired := !p.expiresAt.IsZero() && !time.Now().Add(30*time.Second).Before(p.expiresAt)
@@ -547,13 +479,6 @@ func (p *CodexProvider) credentials(ctx context.Context) (string, string, error)
 }
 
 func (p *CodexProvider) refreshCredentials(ctx context.Context, staleToken string, force bool) error {
-	if p.authFile != "" {
-		if err := p.refresher.Refresh(ctx); err != nil {
-			return errors.New("refresh Codex managed login")
-		}
-		return nil
-	}
-
 	for {
 		p.mu.Lock()
 		if p.accessToken != staleToken {
@@ -620,57 +545,6 @@ type codexCredentials struct {
 	refreshToken string
 	accountID    string
 	expiresAt    time.Time
-}
-
-func (p *CodexProvider) readManagedCredentials() (codexCredentials, error) {
-	file, err := os.Open(p.authFile)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return codexCredentials{}, errors.New("Codex login is not connected; connect it in Admin")
-		}
-		return codexCredentials{}, errors.New("read Codex managed login")
-	}
-	defer func() { _ = file.Close() }()
-
-	data, err := io.ReadAll(io.LimitReader(file, maxCodexAuthBytes+1))
-	if err != nil {
-		return codexCredentials{}, errors.New("read Codex managed login")
-	}
-	if len(data) > maxCodexAuthBytes {
-		return codexCredentials{}, errors.New("Codex managed login is too large")
-	}
-	var auth codexAuthFile
-	if err := json.Unmarshal(data, &auth); err != nil {
-		return codexCredentials{}, errors.New("Codex managed login is malformed")
-	}
-	if !strings.EqualFold(strings.TrimSpace(auth.AuthMode), "chatgpt") {
-		return codexCredentials{}, errors.New("Codex ChatGPT login is not connected; connect it in Admin")
-	}
-	accessToken := strings.TrimSpace(auth.Tokens.AccessToken)
-	if accessToken == "" {
-		return codexCredentials{}, errors.New("Codex ChatGPT login has no access token; reconnect it in Admin")
-	}
-	accountID := strings.TrimSpace(auth.Tokens.AccountID)
-	tokenAccountID, expiresAt, tokenErr := codexJWTMetadata(accessToken)
-	if accountID == "" && tokenErr == nil {
-		accountID = tokenAccountID
-	}
-	if accountID == "" && strings.TrimSpace(auth.Tokens.IDToken) != "" {
-		if idTokenAccountID, _, err := codexJWTMetadata(strings.TrimSpace(auth.Tokens.IDToken)); err == nil {
-			accountID = idTokenAccountID
-		}
-	}
-	if accountID == "" {
-		return codexCredentials{}, errors.New("Codex ChatGPT login has no account ID; reconnect it in Admin")
-	}
-	if tokenErr == nil && !expiresAt.IsZero() && !time.Now().Add(30*time.Second).Before(expiresAt) {
-		return codexCredentials{}, errors.New("Codex login is expired; reconnect it in Admin")
-	}
-	return codexCredentials{
-		accessToken: accessToken,
-		accountID:   accountID,
-		expiresAt:   expiresAt,
-	}, nil
 }
 
 func (p *CodexProvider) requestTokenRefresh(ctx context.Context, refreshToken string) (codexCredentials, error) {

--- a/internal/ai/provider_codex_appserver.go
+++ b/internal/ai/provider_codex_appserver.go
@@ -1,0 +1,77 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ai
+
+import (
+	"context"
+	"errors"
+	"strings"
+)
+
+// CodexAppServerClient executes completions through a Codex app-server session.
+// The implementation owns authentication; PaiBot never reads Codex credentials.
+type CodexAppServerClient interface {
+	Complete(context.Context, CompletionRequest) (CompletionResponse, error)
+	Refresh(context.Context) error
+}
+
+type codexAppServerProvider struct {
+	client CodexAppServerClient
+	model  string
+}
+
+func NewCodexAppServerProvider(client CodexAppServerClient, model string) Provider {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		model = defaultCodexModel
+	}
+	return &codexAppServerProvider{client: client, model: model}
+}
+
+func (p *codexAppServerProvider) Complete(
+	ctx context.Context,
+	req CompletionRequest,
+) (CompletionResponse, error) {
+	if p.client == nil {
+		return CompletionResponse{}, errors.New("Codex app-server is unavailable")
+	}
+	if strings.TrimSpace(req.Model) == "" {
+		req.Model = p.model
+	}
+	return p.client.Complete(ctx, req)
+}
+
+func (p *codexAppServerProvider) StreamComplete(
+	ctx context.Context,
+	req CompletionRequest,
+) (<-chan StreamChunk, error) {
+	chunks := make(chan StreamChunk, 1)
+	go func() {
+		defer close(chunks)
+		response, err := p.Complete(ctx, req)
+		if err != nil {
+			chunks <- StreamChunk{Error: err, Done: true}
+			return
+		}
+		chunks <- StreamChunk{Content: response.Content, Done: true}
+	}()
+	return chunks, nil
+}
+
+func (p *codexAppServerProvider) Models() []ModelInfo {
+	return []ModelInfo{{
+		ID:          p.model,
+		Name:        "Codex " + p.model,
+		Description: "Codex via server-managed device login",
+	}}
+}
+
+func (p *codexAppServerProvider) HealthCheck(ctx context.Context) error {
+	if p.client == nil {
+		return errors.New("Codex app-server is unavailable")
+	}
+	return p.client.Refresh(ctx)
+}
+
+var _ Provider = (*codexAppServerProvider)(nil)

--- a/internal/ai/provider_codex_appserver.go
+++ b/internal/ai/provider_codex_appserver.go
@@ -12,6 +12,7 @@ import (
 // CodexAppServerClient executes completions through a Codex app-server session.
 // The implementation owns authentication; PaiBot never reads Codex credentials.
 type CodexAppServerClient interface {
+	Available() bool
 	Complete(context.Context, CompletionRequest) (CompletionResponse, error)
 	Refresh(context.Context) error
 }
@@ -34,7 +35,7 @@ func (p *codexAppServerProvider) Complete(
 	req CompletionRequest,
 ) (CompletionResponse, error) {
 	if p.client == nil {
-		return CompletionResponse{}, errors.New("Codex app-server is unavailable")
+		return CompletionResponse{}, errors.New("codex app-server is unavailable")
 	}
 	if strings.TrimSpace(req.Model) == "" {
 		req.Model = p.model
@@ -69,7 +70,7 @@ func (p *codexAppServerProvider) Models() []ModelInfo {
 
 func (p *codexAppServerProvider) HealthCheck(ctx context.Context) error {
 	if p.client == nil {
-		return errors.New("Codex app-server is unavailable")
+		return errors.New("codex app-server is unavailable")
 	}
 	return p.client.Refresh(ctx)
 }

--- a/internal/ai/provider_codex_appserver_test.go
+++ b/internal/ai/provider_codex_appserver_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ai
+
+import (
+	"context"
+	"testing"
+)
+
+type recordingCodexAppServer struct {
+	request CompletionRequest
+}
+
+func (*recordingCodexAppServer) Available() bool { return true }
+
+func (client *recordingCodexAppServer) Complete(
+	_ context.Context,
+	request CompletionRequest,
+) (CompletionResponse, error) {
+	client.request = request
+	return CompletionResponse{
+		Content:      "connected through app-server",
+		Model:        request.Model,
+		InputTokens:  12,
+		OutputTokens: 4,
+	}, nil
+}
+
+func (*recordingCodexAppServer) Refresh(context.Context) error { return nil }
+
+func TestCodexAppServerProviderUsesConfiguredDefaultModel(t *testing.T) {
+	client := &recordingCodexAppServer{}
+	provider := NewCodexAppServerProvider(client, "gpt-test")
+
+	response, err := provider.Complete(t.Context(), CompletionRequest{
+		Messages: []Message{{Role: "user", Content: "hello"}},
+	})
+
+	if err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	if client.request.Model != "gpt-test" {
+		t.Fatalf("client request model = %q, want gpt-test", client.request.Model)
+	}
+	if response.Content != "connected through app-server" ||
+		response.Model != "gpt-test" ||
+		response.TotalTokens() != 16 {
+		t.Fatalf("Complete() response = %#v", response)
+	}
+}
+
+func TestCodexAppServerProviderPreservesExplicitModel(t *testing.T) {
+	client := &recordingCodexAppServer{}
+	provider := NewCodexAppServerProvider(client, "gpt-default")
+
+	if _, err := provider.Complete(t.Context(), CompletionRequest{Model: "gpt-explicit"}); err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	if client.request.Model != "gpt-explicit" {
+		t.Fatalf("client request model = %q, want gpt-explicit", client.request.Model)
+	}
+}
+
+func TestCodexAppServerProviderRejectsMissingClient(t *testing.T) {
+	provider := NewCodexAppServerProvider(nil, "")
+
+	_, err := provider.Complete(t.Context(), CompletionRequest{})
+
+	if err == nil || err.Error() != "codex app-server is unavailable" {
+		t.Fatalf("Complete() error = %v", err)
+	}
+}
+
+func TestCodexAppServerProviderStreamsOneFinalChunk(t *testing.T) {
+	client := &recordingCodexAppServer{}
+	provider := NewCodexAppServerProvider(client, "gpt-test")
+
+	chunks, err := provider.StreamComplete(t.Context(), CompletionRequest{})
+	if err != nil {
+		t.Fatalf("StreamComplete() error = %v", err)
+	}
+	chunk, ok := <-chunks
+	if !ok || chunk.Content != "connected through app-server" || !chunk.Done || chunk.Error != nil {
+		t.Fatalf("stream chunk = %#v, open = %v", chunk, ok)
+	}
+	if _, open := <-chunks; open {
+		t.Fatal("stream returned more than one chunk")
+	}
+}

--- a/internal/ai/provider_codex_test.go
+++ b/internal/ai/provider_codex_test.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -616,6 +618,84 @@ func TestCodexProviderRefreshesAndRetriesAfterAuthRejection(t *testing.T) {
 	}
 }
 
+type testCodexCredentialRefresher struct {
+	calls   atomic.Int32
+	refresh func() error
+}
+
+func (r *testCodexCredentialRefresher) Refresh(context.Context) error {
+	r.calls.Add(1)
+	if r.refresh == nil {
+		return nil
+	}
+	return r.refresh()
+}
+
+func TestManagedCodexProviderRefreshesLoginAndPreservesNativeContinuation(t *testing.T) {
+	authFile := filepath.Join(t.TempDir(), "auth.json")
+	writeManagedCodexAuth(t, authFile, "old-token", "account-123")
+	refresher := &testCodexCredentialRefresher{
+		refresh: func() error {
+			writeManagedCodexAuth(t, authFile, "fresh-token", "account-123")
+			return nil
+		},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertCodexHeaders(t, r, "fresh-token", "account-123")
+		writeCodexSSE(w,
+			`{"type":"response.output_item.done","output_index":0,"item":{"type":"reasoning","id":"rs-managed","encrypted_content":"encrypted","summary":[{"type":"summary_text","text":"Use the lookup tool."}]}}`,
+			`{"type":"response.output_item.done","output_index":1,"item":{"type":"function_call","id":"fc-managed","call_id":"call-managed","name":"lookup","arguments":"{\"topic\":\"fractions\"}"}}`,
+			`{"type":"response.completed","response":{"id":"resp-managed","model":"gpt-codex-test","status":"completed","output":[{"type":"reasoning","id":"rs-managed","encrypted_content":"encrypted","summary":[{"type":"summary_text","text":"Use the lookup tool."}]},{"type":"function_call","id":"fc-managed","call_id":"call-managed","name":"lookup","arguments":"{\"topic\":\"fractions\"}"}]}}`,
+		)
+	}))
+	t.Cleanup(server.Close)
+
+	provider, err := NewManagedCodexProvider(
+		authFile,
+		refresher,
+		WithCodexBaseURL(server.URL),
+		WithCodexHTTPClient(server.Client()),
+	)
+	if err != nil {
+		t.Fatalf("NewManagedCodexProvider() error = %v", err)
+	}
+	response, err := provider.CompleteNative(t.Context(), "gpt-codex-test", llm.Context{
+		Messages: []llm.Message{llm.UserText("Help me.")},
+		Tools: []llm.Tool{{
+			Name:       "lookup",
+			Parameters: json.RawMessage(`{"type":"object","properties":{"topic":{"type":"string"}}}`),
+		}},
+	}, nil)
+	if err != nil {
+		t.Fatalf("CompleteNative() error = %v", err)
+	}
+	if refresher.calls.Load() != 1 {
+		t.Fatalf("Refresh() calls = %d, want 1", refresher.calls.Load())
+	}
+	if len(response.Content) != 2 {
+		t.Fatalf("content = %#v", response.Content)
+	}
+	thinking, ok := response.Content[0].(llm.ThinkingContent)
+	if !ok || thinking.Thinking != "Use the lookup tool." || !strings.Contains(thinking.Signature, "encrypted") {
+		t.Fatalf("thinking = %#v", response.Content[0])
+	}
+	call, ok := response.Content[1].(llm.ToolCall)
+	if !ok || call.ID != "call-managed|fc-managed" || call.Arguments["topic"] != "fractions" {
+		t.Fatalf("tool call = %#v", response.Content[1])
+	}
+}
+
+func TestManagedCodexProviderErrorDoesNotExposeAuthPath(t *testing.T) {
+	authFile := filepath.Join(t.TempDir(), "private-auth.json")
+	_, err := NewManagedCodexProvider(authFile, &testCodexCredentialRefresher{})
+	if err == nil {
+		t.Fatal("NewManagedCodexProvider() error = nil")
+	}
+	if strings.Contains(err.Error(), authFile) {
+		t.Fatalf("error exposed auth path: %v", err)
+	}
+}
+
 func TestCodexProviderStreamCompleteEmitsSSEDeltas(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		writeCodexSSE(w,
@@ -684,6 +764,23 @@ func TestCodexProviderPreservesMultipleMessageOutputItems(t *testing.T) {
 	}
 	if text.String() != "AlphaBeta" {
 		t.Fatalf("stream content = %q", text.String())
+	}
+}
+
+func writeManagedCodexAuth(t *testing.T, path, token, accountID string) {
+	t.Helper()
+	data, err := json.Marshal(codexAuthFile{
+		AuthMode: "chatgpt",
+		Tokens: codexTokens{
+			AccessToken: token,
+			AccountID:   accountID,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/ai/provider_codex_test.go
+++ b/internal/ai/provider_codex_test.go
@@ -11,8 +11,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -618,84 +616,6 @@ func TestCodexProviderRefreshesAndRetriesAfterAuthRejection(t *testing.T) {
 	}
 }
 
-type testCodexCredentialRefresher struct {
-	calls   atomic.Int32
-	refresh func() error
-}
-
-func (r *testCodexCredentialRefresher) Refresh(context.Context) error {
-	r.calls.Add(1)
-	if r.refresh == nil {
-		return nil
-	}
-	return r.refresh()
-}
-
-func TestManagedCodexProviderRefreshesLoginAndPreservesNativeContinuation(t *testing.T) {
-	authFile := filepath.Join(t.TempDir(), "auth.json")
-	writeManagedCodexAuth(t, authFile, "old-token", "account-123")
-	refresher := &testCodexCredentialRefresher{
-		refresh: func() error {
-			writeManagedCodexAuth(t, authFile, "fresh-token", "account-123")
-			return nil
-		},
-	}
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assertCodexHeaders(t, r, "fresh-token", "account-123")
-		writeCodexSSE(w,
-			`{"type":"response.output_item.done","output_index":0,"item":{"type":"reasoning","id":"rs-managed","encrypted_content":"encrypted","summary":[{"type":"summary_text","text":"Use the lookup tool."}]}}`,
-			`{"type":"response.output_item.done","output_index":1,"item":{"type":"function_call","id":"fc-managed","call_id":"call-managed","name":"lookup","arguments":"{\"topic\":\"fractions\"}"}}`,
-			`{"type":"response.completed","response":{"id":"resp-managed","model":"gpt-codex-test","status":"completed","output":[{"type":"reasoning","id":"rs-managed","encrypted_content":"encrypted","summary":[{"type":"summary_text","text":"Use the lookup tool."}]},{"type":"function_call","id":"fc-managed","call_id":"call-managed","name":"lookup","arguments":"{\"topic\":\"fractions\"}"}]}}`,
-		)
-	}))
-	t.Cleanup(server.Close)
-
-	provider, err := NewManagedCodexProvider(
-		authFile,
-		refresher,
-		WithCodexBaseURL(server.URL),
-		WithCodexHTTPClient(server.Client()),
-	)
-	if err != nil {
-		t.Fatalf("NewManagedCodexProvider() error = %v", err)
-	}
-	response, err := provider.CompleteNative(t.Context(), "gpt-codex-test", llm.Context{
-		Messages: []llm.Message{llm.UserText("Help me.")},
-		Tools: []llm.Tool{{
-			Name:       "lookup",
-			Parameters: json.RawMessage(`{"type":"object","properties":{"topic":{"type":"string"}}}`),
-		}},
-	}, nil)
-	if err != nil {
-		t.Fatalf("CompleteNative() error = %v", err)
-	}
-	if refresher.calls.Load() != 1 {
-		t.Fatalf("Refresh() calls = %d, want 1", refresher.calls.Load())
-	}
-	if len(response.Content) != 2 {
-		t.Fatalf("content = %#v", response.Content)
-	}
-	thinking, ok := response.Content[0].(llm.ThinkingContent)
-	if !ok || thinking.Thinking != "Use the lookup tool." || !strings.Contains(thinking.Signature, "encrypted") {
-		t.Fatalf("thinking = %#v", response.Content[0])
-	}
-	call, ok := response.Content[1].(llm.ToolCall)
-	if !ok || call.ID != "call-managed|fc-managed" || call.Arguments["topic"] != "fractions" {
-		t.Fatalf("tool call = %#v", response.Content[1])
-	}
-}
-
-func TestManagedCodexProviderErrorDoesNotExposeAuthPath(t *testing.T) {
-	authFile := filepath.Join(t.TempDir(), "private-auth.json")
-	_, err := NewManagedCodexProvider(authFile, &testCodexCredentialRefresher{})
-	if err == nil {
-		t.Fatal("NewManagedCodexProvider() error = nil")
-	}
-	if strings.Contains(err.Error(), authFile) {
-		t.Fatalf("error exposed auth path: %v", err)
-	}
-}
-
 func TestCodexProviderStreamCompleteEmitsSSEDeltas(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		writeCodexSSE(w,
@@ -764,23 +684,6 @@ func TestCodexProviderPreservesMultipleMessageOutputItems(t *testing.T) {
 	}
 	if text.String() != "AlphaBeta" {
 		t.Fatalf("stream content = %q", text.String())
-	}
-}
-
-func writeManagedCodexAuth(t *testing.T, path, token, accountID string) {
-	t.Helper()
-	data, err := json.Marshal(codexAuthFile{
-		AuthMode: "chatgpt",
-		Tokens: codexTokens{
-			AccessToken: token,
-			AccountID:   accountID,
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(path, data, 0o600); err != nil {
-		t.Fatal(err)
 	}
 }
 

--- a/internal/platform/airouter/setup.go
+++ b/internal/platform/airouter/setup.go
@@ -21,16 +21,26 @@ func ProviderNames() []string {
 // Setup builds an AI router from env-backed config, honoring a preferred
 // default provider and per-provider default model selections.
 func Setup(cfg config.AIConfig) *ai.Router {
+	return SetupWithCodexAuth(cfg, nil)
+}
+
+// SetupWithCodexAuth builds a router whose Codex provider refreshes through app-server.
+func SetupWithCodexAuth(cfg config.AIConfig, codexAuth ai.CodexCredentialRefresher) *ai.Router {
 	router := ai.NewRouter()
-	Apply(router, cfg)
+	ApplyWithCodexAuth(router, cfg, codexAuth)
 	return router
 }
 
 // Apply replaces the router's provider set from cfg; providers with no config (e.g. a cleared API key) unregister.
 func Apply(router *ai.Router, cfg config.AIConfig) {
+	ApplyWithCodexAuth(router, cfg, nil)
+}
+
+// ApplyWithCodexAuth replaces providers and gives Codex its managed-session refresher.
+func ApplyWithCodexAuth(router *ai.Router, cfg config.AIConfig, codexAuth ai.CodexCredentialRefresher) {
 	var regs []ai.ProviderRegistration
 	for _, name := range providerOrder(cfg.DefaultProvider) {
-		reg, ok := buildProvider(name, cfg)
+		reg, ok := buildProviderWithCodexAuth(name, cfg, codexAuth)
 		if !ok {
 			continue
 		}
@@ -46,7 +56,26 @@ func WouldRegister(name string, cfg config.AIConfig) bool {
 	return ok
 }
 
+// HasProviderConfiguration reports whether name has credentials or managed
+// login state that a fully wired runtime can register.
+func HasProviderConfiguration(name string, cfg config.AIConfig) bool {
+	if name == "codex" &&
+		cfg.Codex.Enabled &&
+		cfg.Codex.Authenticated() {
+		return true
+	}
+	return WouldRegister(name, cfg)
+}
+
 func buildProvider(name string, cfg config.AIConfig) (ai.ProviderRegistration, bool) {
+	return buildProviderWithCodexAuth(name, cfg, nil)
+}
+
+func buildProviderWithCodexAuth(
+	name string,
+	cfg config.AIConfig,
+	codexAuth ai.CodexCredentialRefresher,
+) (ai.ProviderRegistration, bool) {
 	switch name {
 	case "mock":
 		if cfg.Mock.Response == "" {
@@ -58,20 +87,6 @@ func buildProvider(name string, cfg config.AIConfig) (ai.ProviderRegistration, b
 			return ai.ProviderRegistration{}, false
 		}
 		return ai.ProviderRegistration{Name: name, Provider: ai.NewOpenAIProvider(cfg.OpenAI.APIKey), DefaultModel: cfg.OpenAI.Model}, true
-	case "codex":
-		if strings.TrimSpace(cfg.Codex.AccessToken) == "" {
-			return ai.ProviderRegistration{}, false
-		}
-		provider, err := ai.NewCodexProvider(
-			cfg.Codex.AccessToken,
-			ai.WithCodexRefreshToken(cfg.Codex.RefreshToken),
-			ai.WithCodexAccountID(cfg.Codex.AccountID),
-		)
-		if err != nil {
-			slog.Warn("failed to create Codex provider", "error", err)
-			return ai.ProviderRegistration{}, false
-		}
-		return ai.ProviderRegistration{Name: name, Provider: provider, DefaultModel: cfg.Codex.Model}, true
 	case "anthropic":
 		if cfg.Anthropic.APIKey == "" {
 			return ai.ProviderRegistration{}, false
@@ -102,6 +117,33 @@ func buildProvider(name string, cfg config.AIConfig) (ai.ProviderRegistration, b
 			return ai.ProviderRegistration{}, false
 		}
 		return ai.ProviderRegistration{Name: name, Provider: ai.NewOpenRouterLLMAdapter(cfg.OpenRouter.APIKey), DefaultModel: cfg.OpenRouter.Model}, true
+	case "codex":
+		if cfg.Codex.Enabled && cfg.Codex.Authenticated() {
+			availability, ok := codexAuth.(interface{ Available() bool })
+			if codexAuth == nil || !ok || !availability.Available() {
+				slog.Warn("Codex provider not registered; Codex app-server is unavailable")
+				return ai.ProviderRegistration{}, false
+			}
+			provider, err := ai.NewManagedCodexProvider(cfg.Codex.AuthFile, codexAuth)
+			if err != nil {
+				slog.Warn("failed to create managed Codex provider", "error", err)
+				return ai.ProviderRegistration{}, false
+			}
+			return ai.ProviderRegistration{Name: name, Provider: provider, DefaultModel: cfg.Codex.Model}, true
+		}
+		if strings.TrimSpace(cfg.Codex.AccessToken) == "" {
+			return ai.ProviderRegistration{}, false
+		}
+		provider, err := ai.NewCodexProvider(
+			cfg.Codex.AccessToken,
+			ai.WithCodexRefreshToken(cfg.Codex.RefreshToken),
+			ai.WithCodexAccountID(cfg.Codex.AccountID),
+		)
+		if err != nil {
+			slog.Warn("failed to create Codex provider", "error", err)
+			return ai.ProviderRegistration{}, false
+		}
+		return ai.ProviderRegistration{Name: name, Provider: provider, DefaultModel: cfg.Codex.Model}, true
 	}
 	return ai.ProviderRegistration{}, false
 }

--- a/internal/platform/airouter/setup.go
+++ b/internal/platform/airouter/setup.go
@@ -118,8 +118,7 @@ func buildProviderWithCodexAuth(
 		return ai.ProviderRegistration{Name: name, Provider: ai.NewOpenRouterLLMAdapter(cfg.OpenRouter.APIKey), DefaultModel: cfg.OpenRouter.Model}, true
 	case "codex":
 		if cfg.Codex.Enabled {
-			availability, ok := codexAuth.(interface{ Available() bool })
-			if codexAuth == nil || !ok || !availability.Available() {
+			if codexAuth == nil || !codexAuth.Available() {
 				slog.Warn("Codex provider not registered; Codex app-server is unavailable")
 				return ai.ProviderRegistration{}, false
 			}

--- a/internal/platform/airouter/setup.go
+++ b/internal/platform/airouter/setup.go
@@ -24,8 +24,8 @@ func Setup(cfg config.AIConfig) *ai.Router {
 	return SetupWithCodexAuth(cfg, nil)
 }
 
-// SetupWithCodexAuth builds a router whose Codex provider refreshes through app-server.
-func SetupWithCodexAuth(cfg config.AIConfig, codexAuth ai.CodexCredentialRefresher) *ai.Router {
+// SetupWithCodexAuth builds a router whose managed Codex provider runs through app-server.
+func SetupWithCodexAuth(cfg config.AIConfig, codexAuth ai.CodexAppServerClient) *ai.Router {
 	router := ai.NewRouter()
 	ApplyWithCodexAuth(router, cfg, codexAuth)
 	return router
@@ -37,7 +37,7 @@ func Apply(router *ai.Router, cfg config.AIConfig) {
 }
 
 // ApplyWithCodexAuth replaces providers and gives Codex its managed-session refresher.
-func ApplyWithCodexAuth(router *ai.Router, cfg config.AIConfig, codexAuth ai.CodexCredentialRefresher) {
+func ApplyWithCodexAuth(router *ai.Router, cfg config.AIConfig, codexAuth ai.CodexAppServerClient) {
 	var regs []ai.ProviderRegistration
 	for _, name := range providerOrder(cfg.DefaultProvider) {
 		reg, ok := buildProviderWithCodexAuth(name, cfg, codexAuth)
@@ -57,11 +57,10 @@ func WouldRegister(name string, cfg config.AIConfig) bool {
 }
 
 // HasProviderConfiguration reports whether name has credentials or managed
-// login state that a fully wired runtime can register.
+// app-server configuration that a fully wired runtime can register.
 func HasProviderConfiguration(name string, cfg config.AIConfig) bool {
 	if name == "codex" &&
-		cfg.Codex.Enabled &&
-		cfg.Codex.Authenticated() {
+		cfg.Codex.Enabled {
 		return true
 	}
 	return WouldRegister(name, cfg)
@@ -74,7 +73,7 @@ func buildProvider(name string, cfg config.AIConfig) (ai.ProviderRegistration, b
 func buildProviderWithCodexAuth(
 	name string,
 	cfg config.AIConfig,
-	codexAuth ai.CodexCredentialRefresher,
+	codexAuth ai.CodexAppServerClient,
 ) (ai.ProviderRegistration, bool) {
 	switch name {
 	case "mock":
@@ -118,18 +117,17 @@ func buildProviderWithCodexAuth(
 		}
 		return ai.ProviderRegistration{Name: name, Provider: ai.NewOpenRouterLLMAdapter(cfg.OpenRouter.APIKey), DefaultModel: cfg.OpenRouter.Model}, true
 	case "codex":
-		if cfg.Codex.Enabled && cfg.Codex.Authenticated() {
+		if cfg.Codex.Enabled {
 			availability, ok := codexAuth.(interface{ Available() bool })
 			if codexAuth == nil || !ok || !availability.Available() {
 				slog.Warn("Codex provider not registered; Codex app-server is unavailable")
 				return ai.ProviderRegistration{}, false
 			}
-			provider, err := ai.NewManagedCodexProvider(cfg.Codex.AuthFile, codexAuth)
-			if err != nil {
-				slog.Warn("failed to create managed Codex provider", "error", err)
-				return ai.ProviderRegistration{}, false
-			}
-			return ai.ProviderRegistration{Name: name, Provider: provider, DefaultModel: cfg.Codex.Model}, true
+			return ai.ProviderRegistration{
+				Name:         name,
+				Provider:     ai.NewCodexAppServerProvider(codexAuth, cfg.Codex.Model),
+				DefaultModel: cfg.Codex.Model,
+			}, true
 		}
 		if strings.TrimSpace(cfg.Codex.AccessToken) == "" {
 			return ai.ProviderRegistration{}, false

--- a/internal/platform/airouter/setup_test.go
+++ b/internal/platform/airouter/setup_test.go
@@ -5,6 +5,8 @@ package airouter
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -55,6 +57,84 @@ func TestBuildProviderUsesCodexCredentialsAndModel(t *testing.T) {
 	}
 	if reg.DefaultModel != cfg.Codex.Model {
 		t.Fatalf("Codex default model = %q, want %q", reg.DefaultModel, cfg.Codex.Model)
+	}
+}
+
+func TestBuildProviderUsesCodexLoginAdapterWhenAuthenticated(t *testing.T) {
+	cfg := config.AIConfig{}
+	cfg.Codex.Enabled = true
+	cfg.Codex.AuthFile = filepath.Join(t.TempDir(), "auth.json")
+	cfg.Codex.Model = "gpt-test"
+	if err := os.WriteFile(cfg.Codex.AuthFile, []byte(`{"auth_mode":"chatgpt","tokens":{"access_token":"test-token","account_id":"test-account"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	reg, ok := buildProviderWithCodexAuth("codex", cfg, stubCodexAuth{})
+	if !ok {
+		t.Fatal("buildProvider(codex) = not registered with server auth present")
+	}
+	if _, ok := reg.Provider.(*ai.CodexProvider); !ok {
+		t.Fatalf("Codex provider type = %T, want *ai.CodexProvider", reg.Provider)
+	}
+	if reg.Name != "codex" || reg.DefaultModel != "gpt-test" {
+		t.Fatalf("Codex registration = %#v", reg)
+	}
+}
+
+type stubCodexAuth struct{}
+
+func (stubCodexAuth) Refresh(context.Context) error { return nil }
+func (stubCodexAuth) Available() bool               { return true }
+
+func TestSetupWithCodexAuthRegistersManagedLoginAdapter(t *testing.T) {
+	cfg := config.AIConfig{DefaultProvider: "codex"}
+	cfg.Codex.Enabled = true
+	cfg.Codex.AuthFile = filepath.Join(t.TempDir(), "auth.json")
+	if err := os.WriteFile(cfg.Codex.AuthFile, []byte(`{"auth_mode":"chatgpt","tokens":{"access_token":"test-token","account_id":"test-account"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	router := SetupWithCodexAuth(cfg, stubCodexAuth{})
+
+	if !router.HasNativeProvider() {
+		t.Fatal("Codex provider was not registered as a native provider")
+	}
+}
+
+func TestManagedCodexRequiresRuntimeManagerToRegister(t *testing.T) {
+	cfg := config.AIConfig{DefaultProvider: "codex"}
+	cfg.Codex.Enabled = true
+	cfg.Codex.AuthFile = filepath.Join(t.TempDir(), "auth.json")
+	if err := os.WriteFile(cfg.Codex.AuthFile, []byte(`{"auth_mode":"chatgpt","tokens":{"access_token":"test-token","account_id":"test-account"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if Setup(cfg).HasProvider() {
+		t.Fatal("Setup() registered managed Codex without app-server")
+	}
+	if !HasProviderConfiguration("codex", cfg) {
+		t.Fatal("HasProviderConfiguration() = false for connected managed Codex")
+	}
+}
+
+type unavailableCodexAuth struct{ stubCodexAuth }
+
+func (unavailableCodexAuth) Available() bool { return false }
+
+func TestSetupWithUnavailableCodexAuthLeavesProviderUnregistered(t *testing.T) {
+	cfg := config.AIConfig{DefaultProvider: "codex"}
+	cfg.OpenAI.APIKey = "fallback-key"
+	cfg.Codex.Enabled = true
+	cfg.Codex.AuthFile = filepath.Join(t.TempDir(), "auth.json")
+	if err := os.WriteFile(cfg.Codex.AuthFile, []byte(`{"auth_mode":"chatgpt","tokens":{"access_token":"test-token","account_id":"test-account"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	router := SetupWithCodexAuth(cfg, unavailableCodexAuth{})
+
+	order := router.ProviderOrder()
+	if len(order) != 1 || order[0] != "openai" {
+		t.Fatalf("ProviderOrder() = %v, want [openai] fallback without Codex", order)
 	}
 }
 

--- a/internal/platform/airouter/setup_test.go
+++ b/internal/platform/airouter/setup_test.go
@@ -5,8 +5,6 @@ package airouter
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -60,21 +58,17 @@ func TestBuildProviderUsesCodexCredentialsAndModel(t *testing.T) {
 	}
 }
 
-func TestBuildProviderUsesCodexLoginAdapterWhenAuthenticated(t *testing.T) {
+func TestBuildProviderUsesCodexAppServerWhenEnabled(t *testing.T) {
 	cfg := config.AIConfig{}
 	cfg.Codex.Enabled = true
-	cfg.Codex.AuthFile = filepath.Join(t.TempDir(), "auth.json")
 	cfg.Codex.Model = "gpt-test"
-	if err := os.WriteFile(cfg.Codex.AuthFile, []byte(`{"auth_mode":"chatgpt","tokens":{"access_token":"test-token","account_id":"test-account"}}`), 0o600); err != nil {
-		t.Fatal(err)
-	}
 
 	reg, ok := buildProviderWithCodexAuth("codex", cfg, stubCodexAuth{})
 	if !ok {
-		t.Fatal("buildProvider(codex) = not registered with server auth present")
+		t.Fatal("buildProvider(codex) = not registered with app-server available")
 	}
-	if _, ok := reg.Provider.(*ai.CodexProvider); !ok {
-		t.Fatalf("Codex provider type = %T, want *ai.CodexProvider", reg.Provider)
+	if _, native := reg.Provider.(ai.NativeProvider); native {
+		t.Fatalf("Codex app-server provider unexpectedly implements NativeProvider: %T", reg.Provider)
 	}
 	if reg.Name != "codex" || reg.DefaultModel != "gpt-test" {
 		t.Fatalf("Codex registration = %#v", reg)
@@ -85,29 +79,30 @@ type stubCodexAuth struct{}
 
 func (stubCodexAuth) Refresh(context.Context) error { return nil }
 func (stubCodexAuth) Available() bool               { return true }
+func (stubCodexAuth) Complete(
+	context.Context,
+	ai.CompletionRequest,
+) (ai.CompletionResponse, error) {
+	return ai.CompletionResponse{Content: "ok"}, nil
+}
 
 func TestSetupWithCodexAuthRegistersManagedLoginAdapter(t *testing.T) {
 	cfg := config.AIConfig{DefaultProvider: "codex"}
 	cfg.Codex.Enabled = true
-	cfg.Codex.AuthFile = filepath.Join(t.TempDir(), "auth.json")
-	if err := os.WriteFile(cfg.Codex.AuthFile, []byte(`{"auth_mode":"chatgpt","tokens":{"access_token":"test-token","account_id":"test-account"}}`), 0o600); err != nil {
-		t.Fatal(err)
-	}
 
 	router := SetupWithCodexAuth(cfg, stubCodexAuth{})
 
-	if !router.HasNativeProvider() {
-		t.Fatal("Codex provider was not registered as a native provider")
+	if !router.HasProvider() {
+		t.Fatal("Codex app-server provider was not registered")
+	}
+	if router.HasNativeProvider() {
+		t.Fatal("Codex app-server provider must not expose PaiBot native tool continuation")
 	}
 }
 
 func TestManagedCodexRequiresRuntimeManagerToRegister(t *testing.T) {
 	cfg := config.AIConfig{DefaultProvider: "codex"}
 	cfg.Codex.Enabled = true
-	cfg.Codex.AuthFile = filepath.Join(t.TempDir(), "auth.json")
-	if err := os.WriteFile(cfg.Codex.AuthFile, []byte(`{"auth_mode":"chatgpt","tokens":{"access_token":"test-token","account_id":"test-account"}}`), 0o600); err != nil {
-		t.Fatal(err)
-	}
 
 	if Setup(cfg).HasProvider() {
 		t.Fatal("Setup() registered managed Codex without app-server")
@@ -125,10 +120,6 @@ func TestSetupWithUnavailableCodexAuthLeavesProviderUnregistered(t *testing.T) {
 	cfg := config.AIConfig{DefaultProvider: "codex"}
 	cfg.OpenAI.APIKey = "fallback-key"
 	cfg.Codex.Enabled = true
-	cfg.Codex.AuthFile = filepath.Join(t.TempDir(), "auth.json")
-	if err := os.WriteFile(cfg.Codex.AuthFile, []byte(`{"auth_mode":"chatgpt","tokens":{"access_token":"test-token","account_id":"test-account"}}`), 0o600); err != nil {
-		t.Fatal(err)
-	}
 
 	router := SetupWithCodexAuth(cfg, unavailableCodexAuth{})
 

--- a/internal/platform/codexauth/completion.go
+++ b/internal/platform/codexauth/completion.go
@@ -15,6 +15,12 @@ import (
 
 const codexChatInstructions = `Act only as PaiBot's chat completion engine. Answer from the supplied conversation and instructions. Do not inspect files, run commands, call tools, ask for approval, or modify the environment. Return only the assistant response.`
 
+type agentMessageItem struct {
+	Type  string `json:"type"`
+	Text  string `json:"text"`
+	Phase string `json:"phase"`
+}
+
 // Complete runs one ephemeral, non-interactive Codex thread.
 func (m *Manager) Complete(
 	ctx context.Context,
@@ -36,19 +42,16 @@ func (m *Manager) Complete(
 		"approvalPolicy":        "never",
 		"cwd":                   workspace,
 		"developerInstructions": codexChatInstructions,
-		"dynamicTools":          []any{},
-		"environments":          []any{},
 		"ephemeral":             true,
 		"model":                 strings.TrimSpace(request.Model),
-		"permissions":           ":read-only",
-		"runtimeWorkspaceRoots": []string{workspace},
+		"sandbox":               "read-only",
 	}
 	if baseInstructions != "" {
 		threadParams["baseInstructions"] = baseInstructions
 	}
 	threadRaw, err := m.call(ctx, "thread/start", threadParams)
 	if err != nil {
-		return ai.CompletionResponse{}, errors.New("start Codex chat")
+		return ai.CompletionResponse{}, fmt.Errorf("start Codex chat: %w", err)
 	}
 	var started struct {
 		Thread struct {
@@ -69,7 +72,6 @@ func (m *Manager) Complete(
 	turnParams := map[string]any{
 		"approvalPolicy": "never",
 		"input":          completionInput(messages),
-		"permissions":    ":read-only",
 		"threadId":       threadID,
 	}
 	if request.StructuredOutput != nil {
@@ -82,7 +84,7 @@ func (m *Manager) Complete(
 	}
 	if _, err := m.call(ctx, "turn/start", turnParams); err != nil {
 		m.removeCompletion(threadID)
-		return ai.CompletionResponse{}, errors.New("start Codex response")
+		return ai.CompletionResponse{}, fmt.Errorf("start Codex response: %w", err)
 	}
 
 	select {
@@ -137,16 +139,30 @@ func (m *Manager) handleTokenUsage(params json.RawMessage) {
 	m.mu.Unlock()
 }
 
+func (m *Manager) handleItemCompleted(params json.RawMessage) {
+	var completed struct {
+		ThreadID string           `json:"threadId"`
+		Item     agentMessageItem `json:"item"`
+	}
+	if json.Unmarshal(params, &completed) != nil ||
+		completed.ThreadID == "" ||
+		completed.Item.Type != "agentMessage" ||
+		strings.TrimSpace(completed.Item.Text) == "" {
+		return
+	}
+	m.mu.Lock()
+	if state := m.completions[completed.ThreadID]; state != nil {
+		state.messages = append(state.messages, completed.Item)
+	}
+	m.mu.Unlock()
+}
+
 func (m *Manager) handleTurnCompleted(params json.RawMessage) {
 	var completed struct {
 		ThreadID string `json:"threadId"`
 		Turn     struct {
-			Status string `json:"status"`
-			Items  []struct {
-				Type  string `json:"type"`
-				Text  string `json:"text"`
-				Phase string `json:"phase"`
-			} `json:"items"`
+			Status string             `json:"status"`
+			Items  []agentMessageItem `json:"items"`
 		} `json:"turn"`
 	}
 	if json.Unmarshal(params, &completed) != nil || completed.ThreadID == "" {
@@ -164,7 +180,11 @@ func (m *Manager) handleTurnCompleted(params json.RawMessage) {
 		state.waiter <- completionResult{err: errors.New("codex response failed")}
 		return
 	}
-	content := finalAgentMessage(completed.Turn.Items)
+	messages := completed.Turn.Items
+	if len(messages) == 0 {
+		messages = state.messages
+	}
+	content := finalAgentMessage(messages)
 	if content == "" {
 		state.waiter <- completionResult{err: errors.New("codex returned an empty response")}
 		return
@@ -216,11 +236,7 @@ func completionInput(messages []ai.Message) []map[string]any {
 	return append([]map[string]any{textInput}, input...)
 }
 
-func finalAgentMessage(items []struct {
-	Type  string `json:"type"`
-	Text  string `json:"text"`
-	Phase string `json:"phase"`
-}) string {
+func finalAgentMessage(items []agentMessageItem) string {
 	var final string
 	var messages []string
 	for _, item := range items {

--- a/internal/platform/codexauth/completion.go
+++ b/internal/platform/codexauth/completion.go
@@ -21,14 +21,14 @@ func (m *Manager) Complete(
 	request ai.CompletionRequest,
 ) (ai.CompletionResponse, error) {
 	if err := m.Refresh(ctx); err != nil {
-		return ai.CompletionResponse{}, errors.New("Codex login is not connected; reconnect it in Admin")
+		return ai.CompletionResponse{}, errors.New("codex login is not connected; reconnect it in Admin")
 	}
 
 	m.mu.RLock()
 	workspace := m.workspace
 	m.mu.RUnlock()
 	if workspace == "" {
-		return ai.CompletionResponse{}, errors.New("Codex runtime workspace is unavailable")
+		return ai.CompletionResponse{}, errors.New("codex runtime workspace is unavailable")
 	}
 
 	baseInstructions, messages := splitInstructions(request.Messages)
@@ -161,12 +161,12 @@ func (m *Manager) handleTurnCompleted(params json.RawMessage) {
 		return
 	}
 	if completed.Turn.Status != "completed" {
-		state.waiter <- completionResult{err: errors.New("Codex response failed")}
+		state.waiter <- completionResult{err: errors.New("codex response failed")}
 		return
 	}
 	content := finalAgentMessage(completed.Turn.Items)
 	if content == "" {
-		state.waiter <- completionResult{err: errors.New("Codex returned an empty response")}
+		state.waiter <- completionResult{err: errors.New("codex returned an empty response")}
 		return
 	}
 	state.waiter <- completionResult{response: ai.CompletionResponse{

--- a/internal/platform/codexauth/completion.go
+++ b/internal/platform/codexauth/completion.go
@@ -1,0 +1,248 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package codexauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/p-n-ai/pai-bot/internal/ai"
+)
+
+const codexChatInstructions = `Act only as PaiBot's chat completion engine. Answer from the supplied conversation and instructions. Do not inspect files, run commands, call tools, ask for approval, or modify the environment. Return only the assistant response.`
+
+// Complete runs one ephemeral, non-interactive Codex thread.
+func (m *Manager) Complete(
+	ctx context.Context,
+	request ai.CompletionRequest,
+) (ai.CompletionResponse, error) {
+	if err := m.Refresh(ctx); err != nil {
+		return ai.CompletionResponse{}, errors.New("Codex login is not connected; reconnect it in Admin")
+	}
+
+	m.mu.RLock()
+	workspace := m.workspace
+	m.mu.RUnlock()
+	if workspace == "" {
+		return ai.CompletionResponse{}, errors.New("Codex runtime workspace is unavailable")
+	}
+
+	baseInstructions, messages := splitInstructions(request.Messages)
+	threadParams := map[string]any{
+		"approvalPolicy":        "never",
+		"cwd":                   workspace,
+		"developerInstructions": codexChatInstructions,
+		"dynamicTools":          []any{},
+		"environments":          []any{},
+		"ephemeral":             true,
+		"model":                 strings.TrimSpace(request.Model),
+		"permissions":           ":read-only",
+		"runtimeWorkspaceRoots": []string{workspace},
+	}
+	if baseInstructions != "" {
+		threadParams["baseInstructions"] = baseInstructions
+	}
+	threadRaw, err := m.call(ctx, "thread/start", threadParams)
+	if err != nil {
+		return ai.CompletionResponse{}, errors.New("start Codex chat")
+	}
+	var started struct {
+		Thread struct {
+			ID string `json:"id"`
+		} `json:"thread"`
+		Model string `json:"model"`
+	}
+	if json.Unmarshal(threadRaw, &started) != nil || strings.TrimSpace(started.Thread.ID) == "" {
+		return ai.CompletionResponse{}, errors.New("decode Codex chat")
+	}
+
+	threadID := started.Thread.ID
+	state := &completionState{waiter: make(chan completionResult, 1)}
+	m.mu.Lock()
+	m.completions[threadID] = state
+	m.mu.Unlock()
+
+	turnParams := map[string]any{
+		"approvalPolicy": "never",
+		"input":          completionInput(messages),
+		"permissions":    ":read-only",
+		"threadId":       threadID,
+	}
+	if request.StructuredOutput != nil {
+		var schema any
+		if json.Unmarshal(request.StructuredOutput.JSONSchema, &schema) != nil {
+			m.removeCompletion(threadID)
+			return ai.CompletionResponse{}, errors.New("invalid Codex output schema")
+		}
+		turnParams["outputSchema"] = schema
+	}
+	if _, err := m.call(ctx, "turn/start", turnParams); err != nil {
+		m.removeCompletion(threadID)
+		return ai.CompletionResponse{}, errors.New("start Codex response")
+	}
+
+	select {
+	case completed := <-state.waiter:
+		if completed.err != nil {
+			return ai.CompletionResponse{}, completed.err
+		}
+		if completed.response.Model == "" {
+			completed.response.Model = firstNonEmpty(started.Model, request.Model)
+		}
+		if request.StructuredOutput != nil {
+			completed.response.StructuredOutput = json.RawMessage(completed.response.Content)
+		}
+		return completed.response, nil
+	case <-ctx.Done():
+		m.removeCompletion(threadID)
+		_, _ = m.callWithTimeout("turn/interrupt", map[string]string{"threadId": threadID})
+		return ai.CompletionResponse{}, ctx.Err()
+	}
+}
+
+func (m *Manager) callWithTimeout(method string, params any) (json.RawMessage, error) {
+	ctx, cancel := context.WithTimeout(m.parent, requestTimeout)
+	defer cancel()
+	return m.call(ctx, method, params)
+}
+
+func (m *Manager) removeCompletion(threadID string) {
+	m.mu.Lock()
+	delete(m.completions, threadID)
+	m.mu.Unlock()
+}
+
+func (m *Manager) handleTokenUsage(params json.RawMessage) {
+	var updated struct {
+		ThreadID   string `json:"threadId"`
+		TokenUsage struct {
+			Last struct {
+				InputTokens  int `json:"inputTokens"`
+				OutputTokens int `json:"outputTokens"`
+			} `json:"last"`
+		} `json:"tokenUsage"`
+	}
+	if json.Unmarshal(params, &updated) != nil {
+		return
+	}
+	m.mu.Lock()
+	if state := m.completions[updated.ThreadID]; state != nil {
+		state.inputTokens = updated.TokenUsage.Last.InputTokens
+		state.outputTokens = updated.TokenUsage.Last.OutputTokens
+	}
+	m.mu.Unlock()
+}
+
+func (m *Manager) handleTurnCompleted(params json.RawMessage) {
+	var completed struct {
+		ThreadID string `json:"threadId"`
+		Turn     struct {
+			Status string `json:"status"`
+			Items  []struct {
+				Type  string `json:"type"`
+				Text  string `json:"text"`
+				Phase string `json:"phase"`
+			} `json:"items"`
+		} `json:"turn"`
+	}
+	if json.Unmarshal(params, &completed) != nil || completed.ThreadID == "" {
+		return
+	}
+
+	m.mu.Lock()
+	state := m.completions[completed.ThreadID]
+	delete(m.completions, completed.ThreadID)
+	m.mu.Unlock()
+	if state == nil {
+		return
+	}
+	if completed.Turn.Status != "completed" {
+		state.waiter <- completionResult{err: errors.New("Codex response failed")}
+		return
+	}
+	content := finalAgentMessage(completed.Turn.Items)
+	if content == "" {
+		state.waiter <- completionResult{err: errors.New("Codex returned an empty response")}
+		return
+	}
+	state.waiter <- completionResult{response: ai.CompletionResponse{
+		Content:      content,
+		InputTokens:  state.inputTokens,
+		OutputTokens: state.outputTokens,
+	}}
+}
+
+func splitInstructions(messages []ai.Message) (string, []ai.Message) {
+	instructions := make([]string, 0)
+	conversation := make([]ai.Message, 0, len(messages))
+	for _, message := range messages {
+		if strings.EqualFold(strings.TrimSpace(message.Role), "system") {
+			if content := strings.TrimSpace(message.Content); content != "" {
+				instructions = append(instructions, content)
+			}
+			continue
+		}
+		conversation = append(conversation, message)
+	}
+	return strings.Join(instructions, "\n\n"), conversation
+}
+
+func completionInput(messages []ai.Message) []map[string]any {
+	var transcript strings.Builder
+	input := make([]map[string]any, 0, 1+len(messages))
+	for _, message := range messages {
+		role := strings.ToUpper(strings.TrimSpace(message.Role))
+		if role == "" {
+			role = "USER"
+		}
+		if transcript.Len() > 0 {
+			transcript.WriteString("\n\n")
+		}
+		_, _ = fmt.Fprintf(&transcript, "%s:\n%s", role, strings.TrimSpace(message.Content))
+		for _, imageURL := range message.ImageURLs {
+			if strings.TrimSpace(imageURL) != "" {
+				input = append(input, map[string]any{"type": "image", "url": imageURL})
+			}
+		}
+	}
+	if transcript.Len() == 0 {
+		transcript.WriteString("USER:\n")
+	}
+	textInput := map[string]any{"type": "text", "text": transcript.String()}
+	return append([]map[string]any{textInput}, input...)
+}
+
+func finalAgentMessage(items []struct {
+	Type  string `json:"type"`
+	Text  string `json:"text"`
+	Phase string `json:"phase"`
+}) string {
+	var final string
+	var messages []string
+	for _, item := range items {
+		if item.Type != "agentMessage" || strings.TrimSpace(item.Text) == "" {
+			continue
+		}
+		messages = append(messages, strings.TrimSpace(item.Text))
+		if item.Phase == "final_answer" {
+			final = strings.TrimSpace(item.Text)
+		}
+	}
+	if final != "" {
+		return final
+	}
+	return strings.Join(messages, "\n")
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return "gpt-5.4"
+}

--- a/internal/platform/codexauth/completion_integration_test.go
+++ b/internal/platform/codexauth/completion_integration_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package codexauth
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/p-n-ai/pai-bot/internal/ai"
+)
+
+func TestCodexAppServerLiveCompletion(t *testing.T) {
+	home := strings.TrimSpace(os.Getenv("LEARN_AI_CODEX_HOME"))
+	if home == "" {
+		t.Skip("LEARN_AI_CODEX_HOME is not configured")
+	}
+	executable, err := exec.LookPath("codex")
+	if err != nil {
+		t.Skip("Codex CLI is not available")
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	defer cancel()
+	manager := New(ctx, home, executable, nil)
+
+	response, err := manager.Complete(ctx, ai.CompletionRequest{
+		Model: strings.TrimSpace(os.Getenv("LEARN_AI_CODEX_MODEL")),
+		Messages: []ai.Message{{
+			Role:    "user",
+			Content: "Reply with exactly: codex app-server connected",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	if strings.TrimSpace(response.Content) != "codex app-server connected" {
+		t.Fatalf("Complete() content = %q", response.Content)
+	}
+	if strings.TrimSpace(response.Model) == "" {
+		t.Fatal("Complete() returned no model")
+	}
+}

--- a/internal/platform/codexauth/manager.go
+++ b/internal/platform/codexauth/manager.go
@@ -193,7 +193,7 @@ func (m *Manager) refresh(ctx context.Context, refreshToken bool) error {
 	}
 	if response.Account == nil || response.Account.Type != "chatgpt" {
 		m.setStatusUnlessLoginActive(Status{State: StateDisconnected})
-		return errors.New("Codex ChatGPT login is not connected")
+		return errors.New("codex ChatGPT login is not connected")
 	}
 	m.setStatusUnlessLoginActive(Status{State: StateConnected})
 	return nil
@@ -244,14 +244,14 @@ func (m *Manager) ensureProcess(ctx context.Context) error {
 		return nil
 	}
 	if m.executable == "" || m.home == "" {
-		return errors.New("Codex app-server is unavailable")
+		return errors.New("codex app-server is unavailable")
 	}
 	if err := os.MkdirAll(m.home, 0o700); err != nil {
 		return errors.New("prepare Codex home")
 	}
 	homeInfo, err := os.Lstat(m.home)
 	if err != nil || !homeInfo.IsDir() {
-		return errors.New("Codex home must be a real directory")
+		return errors.New("codex home must be a real directory")
 	}
 	workspace, err := os.MkdirTemp("", "pai-bot-codex-runtime-")
 	if err != nil {
@@ -332,7 +332,7 @@ func (m *Manager) callRunning(ctx context.Context, method string, params any) (j
 			return nil, result.err
 		}
 		if result.message.Error != nil {
-			return nil, errors.New("Codex app-server request failed")
+			return nil, errors.New("codex app-server request failed")
 		}
 		return result.message.Result, nil
 	case <-ctx.Done():
@@ -353,7 +353,7 @@ func (m *Manager) write(message any) error {
 	running := m.running
 	m.mu.RUnlock()
 	if !running || stdin == nil {
-		return errors.New("Codex app-server is not running")
+		return errors.New("codex app-server is not running")
 	}
 	if err := json.NewEncoder(stdin).Encode(message); err != nil {
 		return errors.New("write Codex app-server request")
@@ -484,10 +484,10 @@ func (m *Manager) processStopped() {
 		_ = os.RemoveAll(workspace)
 	}
 	for _, waiter := range pending {
-		waiter <- pendingResponse{err: errors.New("Codex app-server stopped")}
+		waiter <- pendingResponse{err: errors.New("codex app-server stopped")}
 	}
 	for _, completion := range completions {
-		completion.waiter <- completionResult{err: errors.New("Codex app-server stopped")}
+		completion.waiter <- completionResult{err: errors.New("codex app-server stopped")}
 	}
 }
 

--- a/internal/platform/codexauth/manager.go
+++ b/internal/platform/codexauth/manager.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -49,6 +50,14 @@ type rpcError struct {
 	Message string `json:"message"`
 }
 
+type rpcRequestError struct {
+	code int
+}
+
+func (e *rpcRequestError) Error() string {
+	return fmt.Sprintf("codex app-server request failed (%d)", e.code)
+}
+
 type rpcMessage struct {
 	ID     json.RawMessage `json:"id,omitempty"`
 	Method string          `json:"method,omitempty"`
@@ -71,6 +80,7 @@ type completionState struct {
 	waiter       chan completionResult
 	inputTokens  int
 	outputTokens int
+	messages     []agentMessageItem
 }
 
 type Manager struct {
@@ -332,7 +342,9 @@ func (m *Manager) callRunning(ctx context.Context, method string, params any) (j
 			return nil, result.err
 		}
 		if result.message.Error != nil {
-			return nil, errors.New("codex app-server request failed")
+			return nil, &rpcRequestError{
+				code: result.message.Error.Code,
+			}
 		}
 		return result.message.Result, nil
 	case <-ctx.Done():
@@ -385,6 +397,8 @@ func (m *Manager) readLoop(cmd *exec.Cmd, output io.Reader) {
 			m.handleLoginCompleted(message.Params)
 		case "thread/tokenUsage/updated":
 			m.handleTokenUsage(message.Params)
+		case "item/completed":
+			m.handleItemCompleted(message.Params)
 		case "turn/completed":
 			m.handleTurnCompleted(message.Params)
 		}

--- a/internal/platform/codexauth/manager.go
+++ b/internal/platform/codexauth/manager.go
@@ -17,6 +17,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/p-n-ai/pai-bot/internal/ai"
 )
 
 const requestTimeout = 15 * time.Second
@@ -48,7 +50,7 @@ type rpcError struct {
 }
 
 type rpcMessage struct {
-	ID     *int64          `json:"id,omitempty"`
+	ID     json.RawMessage `json:"id,omitempty"`
 	Method string          `json:"method,omitempty"`
 	Params json.RawMessage `json:"params,omitempty"`
 	Result json.RawMessage `json:"result,omitempty"`
@@ -58,6 +60,17 @@ type rpcMessage struct {
 type pendingResponse struct {
 	message rpcMessage
 	err     error
+}
+
+type completionResult struct {
+	response ai.CompletionResponse
+	err      error
+}
+
+type completionState struct {
+	waiter       chan completionResult
+	inputTokens  int
+	outputTokens int
 }
 
 type Manager struct {
@@ -76,6 +89,8 @@ type Manager struct {
 	stdin       io.WriteCloser
 	cancel      context.CancelFunc
 	pending     map[int64]chan pendingResponse
+	completions map[string]*completionState
+	workspace   string
 }
 
 func New(parent context.Context, home, executable string, onConnected func(context.Context) error) *Manager {
@@ -90,6 +105,7 @@ func New(parent context.Context, home, executable string, onConnected func(conte
 		onConnected: onConnected,
 		status:      Status{State: StateDisconnected},
 		pending:     make(map[int64]chan pendingResponse),
+		completions: make(map[string]*completionState),
 	}
 }
 
@@ -233,6 +249,14 @@ func (m *Manager) ensureProcess(ctx context.Context) error {
 	if err := os.MkdirAll(m.home, 0o700); err != nil {
 		return errors.New("prepare Codex home")
 	}
+	homeInfo, err := os.Lstat(m.home)
+	if err != nil || !homeInfo.IsDir() {
+		return errors.New("Codex home must be a real directory")
+	}
+	workspace, err := os.MkdirTemp("", "pai-bot-codex-runtime-")
+	if err != nil {
+		return errors.New("prepare Codex runtime workspace")
+	}
 
 	processCtx, cancel := context.WithCancel(m.parent)
 	cmd := m.command(processCtx, m.executable, "app-server", "--listen", "stdio://")
@@ -240,16 +264,19 @@ func (m *Manager) ensureProcess(ctx context.Context) error {
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		cancel()
+		_ = os.RemoveAll(workspace)
 		return errors.New("open Codex app-server input")
 	}
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		cancel()
+		_ = os.RemoveAll(workspace)
 		return errors.New("open Codex app-server output")
 	}
 	cmd.Stderr = io.Discard
 	if err := cmd.Start(); err != nil {
 		cancel()
+		_ = os.RemoveAll(workspace)
 		return errors.New("start Codex app-server")
 	}
 
@@ -257,6 +284,7 @@ func (m *Manager) ensureProcess(ctx context.Context) error {
 	m.running = true
 	m.stdin = stdin
 	m.cancel = cancel
+	m.workspace = workspace
 	m.mu.Unlock()
 	go m.readLoop(cmd, stdout)
 
@@ -341,16 +369,38 @@ func (m *Manager) readLoop(cmd *exec.Cmd, output io.Reader) {
 		if json.Unmarshal(scanner.Bytes(), &message) != nil {
 			continue
 		}
-		if message.ID != nil {
-			m.resolve(*message.ID, pendingResponse{message: message})
+		if len(message.ID) > 0 && string(message.ID) != "null" {
+			if message.Method != "" {
+				m.rejectServerRequest(message.ID)
+				continue
+			}
+			var id int64
+			if json.Unmarshal(message.ID, &id) == nil {
+				m.resolve(id, pendingResponse{message: message})
+			}
 			continue
 		}
-		if message.Method == "account/login/completed" {
+		switch message.Method {
+		case "account/login/completed":
 			m.handleLoginCompleted(message.Params)
+		case "thread/tokenUsage/updated":
+			m.handleTokenUsage(message.Params)
+		case "turn/completed":
+			m.handleTurnCompleted(message.Params)
 		}
 	}
 	_ = cmd.Wait()
 	m.processStopped()
+}
+
+func (m *Manager) rejectServerRequest(id json.RawMessage) {
+	_ = m.write(map[string]any{
+		"id": id,
+		"error": map[string]any{
+			"code":    -32601,
+			"message": "PaiBot does not expose interactive Codex tools",
+		},
+	})
 }
 
 func (m *Manager) handleLoginCompleted(params json.RawMessage) {
@@ -411,6 +461,8 @@ func (m *Manager) processStopped() {
 	m.running = false
 	m.stdin = nil
 	m.cancel = nil
+	workspace := m.workspace
+	m.workspace = ""
 	if m.status.State == StateStarting || m.status.State == StateAwaiting {
 		m.status = Status{
 			State:   StateFailed,
@@ -425,9 +477,17 @@ func (m *Manager) processStopped() {
 	}
 	pending := m.pending
 	m.pending = make(map[int64]chan pendingResponse)
+	completions := m.completions
+	m.completions = make(map[string]*completionState)
 	m.mu.Unlock()
+	if workspace != "" {
+		_ = os.RemoveAll(workspace)
+	}
 	for _, waiter := range pending {
 		waiter <- pendingResponse{err: errors.New("Codex app-server stopped")}
+	}
+	for _, completion := range completions {
+		completion.waiter <- completionResult{err: errors.New("Codex app-server stopped")}
 	}
 }
 

--- a/internal/platform/codexauth/manager.go
+++ b/internal/platform/codexauth/manager.go
@@ -1,0 +1,470 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package codexauth owns the server-side Codex app-server login session.
+package codexauth
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+
+const requestTimeout = 15 * time.Second
+
+var userCodePattern = regexp.MustCompile(`^[A-Z0-9]{4,8}-[A-Z0-9]{4,8}$`)
+
+type State string
+
+const (
+	StateDisconnected State = "disconnected"
+	StateStarting     State = "starting"
+	StateAwaiting     State = "awaiting_authorization"
+	StateConnected    State = "connected"
+	StateFailed       State = "failed"
+)
+
+type Status struct {
+	State           State  `json:"state"`
+	VerificationURL string `json:"verificationUrl,omitempty"`
+	UserCode        string `json:"userCode,omitempty"`
+	Message         string `json:"message,omitempty"`
+}
+
+type commandFactory func(context.Context, string, ...string) *exec.Cmd
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type rpcMessage struct {
+	ID     *int64          `json:"id,omitempty"`
+	Method string          `json:"method,omitempty"`
+	Params json.RawMessage `json:"params,omitempty"`
+	Result json.RawMessage `json:"result,omitempty"`
+	Error  *rpcError       `json:"error,omitempty"`
+}
+
+type pendingResponse struct {
+	message rpcMessage
+	err     error
+}
+
+type Manager struct {
+	mu          sync.RWMutex
+	startMu     sync.Mutex
+	writeMu     sync.Mutex
+	parent      context.Context
+	home        string
+	executable  string
+	command     commandFactory
+	onConnected func(context.Context) error
+	status      Status
+	loginID     string
+	nextID      int64
+	running     bool
+	stdin       io.WriteCloser
+	cancel      context.CancelFunc
+	pending     map[int64]chan pendingResponse
+}
+
+func New(parent context.Context, home, executable string, onConnected func(context.Context) error) *Manager {
+	if parent == nil {
+		parent = context.Background()
+	}
+	return &Manager{
+		parent:      parent,
+		home:        strings.TrimSpace(home),
+		executable:  strings.TrimSpace(executable),
+		command:     exec.CommandContext,
+		onConnected: onConnected,
+		status:      Status{State: StateDisconnected},
+		pending:     make(map[int64]chan pendingResponse),
+	}
+}
+
+func (m *Manager) SetOnConnected(callback func(context.Context) error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.onConnected = callback
+}
+
+// Available reports whether this manager can start an isolated app-server.
+func (m *Manager) Available() bool {
+	return m.executable != "" && m.home != ""
+}
+
+// Initialize reconciles the displayed state with the isolated app-server account.
+func (m *Manager) Initialize() {
+	go func() {
+		ctx, cancel := context.WithTimeout(m.parent, requestTimeout)
+		defer cancel()
+		if err := m.refresh(ctx, false); err != nil {
+			if m.executable == "" {
+				m.fail("Codex CLI is not installed on the server.")
+			}
+		}
+	}()
+}
+
+func (m *Manager) Status() Status {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.status
+}
+
+func (m *Manager) Start() (Status, error) {
+	m.mu.Lock()
+	if m.status.State == StateStarting ||
+		m.status.State == StateAwaiting {
+		status := m.status
+		m.mu.Unlock()
+		return status, nil
+	}
+	if m.executable == "" {
+		m.status = Status{State: StateFailed, Message: "Codex CLI is not installed on the server."}
+		status := m.status
+		m.mu.Unlock()
+		return status, errors.New("codex executable unavailable")
+	}
+	if m.home == "" {
+		m.status = Status{State: StateFailed, Message: "Codex server credential storage is not configured."}
+		status := m.status
+		m.mu.Unlock()
+		return status, errors.New("codex home unavailable")
+	}
+	m.status = Status{State: StateStarting}
+	status := m.status
+	m.mu.Unlock()
+
+	go m.startDeviceLogin()
+	return status, nil
+}
+
+// Refresh asks Codex app-server to refresh its managed ChatGPT login.
+func (m *Manager) Refresh(ctx context.Context) error {
+	return m.refresh(ctx, true)
+}
+
+func (m *Manager) refresh(ctx context.Context, refreshToken bool) error {
+	result, err := m.call(ctx, "account/read", map[string]bool{"refreshToken": refreshToken})
+	if err != nil {
+		if refreshToken {
+			m.setStatusUnlessLoginActive(Status{
+				State:   StateFailed,
+				Message: "Codex login could not be refreshed. Reconnect it in Admin.",
+			})
+		}
+		return errors.New("refresh Codex account")
+	}
+	var response struct {
+		Account *struct {
+			Type string `json:"type"`
+		} `json:"account"`
+	}
+	if json.Unmarshal(result, &response) != nil {
+		return errors.New("decode Codex account")
+	}
+	if response.Account == nil || response.Account.Type != "chatgpt" {
+		m.setStatusUnlessLoginActive(Status{State: StateDisconnected})
+		return errors.New("Codex ChatGPT login is not connected")
+	}
+	m.setStatusUnlessLoginActive(Status{State: StateConnected})
+	return nil
+}
+
+func (m *Manager) startDeviceLogin() {
+	ctx, cancel := context.WithTimeout(m.parent, requestTimeout)
+	defer cancel()
+	result, err := m.call(ctx, "account/login/start", map[string]string{
+		"type": "chatgptDeviceCode",
+	})
+	if err != nil {
+		m.failStarting("Codex device login could not be started.")
+		return
+	}
+	var response struct {
+		Type            string `json:"type"`
+		LoginID         string `json:"loginId"`
+		VerificationURL string `json:"verificationUrl"`
+		UserCode        string `json:"userCode"`
+	}
+	if json.Unmarshal(result, &response) != nil ||
+		response.Type != "chatgptDeviceCode" ||
+		strings.TrimSpace(response.LoginID) == "" ||
+		response.VerificationURL != "https://auth.openai.com/codex/device" ||
+		!userCodePattern.MatchString(response.UserCode) {
+		m.fail("Codex device login returned invalid authorization instructions.")
+		return
+	}
+	m.mu.Lock()
+	m.loginID = response.LoginID
+	m.status = Status{
+		State:           StateAwaiting,
+		VerificationURL: response.VerificationURL,
+		UserCode:        response.UserCode,
+	}
+	m.mu.Unlock()
+}
+
+func (m *Manager) ensureProcess(ctx context.Context) error {
+	m.startMu.Lock()
+	defer m.startMu.Unlock()
+
+	m.mu.RLock()
+	running := m.running
+	m.mu.RUnlock()
+	if running {
+		return nil
+	}
+	if m.executable == "" || m.home == "" {
+		return errors.New("Codex app-server is unavailable")
+	}
+	if err := os.MkdirAll(m.home, 0o700); err != nil {
+		return errors.New("prepare Codex home")
+	}
+
+	processCtx, cancel := context.WithCancel(m.parent)
+	cmd := m.command(processCtx, m.executable, "app-server", "--listen", "stdio://")
+	cmd.Env = withCodexHome(os.Environ(), m.home)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		cancel()
+		return errors.New("open Codex app-server input")
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		return errors.New("open Codex app-server output")
+	}
+	cmd.Stderr = io.Discard
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return errors.New("start Codex app-server")
+	}
+
+	m.mu.Lock()
+	m.running = true
+	m.stdin = stdin
+	m.cancel = cancel
+	m.mu.Unlock()
+	go m.readLoop(cmd, stdout)
+
+	initCtx, initCancel := context.WithTimeout(ctx, requestTimeout)
+	defer initCancel()
+	if _, err := m.callRunning(initCtx, "initialize", map[string]any{
+		"clientInfo": map[string]string{
+			"name":    "pai_bot",
+			"title":   "PaiBot",
+			"version": "1",
+		},
+	}); err != nil {
+		cancel()
+		return errors.New("initialize Codex app-server")
+	}
+	if err := m.notify(map[string]any{"method": "initialized", "params": map[string]any{}}); err != nil {
+		cancel()
+		return errors.New("acknowledge Codex app-server")
+	}
+	return nil
+}
+
+func (m *Manager) call(ctx context.Context, method string, params any) (json.RawMessage, error) {
+	if err := m.ensureProcess(ctx); err != nil {
+		return nil, err
+	}
+	return m.callRunning(ctx, method, params)
+}
+
+func (m *Manager) callRunning(ctx context.Context, method string, params any) (json.RawMessage, error) {
+	m.mu.Lock()
+	m.nextID++
+	id := m.nextID
+	response := make(chan pendingResponse, 1)
+	m.pending[id] = response
+	m.mu.Unlock()
+
+	if err := m.write(map[string]any{"id": id, "method": method, "params": params}); err != nil {
+		m.removePending(id)
+		return nil, err
+	}
+	select {
+	case result := <-response:
+		if result.err != nil {
+			return nil, result.err
+		}
+		if result.message.Error != nil {
+			return nil, errors.New("Codex app-server request failed")
+		}
+		return result.message.Result, nil
+	case <-ctx.Done():
+		m.removePending(id)
+		return nil, ctx.Err()
+	}
+}
+
+func (m *Manager) notify(message any) error {
+	return m.write(message)
+}
+
+func (m *Manager) write(message any) error {
+	m.writeMu.Lock()
+	defer m.writeMu.Unlock()
+	m.mu.RLock()
+	stdin := m.stdin
+	running := m.running
+	m.mu.RUnlock()
+	if !running || stdin == nil {
+		return errors.New("Codex app-server is not running")
+	}
+	if err := json.NewEncoder(stdin).Encode(message); err != nil {
+		return errors.New("write Codex app-server request")
+	}
+	return nil
+}
+
+func (m *Manager) readLoop(cmd *exec.Cmd, output io.Reader) {
+	scanner := bufio.NewScanner(output)
+	scanner.Buffer(make([]byte, 64*1024), 1<<20)
+	for scanner.Scan() {
+		var message rpcMessage
+		if json.Unmarshal(scanner.Bytes(), &message) != nil {
+			continue
+		}
+		if message.ID != nil {
+			m.resolve(*message.ID, pendingResponse{message: message})
+			continue
+		}
+		if message.Method == "account/login/completed" {
+			m.handleLoginCompleted(message.Params)
+		}
+	}
+	_ = cmd.Wait()
+	m.processStopped()
+}
+
+func (m *Manager) handleLoginCompleted(params json.RawMessage) {
+	var completed struct {
+		LoginID string `json:"loginId"`
+		Success bool   `json:"success"`
+	}
+	if json.Unmarshal(params, &completed) != nil {
+		return
+	}
+	m.mu.RLock()
+	activeLoginID := m.loginID
+	m.mu.RUnlock()
+	if activeLoginID == "" || completed.LoginID != activeLoginID {
+		return
+	}
+	if !completed.Success {
+		m.fail("Codex device login failed. Start a new login.")
+		return
+	}
+
+	m.mu.RLock()
+	callback := m.onConnected
+	m.mu.RUnlock()
+	if callback != nil {
+		ctx, cancel := context.WithTimeout(m.parent, requestTimeout)
+		err := callback(ctx)
+		cancel()
+		if err != nil {
+			m.fail("Codex connected, but PaiBot could not select it as the default provider.")
+			return
+		}
+	}
+	m.mu.Lock()
+	m.loginID = ""
+	m.status = Status{State: StateConnected}
+	m.mu.Unlock()
+}
+
+func (m *Manager) resolve(id int64, response pendingResponse) {
+	m.mu.Lock()
+	waiter := m.pending[id]
+	delete(m.pending, id)
+	m.mu.Unlock()
+	if waiter != nil {
+		waiter <- response
+	}
+}
+
+func (m *Manager) removePending(id int64) {
+	m.mu.Lock()
+	delete(m.pending, id)
+	m.mu.Unlock()
+}
+
+func (m *Manager) processStopped() {
+	m.mu.Lock()
+	m.running = false
+	m.stdin = nil
+	m.cancel = nil
+	if m.status.State == StateStarting || m.status.State == StateAwaiting {
+		m.status = Status{
+			State:   StateFailed,
+			Message: "Codex device login stopped before authorization completed.",
+		}
+		m.loginID = ""
+	} else if m.status.State == StateConnected && m.parent.Err() == nil {
+		m.status = Status{
+			State:   StateFailed,
+			Message: "Codex app-server stopped unexpectedly. Reconnect it in Admin.",
+		}
+	}
+	pending := m.pending
+	m.pending = make(map[int64]chan pendingResponse)
+	m.mu.Unlock()
+	for _, waiter := range pending {
+		waiter <- pendingResponse{err: errors.New("Codex app-server stopped")}
+	}
+}
+
+func (m *Manager) fail(message string) {
+	m.setStatus(Status{State: StateFailed, Message: message})
+}
+
+func (m *Manager) failStarting(message string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.status.State == StateStarting {
+		m.status = Status{State: StateFailed, Message: message}
+	}
+}
+
+func (m *Manager) setStatus(status Status) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.status = status
+}
+
+func (m *Manager) setStatusUnlessLoginActive(status Status) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.status.State == StateStarting || m.status.State == StateAwaiting {
+		return
+	}
+	m.status = status
+}
+
+func withCodexHome(environment []string, home string) []string {
+	result := make([]string, 0, len(environment)+1)
+	for _, variable := range environment {
+		if strings.HasPrefix(variable, "CODEX_HOME=") {
+			continue
+		}
+		result = append(result, variable)
+	}
+	return append(result, "CODEX_HOME="+filepath.Clean(home))
+}

--- a/internal/platform/codexauth/manager_test.go
+++ b/internal/platform/codexauth/manager_test.go
@@ -9,8 +9,11 @@ import (
 	"encoding/json"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/p-n-ai/pai-bot/internal/ai"
 )
 
 func TestDeviceLoginUsesStructuredAppServerFlow(t *testing.T) {
@@ -131,6 +134,37 @@ func TestWithCodexHomeReplacesInheritedValue(t *testing.T) {
 	}
 }
 
+func TestCompleteUsesEphemeralNonInteractiveAppServerThread(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	manager := New(ctx, t.TempDir(), "codex", nil)
+	manager.command = helperCommand("codex-app-server-completion")
+
+	response, err := manager.Complete(t.Context(), ai.CompletionRequest{
+		Model: "gpt-test",
+		Messages: []ai.Message{
+			{Role: "system", Content: "Teach clearly."},
+			{Role: "user", Content: "Explain fractions."},
+		},
+		StructuredOutput: &ai.StructuredOutputSpec{
+			Name:       "answer",
+			JSONSchema: json.RawMessage(`{"type":"object","required":["answer"],"properties":{"answer":{"type":"string"}}}`),
+			Strict:     true,
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	if response.Content != `{"answer":"Use equal parts."}` ||
+		string(response.StructuredOutput) != response.Content ||
+		response.Model != "gpt-test" ||
+		response.InputTokens != 17 ||
+		response.OutputTokens != 6 {
+		t.Fatalf("Complete() response = %#v", response)
+	}
+}
+
 func newTestManager(
 	ctx context.Context,
 	home string,
@@ -181,6 +215,7 @@ func TestCodexAppServerHelperProcess(t *testing.T) {
 	mode := os.Args[len(os.Args)-1]
 	if mode != "codex-app-server-helper" &&
 		mode != "codex-app-server-awaits-login" &&
+		mode != "codex-app-server-completion" &&
 		mode != "codex-app-server-stops-after-login" &&
 		mode != "codex-app-server-stops-during-login" {
 		return
@@ -253,6 +288,95 @@ func TestCodexAppServerHelperProcess(t *testing.T) {
 			if mode == "codex-app-server-stops-after-login" {
 				os.Exit(0)
 			}
+		case "thread/start":
+			var params struct {
+				BaseInstructions      string   `json:"baseInstructions"`
+				CWD                   string   `json:"cwd"`
+				DeveloperInstructions string   `json:"developerInstructions"`
+				DynamicTools          []any    `json:"dynamicTools"`
+				Environments          []any    `json:"environments"`
+				Ephemeral             bool     `json:"ephemeral"`
+				Model                 string   `json:"model"`
+				Permissions           string   `json:"permissions"`
+				RuntimeWorkspaceRoots []string `json:"runtimeWorkspaceRoots"`
+			}
+			if json.Unmarshal(request.Params, &params) != nil ||
+				params.BaseInstructions != "Teach clearly." ||
+				params.CWD == "" ||
+				!strings.Contains(params.DeveloperInstructions, "Do not inspect files") ||
+				params.DynamicTools == nil ||
+				params.Environments == nil ||
+				!params.Ephemeral ||
+				params.Model != "gpt-test" ||
+				params.Permissions != ":read-only" ||
+				len(params.RuntimeWorkspaceRoots) != 1 ||
+				params.RuntimeWorkspaceRoots[0] != params.CWD {
+				_ = encoder.Encode(map[string]any{
+					"id":    *request.ID,
+					"error": map[string]any{"code": -1, "message": "unsafe thread parameters"},
+				})
+				continue
+			}
+			_ = encoder.Encode(map[string]any{
+				"id": *request.ID,
+				"result": map[string]any{
+					"thread": map[string]any{"id": "thread-1"},
+					"model":  "gpt-test",
+				},
+			})
+		case "turn/start":
+			var params struct {
+				ApprovalPolicy string           `json:"approvalPolicy"`
+				Input          []map[string]any `json:"input"`
+				OutputSchema   map[string]any   `json:"outputSchema"`
+				Permissions    string           `json:"permissions"`
+				ThreadID       string           `json:"threadId"`
+			}
+			var text string
+			if json.Unmarshal(request.Params, &params) != nil {
+				text = ""
+			} else if len(params.Input) > 0 {
+				text, _ = params.Input[0]["text"].(string)
+			}
+			if params.ApprovalPolicy != "never" ||
+				!strings.Contains(text, "USER:\nExplain fractions.") ||
+				params.OutputSchema["type"] != "object" ||
+				params.Permissions != ":read-only" ||
+				params.ThreadID != "thread-1" {
+				_ = encoder.Encode(map[string]any{
+					"id":    *request.ID,
+					"error": map[string]any{"code": -1, "message": "unsafe turn parameters"},
+				})
+				continue
+			}
+			_ = encoder.Encode(map[string]any{
+				"id":     *request.ID,
+				"result": map[string]any{"turn": map[string]any{"id": "turn-1"}},
+			})
+			_ = encoder.Encode(map[string]any{
+				"method": "thread/tokenUsage/updated",
+				"params": map[string]any{
+					"threadId": "thread-1",
+					"tokenUsage": map[string]any{
+						"last": map[string]any{"inputTokens": 17, "outputTokens": 6},
+					},
+				},
+			})
+			_ = encoder.Encode(map[string]any{
+				"method": "turn/completed",
+				"params": map[string]any{
+					"threadId": "thread-1",
+					"turn": map[string]any{
+						"status": "completed",
+						"items": []map[string]any{{
+							"id":    "message-1",
+							"type":  "agentMessage",
+							"text":  `{"answer":"Use equal parts."}`,
+							"phase": "final_answer",
+						}},
+					},
+				},
+			})
 		}
 	}
 	os.Exit(0)

--- a/internal/platform/codexauth/manager_test.go
+++ b/internal/platform/codexauth/manager_test.go
@@ -1,0 +1,259 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package codexauth
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+func TestDeviceLoginUsesStructuredAppServerFlow(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	connected := make(chan struct{}, 1)
+	manager := newTestManager(ctx, t.TempDir(), func(context.Context) error {
+		connected <- struct{}{}
+		return nil
+	})
+
+	status, err := manager.Start()
+	if err != nil || status.State != StateStarting {
+		t.Fatalf("Start() = %#v, %v; want starting", status, err)
+	}
+	awaitState(t, manager, StateAwaiting)
+	awaitSignal(t, connected)
+	awaitState(t, manager, StateConnected)
+}
+
+func TestInitializeAndRefreshUseManagedChatGPTAccount(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	manager := newTestManager(ctx, t.TempDir(), nil)
+
+	manager.Initialize()
+	awaitState(t, manager, StateConnected)
+	if err := manager.Refresh(t.Context()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+}
+
+func TestStartRenewsConnectedAccountWithDeviceLogin(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	manager := newTestManager(ctx, t.TempDir(), nil)
+	manager.Initialize()
+	awaitState(t, manager, StateConnected)
+
+	status, err := manager.Start()
+	if err != nil || status.State != StateStarting {
+		t.Fatalf("Start() = %#v, %v; want starting", status, err)
+	}
+	awaitState(t, manager, StateAwaiting)
+}
+
+func TestRefreshDoesNotHideActiveDeviceLogin(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	manager := New(ctx, t.TempDir(), "codex", nil)
+	manager.command = helperCommand("codex-app-server-awaits-login")
+
+	if _, err := manager.Start(); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	awaitState(t, manager, StateAwaiting)
+	if err := manager.Refresh(t.Context()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+	if got := manager.Status().State; got != StateAwaiting {
+		t.Fatalf("Status().State = %q, want %q", got, StateAwaiting)
+	}
+}
+
+func TestStartWithoutExecutableReturnsSafeFailure(t *testing.T) {
+	manager := New(t.Context(), t.TempDir(), "", nil)
+
+	status, err := manager.Start()
+
+	if err == nil || status != (Status{
+		State:   StateFailed,
+		Message: "Codex CLI is not installed on the server.",
+	}) {
+		t.Fatalf("Start() = %#v, %v", status, err)
+	}
+}
+
+func TestDeviceLoginFailsWhenAppServerStopsBeforeCompletion(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	manager := New(ctx, t.TempDir(), "codex", nil)
+	manager.command = helperCommand("codex-app-server-stops-during-login")
+
+	if _, err := manager.Start(); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	awaitState(t, manager, StateFailed)
+	if got := manager.Status().Message; got != "Codex device login stopped before authorization completed." {
+		t.Fatalf("Status().Message = %q", got)
+	}
+}
+
+func TestConnectedStateFailsWhenAppServerStopsUnexpectedly(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	connected := make(chan struct{}, 1)
+	manager := New(ctx, t.TempDir(), "codex", func(context.Context) error {
+		connected <- struct{}{}
+		return nil
+	})
+	manager.command = helperCommand("codex-app-server-stops-after-login")
+
+	if _, err := manager.Start(); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	awaitSignal(t, connected)
+	awaitState(t, manager, StateFailed)
+	if got := manager.Status().Message; got != "Codex app-server stopped unexpectedly. Reconnect it in Admin." {
+		t.Fatalf("Status().Message = %q", got)
+	}
+}
+
+func TestWithCodexHomeReplacesInheritedValue(t *testing.T) {
+	got := withCodexHome([]string{"PATH=/bin", "CODEX_HOME=/personal/codex"}, "/server/codex")
+	want := []string{"PATH=/bin", "CODEX_HOME=/server/codex"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("withCodexHome() = %v, want %v", got, want)
+	}
+}
+
+func newTestManager(
+	ctx context.Context,
+	home string,
+	onConnected func(context.Context) error,
+) *Manager {
+	manager := New(ctx, home, "codex", onConnected)
+	manager.command = helperCommand("codex-app-server-helper")
+	return manager
+}
+
+func helperCommand(mode string) commandFactory {
+	return func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+		return exec.CommandContext(
+			ctx,
+			os.Args[0],
+			"-test.run=TestCodexAppServerHelperProcess",
+			"--",
+			mode,
+		)
+	}
+}
+
+func awaitState(t *testing.T, manager *Manager, want State) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if manager.Status().State == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("Status() = %#v, want %q", manager.Status(), want)
+}
+
+func awaitSignal(t *testing.T, signal <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(2 * time.Second):
+		t.Fatal("connected callback was not called")
+	}
+}
+
+func TestCodexAppServerHelperProcess(t *testing.T) {
+	if len(os.Args) == 0 {
+		return
+	}
+	mode := os.Args[len(os.Args)-1]
+	if mode != "codex-app-server-helper" &&
+		mode != "codex-app-server-awaits-login" &&
+		mode != "codex-app-server-stops-after-login" &&
+		mode != "codex-app-server-stops-during-login" {
+		return
+	}
+	scanner := bufio.NewScanner(os.Stdin)
+	encoder := json.NewEncoder(os.Stdout)
+	for scanner.Scan() {
+		var request struct {
+			ID     *int64          `json:"id"`
+			Method string          `json:"method"`
+			Params json.RawMessage `json:"params"`
+		}
+		if json.Unmarshal(scanner.Bytes(), &request) != nil || request.ID == nil {
+			continue
+		}
+		switch request.Method {
+		case "initialize":
+			_ = encoder.Encode(map[string]any{"id": *request.ID, "result": map[string]any{}})
+		case "account/read":
+			var params struct {
+				RefreshToken *bool `json:"refreshToken"`
+			}
+			if json.Unmarshal(request.Params, &params) != nil || params.RefreshToken == nil {
+				_ = encoder.Encode(map[string]any{
+					"id":    *request.ID,
+					"error": map[string]any{"code": -1, "message": "missing refreshToken"},
+				})
+				continue
+			}
+			_ = encoder.Encode(map[string]any{
+				"id": *request.ID,
+				"result": map[string]any{
+					"account": map[string]any{"type": "chatgpt"},
+				},
+			})
+		case "account/login/start":
+			if mode == "codex-app-server-stops-during-login" {
+				os.Exit(0)
+			}
+			var params struct {
+				Type string `json:"type"`
+			}
+			if json.Unmarshal(request.Params, &params) != nil || params.Type != "chatgptDeviceCode" {
+				_ = encoder.Encode(map[string]any{
+					"id":    *request.ID,
+					"error": map[string]any{"code": -1, "message": "wrong login type"},
+				})
+				continue
+			}
+			_ = encoder.Encode(map[string]any{
+				"id": *request.ID,
+				"result": map[string]any{
+					"type":            "chatgptDeviceCode",
+					"loginId":         "login-1",
+					"verificationUrl": "https://auth.openai.com/codex/device",
+					"userCode":        "ABCD-1234",
+				},
+			})
+			if mode == "codex-app-server-awaits-login" {
+				continue
+			}
+			time.Sleep(25 * time.Millisecond)
+			_ = encoder.Encode(map[string]any{
+				"method": "account/login/completed",
+				"params": map[string]any{
+					"loginId": "login-1",
+					"success": true,
+				},
+			})
+			if mode == "codex-app-server-stops-after-login" {
+				os.Exit(0)
+			}
+		}
+	}
+	os.Exit(0)
+}

--- a/internal/platform/codexauth/manager_test.go
+++ b/internal/platform/codexauth/manager_test.go
@@ -290,27 +290,20 @@ func TestCodexAppServerHelperProcess(t *testing.T) {
 			}
 		case "thread/start":
 			var params struct {
-				BaseInstructions      string   `json:"baseInstructions"`
-				CWD                   string   `json:"cwd"`
-				DeveloperInstructions string   `json:"developerInstructions"`
-				DynamicTools          []any    `json:"dynamicTools"`
-				Environments          []any    `json:"environments"`
-				Ephemeral             bool     `json:"ephemeral"`
-				Model                 string   `json:"model"`
-				Permissions           string   `json:"permissions"`
-				RuntimeWorkspaceRoots []string `json:"runtimeWorkspaceRoots"`
+				BaseInstructions      string `json:"baseInstructions"`
+				CWD                   string `json:"cwd"`
+				DeveloperInstructions string `json:"developerInstructions"`
+				Ephemeral             bool   `json:"ephemeral"`
+				Model                 string `json:"model"`
+				Sandbox               string `json:"sandbox"`
 			}
 			if json.Unmarshal(request.Params, &params) != nil ||
 				params.BaseInstructions != "Teach clearly." ||
 				params.CWD == "" ||
 				!strings.Contains(params.DeveloperInstructions, "Do not inspect files") ||
-				params.DynamicTools == nil ||
-				params.Environments == nil ||
 				!params.Ephemeral ||
 				params.Model != "gpt-test" ||
-				params.Permissions != ":read-only" ||
-				len(params.RuntimeWorkspaceRoots) != 1 ||
-				params.RuntimeWorkspaceRoots[0] != params.CWD {
+				params.Sandbox != "read-only" {
 				_ = encoder.Encode(map[string]any{
 					"id":    *request.ID,
 					"error": map[string]any{"code": -1, "message": "unsafe thread parameters"},
@@ -329,7 +322,6 @@ func TestCodexAppServerHelperProcess(t *testing.T) {
 				ApprovalPolicy string           `json:"approvalPolicy"`
 				Input          []map[string]any `json:"input"`
 				OutputSchema   map[string]any   `json:"outputSchema"`
-				Permissions    string           `json:"permissions"`
 				ThreadID       string           `json:"threadId"`
 			}
 			var text string
@@ -341,7 +333,6 @@ func TestCodexAppServerHelperProcess(t *testing.T) {
 			if params.ApprovalPolicy != "never" ||
 				!strings.Contains(text, "USER:\nExplain fractions.") ||
 				params.OutputSchema["type"] != "object" ||
-				params.Permissions != ":read-only" ||
 				params.ThreadID != "thread-1" {
 				_ = encoder.Encode(map[string]any{
 					"id":    *request.ID,
@@ -363,17 +354,25 @@ func TestCodexAppServerHelperProcess(t *testing.T) {
 				},
 			})
 			_ = encoder.Encode(map[string]any{
+				"method": "item/completed",
+				"params": map[string]any{
+					"threadId": "thread-1",
+					"turnId":   "turn-1",
+					"item": map[string]any{
+						"id":    "message-1",
+						"type":  "agentMessage",
+						"text":  `{"answer":"Use equal parts."}`,
+						"phase": "final_answer",
+					},
+				},
+			})
+			_ = encoder.Encode(map[string]any{
 				"method": "turn/completed",
 				"params": map[string]any{
 					"threadId": "thread-1",
 					"turn": map[string]any{
 						"status": "completed",
-						"items": []map[string]any{{
-							"id":    "message-1",
-							"type":  "agentMessage",
-							"text":  `{"answer":"Use equal parts."}`,
-							"phase": "final_answer",
-						}},
+						"items":  []map[string]any{},
 					},
 				},
 			})

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -6,7 +6,6 @@
 package config
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
@@ -147,35 +146,10 @@ type OpenRouterConfig struct {
 type CodexConfig struct {
 	Enabled      bool
 	Home         string
-	AuthFile     string
 	AccessToken  string
 	RefreshToken string
 	AccountID    string
 	Model        string
-}
-
-// Authenticated reports whether the isolated server credential file contains
-// a credential shape the Codex provider can use or refresh.
-func (c CodexConfig) Authenticated() bool {
-	info, err := os.Stat(strings.TrimSpace(c.AuthFile))
-	if err != nil || !info.Mode().IsRegular() || info.Size() > 1<<20 {
-		return false
-	}
-	data, err := os.ReadFile(strings.TrimSpace(c.AuthFile))
-	if err != nil {
-		return false
-	}
-	var auth struct {
-		AuthMode string `json:"auth_mode"`
-		Tokens struct {
-			AccessToken string `json:"access_token"`
-		} `json:"tokens"`
-	}
-	if json.Unmarshal(data, &auth) != nil {
-		return false
-	}
-	return strings.EqualFold(strings.TrimSpace(auth.AuthMode), "chatgpt") &&
-		strings.TrimSpace(auth.Tokens.AccessToken) != ""
 }
 
 // TelegramConfig holds Telegram Bot API settings.
@@ -332,7 +306,6 @@ func Load() (*Config, error) {
 			Codex: CodexConfig{
 				Enabled:      envBool("LEARN_AI_CODEX_ENABLED", false),
 				Home:         envStr("LEARN_AI_CODEX_HOME", defaultCodexHome()),
-				AuthFile:     filepath.Join(envStr("LEARN_AI_CODEX_HOME", defaultCodexHome()), "auth.json"),
 				AccessToken:  envStr("LEARN_AI_CODEX_ACCESS_TOKEN", ""),
 				RefreshToken: envStr("LEARN_AI_CODEX_REFRESH_TOKEN", ""),
 				AccountID:    envStr("LEARN_AI_CODEX_ACCOUNT_ID", ""),
@@ -516,15 +489,14 @@ func (c *Config) HasAIProvider() bool {
 		c.AI.Google.APIKey != "" ||
 		c.AI.OpenRouter.APIKey != "" ||
 		c.AI.Ollama.Enabled ||
-		(c.AI.Codex.Enabled && c.AI.Codex.Authenticated())
+		c.CodexDeviceAuthAvailable()
 }
 
 // CodexDeviceAuthAvailable reports whether the server has isolated storage
 // where an authenticated admin can establish the Codex provider.
 func (c *Config) CodexDeviceAuthAvailable() bool {
 	return c.AI.Codex.Enabled &&
-		strings.TrimSpace(c.AI.Codex.Home) != "" &&
-		strings.TrimSpace(c.AI.Codex.AuthFile) != ""
+		strings.TrimSpace(c.AI.Codex.Home) != ""
 }
 
 func (c *Config) mockAIProviderEnabled() bool {

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -6,9 +6,11 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -110,14 +112,6 @@ type OpenAIConfig struct {
 	Model  string
 }
 
-// CodexConfig holds Codex provider settings.
-type CodexConfig struct {
-	AccessToken  string
-	RefreshToken string
-	AccountID    string
-	Model        string
-}
-
 // AnthropicConfig holds Anthropic provider settings.
 type AnthropicConfig struct {
 	APIKey string
@@ -147,6 +141,41 @@ type OllamaConfig struct {
 type OpenRouterConfig struct {
 	APIKey string
 	Model  string
+}
+
+// CodexConfig holds local Codex CLI credential and model settings.
+type CodexConfig struct {
+	Enabled      bool
+	Home         string
+	AuthFile     string
+	AccessToken  string
+	RefreshToken string
+	AccountID    string
+	Model        string
+}
+
+// Authenticated reports whether the isolated server credential file contains
+// a credential shape the Codex provider can use or refresh.
+func (c CodexConfig) Authenticated() bool {
+	info, err := os.Stat(strings.TrimSpace(c.AuthFile))
+	if err != nil || !info.Mode().IsRegular() || info.Size() > 1<<20 {
+		return false
+	}
+	data, err := os.ReadFile(strings.TrimSpace(c.AuthFile))
+	if err != nil {
+		return false
+	}
+	var auth struct {
+		AuthMode string `json:"auth_mode"`
+		Tokens struct {
+			AccessToken string `json:"access_token"`
+		} `json:"tokens"`
+	}
+	if json.Unmarshal(data, &auth) != nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(auth.AuthMode), "chatgpt") &&
+		strings.TrimSpace(auth.Tokens.AccessToken) != ""
 }
 
 // TelegramConfig holds Telegram Bot API settings.
@@ -279,12 +308,6 @@ func Load() (*Config, error) {
 				APIKey: envStr("LEARN_AI_OPENAI_API_KEY", ""),
 				Model:  envStr("LEARN_AI_OPENAI_MODEL", ""),
 			},
-			Codex: CodexConfig{
-				AccessToken:  envStr("LEARN_AI_CODEX_ACCESS_TOKEN", ""),
-				RefreshToken: envStr("LEARN_AI_CODEX_REFRESH_TOKEN", ""),
-				AccountID:    envStr("LEARN_AI_CODEX_ACCOUNT_ID", ""),
-				Model:        envStr("LEARN_AI_CODEX_MODEL", ""),
-			},
 			Anthropic: AnthropicConfig{
 				APIKey: envStr("LEARN_AI_ANTHROPIC_API_KEY", ""),
 				Model:  envStr("LEARN_AI_ANTHROPIC_MODEL", ""),
@@ -305,6 +328,15 @@ func Load() (*Config, error) {
 			OpenRouter: OpenRouterConfig{
 				APIKey: envStr("LEARN_AI_OPENROUTER_API_KEY", ""),
 				Model:  envStr("LEARN_AI_OPENROUTER_MODEL", ""),
+			},
+			Codex: CodexConfig{
+				Enabled:      envBool("LEARN_AI_CODEX_ENABLED", false),
+				Home:         envStr("LEARN_AI_CODEX_HOME", defaultCodexHome()),
+				AuthFile:     filepath.Join(envStr("LEARN_AI_CODEX_HOME", defaultCodexHome()), "auth.json"),
+				AccessToken:  envStr("LEARN_AI_CODEX_ACCESS_TOKEN", ""),
+				RefreshToken: envStr("LEARN_AI_CODEX_REFRESH_TOKEN", ""),
+				AccountID:    envStr("LEARN_AI_CODEX_ACCOUNT_ID", ""),
+				Model:        envStr("LEARN_AI_CODEX_MODEL", "gpt-5.4"),
 			},
 		},
 		Email: EmailConfig{
@@ -384,7 +416,10 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("at least one external chat adapter must be configured")
 	}
 
-	if !c.HasAIProvider() && !c.Runtime.DevMode {
+	if c.AI.Codex.Enabled && isPersonalCodexHome(c.AI.Codex.Home) {
+		return fmt.Errorf("LEARN_AI_CODEX_HOME must not use the backend user's personal .codex directory")
+	}
+	if !c.HasAIProvider() && !c.CodexDeviceAuthAvailable() && !c.Runtime.DevMode {
 		return fmt.Errorf("at least one AI provider must be configured")
 	}
 	if c.AI.DefaultProvider != "" && !isKnownAIProvider(c.AI.DefaultProvider) {
@@ -480,7 +515,16 @@ func (c *Config) HasAIProvider() bool {
 		c.AI.DeepSeek.APIKey != "" ||
 		c.AI.Google.APIKey != "" ||
 		c.AI.OpenRouter.APIKey != "" ||
-		c.AI.Ollama.Enabled
+		c.AI.Ollama.Enabled ||
+		(c.AI.Codex.Enabled && c.AI.Codex.Authenticated())
+}
+
+// CodexDeviceAuthAvailable reports whether the server has isolated storage
+// where an authenticated admin can establish the Codex provider.
+func (c *Config) CodexDeviceAuthAvailable() bool {
+	return c.AI.Codex.Enabled &&
+		strings.TrimSpace(c.AI.Codex.Home) != "" &&
+		strings.TrimSpace(c.AI.Codex.AuthFile) != ""
 }
 
 func (c *Config) mockAIProviderEnabled() bool {
@@ -495,6 +539,30 @@ func isKnownAIProvider(name string) bool {
 	default:
 		return false
 	}
+}
+
+func defaultCodexHome() string {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(configDir, "pai-bot", "codex")
+}
+
+func isPersonalCodexHome(configured string) bool {
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(configured) == "" {
+		return false
+	}
+	personal := filepath.Join(home, ".codex")
+	configuredAbs, configuredErr := filepath.Abs(configured)
+	personalAbs, personalErr := filepath.Abs(personal)
+	if configuredErr == nil && personalErr == nil && filepath.Clean(configuredAbs) == filepath.Clean(personalAbs) {
+		return true
+	}
+	configuredInfo, configuredErr := os.Stat(configured)
+	personalInfo, personalErr := os.Stat(personal)
+	return configuredErr == nil && personalErr == nil && os.SameFile(configuredInfo, personalInfo)
 }
 
 func envStr(key, fallback string) string {

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -56,6 +57,9 @@ func clearEnv(t *testing.T) {
 		"LEARN_AI_GOOGLE_MODEL",
 		"LEARN_AI_OPENROUTER_API_KEY",
 		"LEARN_AI_OPENROUTER_MODEL",
+		"LEARN_AI_CODEX_ENABLED",
+		"LEARN_AI_CODEX_HOME",
+		"LEARN_AI_CODEX_MODEL",
 		"LEARN_AI_DEFAULT_PROVIDER",
 		"LEARN_AI_OLLAMA_ENABLED",
 		"LEARN_AI_OLLAMA_URL",
@@ -82,6 +86,7 @@ func clearEnv(t *testing.T) {
 	for _, v := range envVars {
 		_ = os.Unsetenv(v)
 	}
+	t.Setenv("LEARN_AI_CODEX_HOME", filepath.Join(t.TempDir(), "codex"))
 }
 
 func TestLoad_FeatureFlagsRejectUnknown(t *testing.T) {
@@ -171,6 +176,9 @@ func TestLoad_FromEnv(t *testing.T) {
 	t.Setenv("LEARN_AI_MOCK_RESPONSE", "mock tutor response")
 	t.Setenv("LEARN_AI_OLLAMA_URL", "http://localhost:11434")
 	t.Setenv("LEARN_AI_OLLAMA_MODEL", "qwen3:14b")
+	t.Setenv("LEARN_AI_CODEX_ENABLED", "true")
+	t.Setenv("LEARN_AI_CODEX_HOME", "/tmp/pai-bot-codex")
+	t.Setenv("LEARN_AI_CODEX_MODEL", "gpt-test")
 	t.Setenv("LEARN_AI_DEFAULT_PROVIDER", "openrouter")
 	t.Setenv("PAI_AUTH_SECRET", "super-secret")
 	t.Setenv("PAI_AUTH_GOOGLE_CLIENT_ID", "google-client")
@@ -253,6 +261,12 @@ func TestLoad_FromEnv(t *testing.T) {
 	}
 	if cfg.AI.Ollama.Model != "qwen3:14b" {
 		t.Errorf("AI.Ollama.Model = %q, want qwen3:14b", cfg.AI.Ollama.Model)
+	}
+	if !cfg.AI.Codex.Enabled ||
+		cfg.AI.Codex.Home != "/tmp/pai-bot-codex" ||
+		cfg.AI.Codex.AuthFile != "/tmp/pai-bot-codex/auth.json" ||
+		cfg.AI.Codex.Model != "gpt-test" {
+		t.Errorf("AI.Codex = %#v", cfg.AI.Codex)
 	}
 	if cfg.AI.DefaultProvider != "openrouter" {
 		t.Errorf("AI.DefaultProvider = %q, want openrouter", cfg.AI.DefaultProvider)
@@ -395,7 +409,6 @@ func TestValidate_DefaultProvider_Invalid(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load() error = %v", err)
 	}
-
 	if err := cfg.Validate(); err == nil {
 		t.Fatal("Validate() should reject unsupported LEARN_AI_DEFAULT_PROVIDER")
 	}
@@ -474,6 +487,7 @@ func TestValidate_MissingAIProvider(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load() error = %v", err)
 	}
+	cfg.AI.Codex = CodexConfig{}
 
 	if err := cfg.Validate(); err == nil {
 		t.Fatal("Validate() should return error when no AI provider is configured")
@@ -725,6 +739,99 @@ func TestHasAIProvider(t *testing.T) {
 				t.Errorf("HasAIProvider() = %v, want %v", cfg.HasAIProvider(), tt.want)
 			}
 		})
+	}
+}
+
+func TestHasAIProviderRecognizesExistingCodexLogin(t *testing.T) {
+	clearEnv(t)
+	home := t.TempDir()
+	t.Setenv("LEARN_AI_CODEX_ENABLED", "true")
+	t.Setenv("LEARN_AI_CODEX_HOME", home)
+	if err := os.WriteFile(
+		filepath.Join(home, "auth.json"),
+		[]byte(`{"auth_mode":"chatgpt","tokens":{"access_token":"test-token"}}`),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if !cfg.HasAIProvider() {
+		t.Fatal("HasAIProvider() = false, want true for existing Codex auth")
+	}
+}
+
+func TestHasAIProviderRejectsUnusableCodexAuthFile(t *testing.T) {
+	clearEnv(t)
+	home := t.TempDir()
+	t.Setenv("LEARN_AI_CODEX_ENABLED", "true")
+	t.Setenv("LEARN_AI_CODEX_HOME", home)
+	if err := os.WriteFile(filepath.Join(home, "auth.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.HasAIProvider() {
+		t.Fatal("HasAIProvider() = true for unusable Codex auth")
+	}
+}
+
+func TestValidateAllowsAdminCodexSetupWithoutExistingProvider(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("LEARN_TELEGRAM_BOT_TOKEN", "test-token")
+	t.Setenv("LEARN_AI_CODEX_ENABLED", "true")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.HasAIProvider() {
+		t.Fatal("HasAIProvider() = true before Codex auth")
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v, want Admin Codex setup allowed", err)
+	}
+}
+
+func TestValidateRejectsAdminCodexSetupWhenDisabled(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("LEARN_TELEGRAM_BOT_TOKEN", "test-token")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.CodexDeviceAuthAvailable() {
+		t.Fatal("CodexDeviceAuthAvailable() = true while Codex is disabled")
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("Validate() should reject zero providers while Codex is disabled")
+	}
+}
+
+func TestValidateRejectsPersonalCodexHome(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("LEARN_TELEGRAM_BOT_TOKEN", "test-token")
+	t.Setenv("LEARN_AI_CODEX_ENABLED", "true")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LEARN_AI_CODEX_HOME", filepath.Join(home, ".codex"))
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	err = cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "personal .codex") {
+		t.Fatalf("Validate() error = %v, want personal Codex home rejection", err)
 	}
 }
 

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -264,7 +264,6 @@ func TestLoad_FromEnv(t *testing.T) {
 	}
 	if !cfg.AI.Codex.Enabled ||
 		cfg.AI.Codex.Home != "/tmp/pai-bot-codex" ||
-		cfg.AI.Codex.AuthFile != "/tmp/pai-bot-codex/auth.json" ||
 		cfg.AI.Codex.Model != "gpt-test" {
 		t.Errorf("AI.Codex = %#v", cfg.AI.Codex)
 	}
@@ -742,43 +741,25 @@ func TestHasAIProvider(t *testing.T) {
 	}
 }
 
-func TestHasAIProviderRecognizesExistingCodexLogin(t *testing.T) {
+func TestHasAIProviderRecognizesEnabledCodexDeviceSetup(t *testing.T) {
 	clearEnv(t)
 	home := t.TempDir()
 	t.Setenv("LEARN_AI_CODEX_ENABLED", "true")
 	t.Setenv("LEARN_AI_CODEX_HOME", home)
-	if err := os.WriteFile(
-		filepath.Join(home, "auth.json"),
-		[]byte(`{"auth_mode":"chatgpt","tokens":{"access_token":"test-token"}}`),
-		0o600,
-	); err != nil {
-		t.Fatal(err)
-	}
 
 	cfg, err := Load()
 	if err != nil {
 		t.Fatalf("Load() error = %v", err)
 	}
 	if !cfg.HasAIProvider() {
-		t.Fatal("HasAIProvider() = false, want true for existing Codex auth")
+		t.Fatal("HasAIProvider() = false, want true for enabled Codex device setup")
 	}
 }
 
-func TestHasAIProviderRejectsUnusableCodexAuthFile(t *testing.T) {
-	clearEnv(t)
-	home := t.TempDir()
-	t.Setenv("LEARN_AI_CODEX_ENABLED", "true")
-	t.Setenv("LEARN_AI_CODEX_HOME", home)
-	if err := os.WriteFile(filepath.Join(home, "auth.json"), []byte("{}"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	cfg, err := Load()
-	if err != nil {
-		t.Fatalf("Load() error = %v", err)
-	}
+func TestHasAIProviderRejectsCodexDeviceSetupWithoutHome(t *testing.T) {
+	cfg := Config{AI: AIConfig{Codex: CodexConfig{Enabled: true}}}
 	if cfg.HasAIProvider() {
-		t.Fatal("HasAIProvider() = true for unusable Codex auth")
+		t.Fatal("HasAIProvider() = true without Codex device storage")
 	}
 }
 
@@ -791,8 +772,8 @@ func TestValidateAllowsAdminCodexSetupWithoutExistingProvider(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load() error = %v", err)
 	}
-	if cfg.HasAIProvider() {
-		t.Fatal("HasAIProvider() = true before Codex auth")
+	if !cfg.HasAIProvider() {
+		t.Fatal("HasAIProvider() = false for enabled Codex app-server setup")
 	}
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("Validate() error = %v, want Admin Codex setup allowed", err)

--- a/internal/server/admin_ai_settings.go
+++ b/internal/server/admin_ai_settings.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/p-n-ai/pai-bot/internal/platform/airouter"
+	"github.com/p-n-ai/pai-bot/internal/platform/codexauth"
 	"github.com/p-n-ai/pai-bot/internal/platform/config"
 	"github.com/p-n-ai/pai-bot/internal/platform/featureflags"
 	"github.com/p-n-ai/pai-bot/internal/platform/settings"
@@ -26,6 +27,11 @@ type runtimeSettingsStore interface {
 	MergedAI(settings.Settings) config.AIConfig
 	// Update must run apply (nil ok) before releasing its write lock so live re-applies happen in save order.
 	Update(ctx context.Context, mutate func(settings.Settings) (settings.Settings, error), apply func(settings.Settings)) (settings.Settings, error)
+}
+
+type codexDeviceAuth interface {
+	Status() codexauth.Status
+	Start() (codexauth.Status, error)
 }
 
 type aiSettingsKeyStatus struct {
@@ -78,7 +84,7 @@ func handleAdminUpdateAISettings(store runtimeSettingsStore, applySettings func(
 			// Only a request that sets defaultProvider is checked against the
 			// merged config: clearing a key under a stale default must still work.
 			if err == nil && body.DefaultProvider != nil && next.AI.DefaultProvider != "" &&
-				!airouter.WouldRegister(next.AI.DefaultProvider, store.MergedAI(next)) {
+				!airouter.HasProviderConfiguration(next.AI.DefaultProvider, store.MergedAI(next)) {
 				err = fmt.Errorf("provider %q has no usable configuration", next.AI.DefaultProvider)
 			}
 			// Clearing the key is the only update that can remove a provider;
@@ -110,9 +116,22 @@ func handleAdminUpdateAISettings(store runtimeSettingsStore, applySettings func(
 	}
 }
 
+func handleAdminGetCodexAuth(deviceAuth codexDeviceAuth) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusOK, deviceAuth.Status())
+	}
+}
+
+func handleAdminStartCodexAuth(deviceAuth codexDeviceAuth) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		status, _ := deviceAuth.Start()
+		writeJSON(w, http.StatusOK, status)
+	}
+}
+
 func anyProviderRegistrable(cfg config.AIConfig) bool {
 	return slices.ContainsFunc(airouter.ProviderNames(), func(name string) bool {
-		return airouter.WouldRegister(name, cfg)
+		return airouter.HasProviderConfiguration(name, cfg)
 	})
 }
 

--- a/internal/server/admin_ai_settings_test.go
+++ b/internal/server/admin_ai_settings_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/p-n-ai/pai-bot/internal/platform/codexauth"
 	"github.com/p-n-ai/pai-bot/internal/platform/config"
 	"github.com/p-n-ai/pai-bot/internal/platform/featureflags"
 	"github.com/p-n-ai/pai-bot/internal/platform/settings"
@@ -24,6 +25,17 @@ type memorySettingsStore struct {
 	envFlags featureflags.Features
 	current  settings.Settings
 	saves    int
+}
+
+type stubCodexDeviceAuth struct {
+	status codexauth.Status
+	starts int
+}
+
+func (s *stubCodexDeviceAuth) Status() codexauth.Status { return s.status }
+func (s *stubCodexDeviceAuth) Start() (codexauth.Status, error) {
+	s.starts++
+	return s.status, nil
 }
 
 func (m *memorySettingsStore) Effective() settings.EffectiveSettings {
@@ -53,6 +65,24 @@ func newAISettingsHandler(store runtimeSettingsStore, apply func(settings.Settin
 
 func newMultiTenantAISettingsHandler(store runtimeSettingsStore, apply func(settings.Settings), multiTenant bool) http.Handler {
 	return newHandlerWithAdminProvider(fixedAdminDataSourceProvider{source: stubAdminAPI{}}, nil, &chatGatewayStub{}, retrieval.NewMemoryService(), &stubAuthService{}, "change-me-in-production", time.Hour, "", store, apply, multiTenant)
+}
+
+func newCodexAuthHandler(store runtimeSettingsStore, deviceAuth codexDeviceAuth) http.Handler {
+	return NewHandlerWithAdminProviderAndTeacherResourcesAndCodexAuth(
+		fixedAdminDataSourceProvider{source: stubAdminAPI{}},
+		nil,
+		&chatGatewayStub{},
+		retrieval.NewMemoryService(),
+		nil,
+		&stubAuthService{},
+		"change-me-in-production",
+		time.Hour,
+		"",
+		store,
+		nil,
+		false,
+		deviceAuth,
+	)
 }
 
 func doAISettingsRequest(t *testing.T, handler http.Handler, method, token, body string) *httptest.ResponseRecorder {
@@ -422,4 +452,43 @@ func TestAdminAISettingsMultiTenantRejectsTenantAdmin(t *testing.T) {
 		}
 	}
 	decodeAISettingsPayload(t, doAISettingsRequest(t, handler, http.MethodGet, mustIssuePlatformAdminToken(t), ""))
+}
+
+func TestAdminCodexDeviceAuthReturnsOnlySafeParsedState(t *testing.T) {
+	deviceAuth := &stubCodexDeviceAuth{status: codexauth.Status{
+		State:           codexauth.StateAwaiting,
+		VerificationURL: "https://auth.openai.com/codex/device",
+		UserCode:        "ABCD-1234",
+	}}
+	handler := newCodexAuthHandler(&memorySettingsStore{}, deviceAuth)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/admin/ai/codex/auth/device", nil)
+	req.Header.Set("Authorization", "Bearer "+mustIssueAdminToken(t))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK || deviceAuth.starts != 1 {
+		t.Fatalf("status/starts = %d/%d, want 200/1", rec.Code, deviceAuth.starts)
+	}
+	var payload codexauth.Status
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if payload != deviceAuth.status {
+		t.Fatalf("payload = %#v, want %#v", payload, deviceAuth.status)
+	}
+}
+
+func TestAdminCodexDeviceAuthRejectsTeacher(t *testing.T) {
+	deviceAuth := &stubCodexDeviceAuth{}
+	handler := newCodexAuthHandler(&memorySettingsStore{}, deviceAuth)
+	req := httptest.NewRequest(http.MethodPost, "/api/admin/ai/codex/auth/device", nil)
+	req.Header.Set("Authorization", "Bearer "+mustIssueTeacherToken(t))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden || deviceAuth.starts != 0 {
+		t.Fatalf("status/starts = %d/%d, want 403/0", rec.Code, deviceAuth.starts)
+	}
 }

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -40,6 +40,7 @@ type TenantAdminDataSourceProvider = tenantAdminDataSourceProvider
 type GatewayNotifier = gatewayNotifier
 type GatewayTurnDeliverer = gatewayTurnDeliverer
 type RuntimeSettingsStore = runtimeSettingsStore
+type CodexDeviceAuth = codexDeviceAuth
 
 func NewGatewaySender(gw *chat.Gateway) messageSender { return gatewaySender{gw: gw} }
 func NewGatewayNotifier(gw *chat.Gateway, routes proactiveRouteLookup) GatewayNotifier {
@@ -61,7 +62,10 @@ func NewHandlerWithAdminProvider(adminProvider AdminDataSourceProvider, joinSour
 	return newHandlerWithAdminProvider(adminProvider, joinSource, sender, retrievalService, authSvc, jwtSecret, accessTokenTTL, inviteBaseURL, settingsStore, applySettings, multiTenant)
 }
 func NewHandlerWithAdminProviderAndTeacherResources(adminProvider AdminDataSourceProvider, joinSource JoinClassSource, sender MessageSender, retrievalService *retrieval.Service, teacherResources *retrieval.TeacherResourceService, authSvc AuthService, jwtSecret string, accessTokenTTL time.Duration, inviteBaseURL string, settingsStore RuntimeSettingsStore, applySettings func(settings.Settings), multiTenant bool) http.Handler {
-	return newHandlerWithAdminProviderAndTeacherResources(adminProvider, joinSource, sender, retrievalService, teacherResources, authSvc, jwtSecret, accessTokenTTL, inviteBaseURL, settingsStore, applySettings, multiTenant)
+	return newHandlerWithAdminProviderAndTeacherResources(adminProvider, joinSource, sender, retrievalService, teacherResources, authSvc, jwtSecret, accessTokenTTL, inviteBaseURL, settingsStore, applySettings, multiTenant, nil)
+}
+func NewHandlerWithAdminProviderAndTeacherResourcesAndCodexAuth(adminProvider AdminDataSourceProvider, joinSource JoinClassSource, sender MessageSender, retrievalService *retrieval.Service, teacherResources *retrieval.TeacherResourceService, authSvc AuthService, jwtSecret string, accessTokenTTL time.Duration, inviteBaseURL string, settingsStore RuntimeSettingsStore, applySettings func(settings.Settings), multiTenant bool, deviceAuth CodexDeviceAuth) http.Handler {
+	return newHandlerWithAdminProviderAndTeacherResources(adminProvider, joinSource, sender, retrievalService, teacherResources, authSvc, jwtSecret, accessTokenTTL, inviteBaseURL, settingsStore, applySettings, multiTenant, deviceAuth)
 }
 func NewTenantAdminDataSourceProvider(newForTenant func(string) AdminDataSource, newForPlatform func() AdminDataSource, defaultTenantID func(context.Context) (string, error)) TenantAdminDataSourceProvider {
 	return tenantAdminDataSourceProvider{newForTenant: newForTenant, newForPlatform: newForPlatform, defaultTenantID: defaultTenantID}
@@ -482,10 +486,10 @@ func newHandlerWithRetrievalService(admin adminDataSource, sender messageSender,
 // unregistered (tests, unwired deployments). multiTenant restricts those
 // routes to platform admins: the settings row is platform-global.
 func newHandlerWithAdminProvider(adminProvider adminDataSourceProvider, joinSource joinClassSource, sender messageSender, retrievalService *retrieval.Service, authSvc authService, jwtSecret string, accessTokenTTL time.Duration, inviteBaseURL string, settingsStore runtimeSettingsStore, applySettings func(settings.Settings), multiTenant bool) http.Handler {
-	return newHandlerWithAdminProviderAndTeacherResources(adminProvider, joinSource, sender, retrievalService, nil, authSvc, jwtSecret, accessTokenTTL, inviteBaseURL, settingsStore, applySettings, multiTenant)
+	return newHandlerWithAdminProviderAndTeacherResources(adminProvider, joinSource, sender, retrievalService, nil, authSvc, jwtSecret, accessTokenTTL, inviteBaseURL, settingsStore, applySettings, multiTenant, nil)
 }
 
-func newHandlerWithAdminProviderAndTeacherResources(adminProvider adminDataSourceProvider, joinSource joinClassSource, sender messageSender, retrievalService *retrieval.Service, teacherResources *retrieval.TeacherResourceService, authSvc authService, jwtSecret string, accessTokenTTL time.Duration, inviteBaseURL string, settingsStore runtimeSettingsStore, applySettings func(settings.Settings), multiTenant bool) http.Handler {
+func newHandlerWithAdminProviderAndTeacherResources(adminProvider adminDataSourceProvider, joinSource joinClassSource, sender messageSender, retrievalService *retrieval.Service, teacherResources *retrieval.TeacherResourceService, authSvc authService, jwtSecret string, accessTokenTTL time.Duration, inviteBaseURL string, settingsStore runtimeSettingsStore, applySettings func(settings.Settings), multiTenant bool, deviceAuth codexDeviceAuth) http.Handler {
 	mux := newMux(nil, sender)
 	manager := auth.NewTokenManager(jwtSecret, accessTokenTTL)
 	authenticated := authenticateRequests(authSvc, manager, time.Now)
@@ -546,6 +550,10 @@ func newHandlerWithAdminProviderAndTeacherResources(adminProvider adminDataSourc
 		settingsAdmin := chain(authenticated, auth.RequireRoles(settingsRoles...))
 		mux.Handle("GET /api/admin/ai/settings", settingsAdmin(handleAdminGetAISettings(settingsStore)))
 		mux.Handle("PUT /api/admin/ai/settings", settingsAdmin(handleAdminUpdateAISettings(settingsStore, applySettings)))
+		if deviceAuth != nil {
+			mux.Handle("GET /api/admin/ai/codex/auth", settingsAdmin(handleAdminGetCodexAuth(deviceAuth)))
+			mux.Handle("POST /api/admin/ai/codex/auth/device", settingsAdmin(handleAdminStartCodexAuth(deviceAuth)))
+		}
 	}
 	mux.Handle("GET /api/admin/export/students", adminOrAbove(handleAdminExportStudents(adminProvider)))
 	mux.Handle("GET /api/admin/export/conversations", adminOrAbove(handleAdminExportConversations(adminProvider)))


### PR DESCRIPTION
## Summary

- add authenticated Admin device-code login through a server-owned Codex app-server session
- route managed PaiBot completions through stable app-server events without reading Codex credential files
- select Codex as the persisted default provider after authorization while keeping configured providers available during setup
- ship a pinned Codex CLI in the production image and persist its isolated login across Docker Compose deployments
- add the Admin status, polling, and device verification interface

## Verification

- `go test ./... -count=1`
- production Compose config resolves `LEARN_AI_CODEX_HOME` to the persistent `codex-data` volume
- focused app-server tests cover device login, final-message events, structured output, usage, cancellation, and rejected interactive requests

After deployment, a trusted administrator completes the one-time device authorization from Admin. PaiBot keeps the existing configured provider active until Codex connects, then persists Codex as the default.
