### PR TITLE
Add feature-gated app and AI uptime monitoring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -121,6 +121,8 @@ LEARN_TENANT_MODE=single
 LEARN_CURRICULUM_PATH=./oss
 
 # --- Features ---
+PAI_FEATURES=
+PAI_AI_HEALTH_TOKEN=
 LEARN_DEV_MODE=true
 # Set true to force single-language (Bahasa Melayu) and disable onboarding language selection + /language change.
 LEARN_DISABLE_MULTI_LANGUAGE=false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -189,7 +189,7 @@ jobs:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_KEY }}
-          envs: DEPLOY_DIR,PG_PASS,TG_TOKEN,AUTH_SECRET,OPENAI_KEY,ANTHROPIC_KEY,DEEPSEEK_KEY,GOOGLE_KEY,OPENROUTER_KEY,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_ALLOWED_DOMAIN,SMTP_ADDR,SMTP_USER,SMTP_PASS,SMTP_FROM,SMTP_NAME,DOMAIN_VAL
+          envs: DEPLOY_DIR,PG_PASS,TG_TOKEN,AUTH_SECRET,OPENAI_KEY,ANTHROPIC_KEY,DEEPSEEK_KEY,GOOGLE_KEY,OPENROUTER_KEY,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_ALLOWED_DOMAIN,SMTP_ADDR,SMTP_USER,SMTP_PASS,SMTP_FROM,SMTP_NAME,DOMAIN_VAL,FEATURES,AI_HEALTH_TOKEN
           script: |
             cd "$DEPLOY_DIR"
             printf '%s\n' \
@@ -213,6 +213,8 @@ jobs:
               "LEARN_AI_OLLAMA_ENABLED=false" \
               "LEARN_TENANT_MODE=single" \
               "LEARN_CURRICULUM_PATH=./oss" \
+              "PAI_FEATURES=${FEATURES}" \
+              "PAI_AI_HEALTH_TOKEN=${AI_HEALTH_TOKEN}" \
               "LEARN_DISABLE_MULTI_LANGUAGE=false" \
               "LEARN_RATING_PROMPT_EVERY_REPLIES=5" \
               "LEARN_AI_PERSONALIZED_NUDGES_ENABLED=true" \
@@ -261,6 +263,8 @@ jobs:
           SMTP_FROM: ${{ secrets.LEARN_EMAIL_FROM_ADDRESS }}
           SMTP_NAME: ${{ secrets.LEARN_EMAIL_FROM_NAME }}
           DOMAIN_VAL: ${{ secrets.DOMAIN }}
+          FEATURES: ${{ vars.PAI_FEATURES }}
+          AI_HEALTH_TOKEN: ${{ secrets.PAI_AI_HEALTH_TOKEN }}
 
       - name: Deploy
         uses: appleboy/ssh-action@v1

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -1,0 +1,98 @@
+name: Uptime
+
+on:
+  schedule:
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+    inputs:
+      verification_mode:
+        description: Run normally or fail after a healthy owned-origin response
+        required: true
+        default: healthy
+        type: choice
+        options:
+          - healthy
+          - deliberate-failure
+      check:
+        description: Health surface to verify
+        required: true
+        default: app
+        type: choice
+        options:
+          - app
+          - ai
+
+concurrency:
+  group: uptime-production-${{ github.event_name }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    if: >-
+      (github.event_name == 'workflow_dispatch' && inputs.check == 'app') ||
+      (github.event_name == 'schedule' && vars.PAI_UPTIME_ENABLED == 'true')
+    name: Public health probe
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    environment: production
+    env:
+      TARGET_URL: ${{ secrets.NEXT_PUBLIC_API_URL }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Require monitoring target
+        run: |
+          if [ -z "$TARGET_URL" ]; then
+            echo "::error::Set NEXT_PUBLIC_API_URL in the production environment."
+            exit 1
+          fi
+
+      - name: Probe public health endpoint
+        env:
+          VERIFICATION_MODE: ${{ inputs.verification_mode }}
+        run: |
+          if [ "$VERIFICATION_MODE" = "deliberate-failure" ]; then
+            python3 scripts/uptime_probe.py "$TARGET_URL" --timeout 10 --deliberate-failure
+          else
+            python3 scripts/uptime_probe.py "$TARGET_URL" --timeout 10
+          fi
+
+  ai-probe:
+    if: >-
+      (github.event_name == 'workflow_dispatch' && inputs.check == 'ai') ||
+      (github.event_name == 'schedule' && vars.PAI_AI_UPTIME_ENABLED == 'true')
+    name: AI provider health probe
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    environment: production
+    env:
+      TARGET_URL: ${{ secrets.NEXT_PUBLIC_API_URL }}
+      PAI_AI_HEALTH_TOKEN: ${{ secrets.PAI_AI_HEALTH_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Require AI monitoring configuration
+        run: |
+          if [ -z "$TARGET_URL" ]; then
+            echo "::error::Set NEXT_PUBLIC_API_URL in the production environment."
+            exit 1
+          fi
+          if [ -z "$PAI_AI_HEALTH_TOKEN" ]; then
+            echo "::error::Set PAI_AI_HEALTH_TOKEN in the production environment."
+            exit 1
+          fi
+
+      - name: Probe AI health endpoint
+        env:
+          VERIFICATION_MODE: ${{ inputs.verification_mode }}
+        run: |
+          if [ "$VERIFICATION_MODE" = "deliberate-failure" ]; then
+            python3 scripts/uptime_probe.py "$TARGET_URL" --check ai --timeout 10 --deliberate-failure
+          else
+            python3 scripts/uptime_probe.py "$TARGET_URL" --check ai --timeout 10
+          fi

--- a/admin-spa/src/auth-provider.tsx
+++ b/admin-spa/src/auth-provider.tsx
@@ -40,10 +40,24 @@ const pendingAuth: AuthState = {
 
 const AuthContext = createContext<AuthContextValue | null>(null)
 
-export function AuthProvider({ children }: { children: ReactNode }) {
-  const [auth, setAuth] = useState<AuthState>(pendingAuth)
+export function AuthProvider({
+  children,
+  readSession = true,
+}: {
+  children: ReactNode
+  readSession?: boolean
+}) {
+  const [auth, setAuth] = useState<AuthState>(
+    readSession
+      ? pendingAuth
+      : { status: 'anonymous', session: null, error: null },
+  )
 
   useEffect(() => {
+    if (!readSession) {
+      return
+    }
+
     let mounted = true
 
     readAuthSession()
@@ -73,7 +87,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return () => {
       mounted = false
     }
-  }, [])
+  }, [readSession])
 
   const value = useMemo(
     () => ({

--- a/admin-spa/src/components/status/public-status-page.test.tsx
+++ b/admin-spa/src/components/status/public-status-page.test.tsx
@@ -39,9 +39,10 @@ it('shows the application and AI availability without requiring admin auth', asy
   expect(screen.getByText('Application API')).toBeInTheDocument()
   expect(screen.getByText('AI services')).toBeInTheDocument()
   expect(screen.getAllByText('Operational')).toHaveLength(2)
-  expect(
-    screen.getByRole('link', { name: 'View JSON status' }),
-  ).toHaveAttribute('href', '/health/api')
+  expect(screen.getByRole('link', { name: 'JSON status' })).toHaveAttribute(
+    'href',
+    '/health/api',
+  )
 })
 
 it('does not claim an outage when the status service cannot be reached', async () => {

--- a/admin-spa/src/components/status/public-status-page.test.tsx
+++ b/admin-spa/src/components/status/public-status-page.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom/vitest'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+
+import { PublicStatusPage } from './public-status-page'
+
+const readPublicStatus = vi.hoisted(() => vi.fn())
+
+vi.mock('@/lib/public-status-client', () => ({
+  readPublicStatus,
+}))
+
+afterEach(() => {
+  cleanup()
+  readPublicStatus.mockReset()
+})
+
+it('shows the application and AI availability without requiring admin auth', async () => {
+  readPublicStatus.mockResolvedValue({
+    status: 'ok',
+    components: [
+      { id: 'application', status: 'operational' },
+      { id: 'ai', status: 'operational' },
+    ],
+  })
+
+  render(<PublicStatusPage />)
+
+  expect(
+    await screen.findByRole('heading', {
+      level: 1,
+      name: 'All systems operational',
+    }),
+  ).toBeInTheDocument()
+  expect(screen.getByText('Application API')).toBeInTheDocument()
+  expect(screen.getByText('AI services')).toBeInTheDocument()
+  expect(screen.getAllByText('Operational')).toHaveLength(2)
+  expect(
+    screen.getByRole('link', { name: 'View JSON status' }),
+  ).toHaveAttribute('href', '/health/api')
+})
+
+it('does not claim an outage when the status service cannot be reached', async () => {
+  readPublicStatus.mockRejectedValue(new Error('private detail'))
+
+  render(<PublicStatusPage />)
+
+  expect(
+    await screen.findByRole('heading', {
+      level: 1,
+      name: 'Status currently unavailable',
+    }),
+  ).toBeInTheDocument()
+  expect(screen.getByText('Unknown')).toBeInTheDocument()
+  expect(screen.queryByText('private detail')).not.toBeInTheDocument()
+})

--- a/admin-spa/src/components/status/public-status-page.tsx
+++ b/admin-spa/src/components/status/public-status-page.tsx
@@ -56,52 +56,45 @@ export function PublicStatusPage() {
   const presentation = statusPresentation(viewState)
 
   return (
-    <div className='min-h-svh overflow-hidden bg-[oklch(0.982_0.004_250)] text-[oklch(0.22_0.018_255)]'>
-      <div
-        aria-hidden='true'
-        className='pointer-events-none absolute inset-x-0 top-0 h-[34rem] bg-[radial-gradient(circle_at_50%_-12rem,oklch(0.91_0.05_230/0.75),transparent_32rem)]'
-      />
-      <div className='relative mx-auto w-[min(calc(100%-2rem),48rem)] px-[max(0rem,env(safe-area-inset-left))] py-8 sm:py-12 lg:py-14'>
-        <header className='mb-12 flex items-center justify-between gap-4 sm:mb-16'>
+    <div className='min-h-svh bg-[oklch(0.982_0.004_250)] text-[oklch(0.22_0.018_255)]'>
+      <div className='mx-auto w-[min(calc(100%-2rem),40rem)] px-[max(0rem,env(safe-area-inset-left))] py-8 sm:py-12'>
+        <header className='mb-14 sm:mb-16'>
           <a
-            className='inline-flex min-h-11 items-center gap-3 rounded-xl text-base font-semibold tracking-[-0.015em] no-underline outline-offset-4 focus-visible:outline-2'
+            className='inline-flex min-h-11 items-center gap-3 rounded-lg text-sm font-semibold tracking-[-0.01em] no-underline outline-offset-4 focus-visible:outline-2'
             href='/health'
           >
             <span
               aria-hidden='true'
-              className='grid size-9 place-items-center rounded-xl bg-[oklch(0.22_0.018_255)] text-xs font-bold tracking-[-0.04em] text-white'
+              className='grid size-8 place-items-center rounded-lg bg-[oklch(0.22_0.018_255)] text-[11px] font-bold tracking-[-0.04em] text-white'
             >
               P&amp;
             </span>
             <span>P&amp;AI Status</span>
           </a>
-          <span className='inline-flex items-center gap-2 text-[13px] font-medium whitespace-nowrap text-[oklch(0.49_0.018_255)]'>
-            <span
-              aria-hidden='true'
-              className={
-                presentation.tone === 'operational'
-                  ? 'size-2.5 rounded-full bg-[oklch(0.58_0.16_153)] shadow-[0_0_0_4px_oklch(0.94_0.052_153)]'
-                  : presentation.tone === 'degraded'
-                    ? 'size-2.5 rounded-full bg-[oklch(0.63_0.18_45)] shadow-[0_0_0_4px_oklch(0.95_0.045_75)]'
-                    : 'size-2.5 rounded-full bg-[oklch(0.6_0.012_250)] shadow-[0_0_0_4px_oklch(0.93_0.006_250)]'
-              }
-            />
-            {presentation.liveLabel}
-          </span>
         </header>
 
-        <div aria-live='polite' className='grid gap-12'>
+        <div aria-live='polite' className='grid gap-14'>
           <section aria-labelledby='status-heading' className='max-w-2xl'>
-            <p className='mb-4 text-[13px] font-semibold tracking-[0.08em] text-[oklch(0.49_0.018_255)] uppercase'>
-              Current status
+            <p className='mb-4 inline-flex items-center gap-2 text-sm font-medium text-[oklch(0.49_0.018_255)]'>
+              <span
+                aria-hidden='true'
+                className={
+                  presentation.tone === 'operational'
+                    ? 'size-2.5 rounded-full bg-[oklch(0.58_0.16_153)]'
+                    : presentation.tone === 'degraded'
+                      ? 'size-2.5 rounded-full bg-[oklch(0.63_0.18_45)]'
+                      : 'size-2.5 rounded-full bg-[oklch(0.6_0.012_250)]'
+                }
+              />
+              {presentation.liveLabel}
             </p>
             <h1
-              className='m-0 max-w-[14ch] text-[clamp(2.5rem,8vw,4.75rem)] leading-[1.02] font-semibold tracking-[-0.055em] text-balance'
+              className='m-0 text-[clamp(2rem,6vw,3rem)] leading-[1.08] font-semibold tracking-[-0.04em] text-balance'
               id='status-heading'
             >
               {presentation.headline}
             </h1>
-            <p className='mt-6 max-w-[60ch] text-[clamp(1rem,2.5vw,1.125rem)] leading-[1.6] text-pretty text-[oklch(0.49_0.018_255)]'>
+            <p className='mt-4 max-w-[60ch] text-base leading-7 text-pretty text-[oklch(0.49_0.018_255)]'>
               {presentation.summary}
             </p>
           </section>
@@ -109,15 +102,14 @@ export function PublicStatusPage() {
           <section
             aria-busy={viewState.kind === 'loading'}
             aria-labelledby='systems-heading'
-            className='rounded-3xl bg-white/92 p-5 shadow-[0_0_0_1px_oklch(0_0_0/0.06),0_1.5rem_4rem_oklch(0.3_0.03_250/0.08)] sm:p-8'
           >
             <h2
-              className='mb-7 text-base leading-tight font-semibold'
+              className='mb-6 text-sm leading-tight font-semibold'
               id='systems-heading'
             >
               System status
             </h2>
-            <ul className='m-0 grid list-none gap-7 p-0'>
+            <ul className='m-0 grid list-none gap-8 p-0'>
               {presentation.components.map((component) => (
                 <StatusRow component={component} key={component.id} />
               ))}
@@ -125,15 +117,12 @@ export function PublicStatusPage() {
           </section>
         </div>
 
-        <footer className='mt-8 flex flex-wrap justify-between gap-x-8 gap-y-4 text-[13px] leading-5 text-[oklch(0.49_0.018_255)]'>
-          <p className='m-0 max-w-[52ch]'>
-            Availability is reported across P&amp;AI’s shared services.
-          </p>
+        <footer className='mt-14 text-[13px] leading-5 text-[oklch(0.49_0.018_255)]'>
           <a
-            className='min-h-11 rounded-sm py-3 underline decoration-from-font underline-offset-4 outline-offset-4 focus-visible:outline-2'
+            className='inline-flex min-h-11 items-center rounded-sm underline decoration-from-font underline-offset-4 outline-offset-4 focus-visible:outline-2'
             href='/health/api'
           >
-            View JSON status
+            JSON status
           </a>
         </footer>
       </div>
@@ -154,7 +143,7 @@ function StatusRow({ component }: { component: StatusRowModel }) {
         : 'Unknown'
 
   return (
-    <li className='grid items-center gap-4 min-[32rem]:grid-cols-[minmax(0,1fr)_auto]'>
+    <li className='grid items-start gap-3 min-[32rem]:grid-cols-[minmax(0,1fr)_auto]'>
       <div className='min-w-0'>
         <h3 className='m-0 text-base leading-[1.3] font-semibold'>
           {copy.name}
@@ -166,10 +155,10 @@ function StatusRow({ component }: { component: StatusRowModel }) {
       <span
         className={
           operational
-            ? 'inline-flex min-h-8 w-fit items-center gap-2 rounded-full bg-[oklch(0.94_0.052_153)] px-3 text-[13px] font-semibold whitespace-nowrap text-[oklch(0.39_0.13_153)]'
+            ? 'inline-flex w-fit items-center gap-2 text-[13px] font-semibold whitespace-nowrap text-[oklch(0.39_0.13_153)]'
             : unavailable
-              ? 'inline-flex min-h-8 w-fit items-center gap-2 rounded-full bg-[oklch(0.95_0.045_75)] px-3 text-[13px] font-semibold whitespace-nowrap text-[oklch(0.46_0.16_42)]'
-              : 'inline-flex min-h-8 w-fit items-center gap-2 rounded-full bg-[oklch(0.95_0.006_250)] px-3 text-[13px] font-semibold whitespace-nowrap text-[oklch(0.46_0.018_255)]'
+              ? 'inline-flex w-fit items-center gap-2 text-[13px] font-semibold whitespace-nowrap text-[oklch(0.46_0.16_42)]'
+              : 'inline-flex w-fit items-center gap-2 text-[13px] font-semibold whitespace-nowrap text-[oklch(0.46_0.018_255)]'
         }
       >
         <span aria-hidden='true' className='size-2 rounded-full bg-current' />

--- a/admin-spa/src/components/status/public-status-page.tsx
+++ b/admin-spa/src/components/status/public-status-page.tsx
@@ -1,0 +1,226 @@
+import { useEffect, useState } from 'react'
+
+import type {
+  PublicStatusComponent,
+  PublicStatusSnapshot,
+} from '@/lib/public-status-types'
+import { readPublicStatus } from '@/lib/public-status-client'
+
+type StatusViewState =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'ready'; readonly snapshot: PublicStatusSnapshot }
+  | { readonly kind: 'error' }
+
+interface StatusRowModel {
+  readonly id: PublicStatusComponent['id']
+  readonly status: PublicStatusComponent['status'] | 'checking' | 'unknown'
+}
+
+const componentCopy = {
+  application: {
+    name: 'Application API',
+    description: 'Core application and chat services',
+  },
+  ai: {
+    name: 'AI services',
+    description: 'Model routing and provider availability',
+  },
+} as const
+
+export function PublicStatusPage() {
+  const [viewState, setViewState] = useState<StatusViewState>({
+    kind: 'loading',
+  })
+
+  useEffect(() => {
+    const controller = new AbortController()
+
+    readPublicStatus((input, init) =>
+      fetch(input, { ...init, signal: controller.signal }),
+    )
+      .then((snapshot) => {
+        setViewState({ kind: 'ready', snapshot })
+      })
+      .catch((error: unknown) => {
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          return
+        }
+        setViewState({ kind: 'error' })
+      })
+
+    return () => {
+      controller.abort()
+    }
+  }, [])
+
+  const presentation = statusPresentation(viewState)
+
+  return (
+    <div className='min-h-svh overflow-hidden bg-[oklch(0.982_0.004_250)] text-[oklch(0.22_0.018_255)]'>
+      <div
+        aria-hidden='true'
+        className='pointer-events-none absolute inset-x-0 top-0 h-[34rem] bg-[radial-gradient(circle_at_50%_-12rem,oklch(0.91_0.05_230/0.75),transparent_32rem)]'
+      />
+      <div className='relative mx-auto w-[min(calc(100%-2rem),48rem)] px-[max(0rem,env(safe-area-inset-left))] py-8 sm:py-12 lg:py-14'>
+        <header className='mb-12 flex items-center justify-between gap-4 sm:mb-16'>
+          <a
+            className='inline-flex min-h-11 items-center gap-3 rounded-xl text-base font-semibold tracking-[-0.015em] no-underline outline-offset-4 focus-visible:outline-2'
+            href='/health'
+          >
+            <span
+              aria-hidden='true'
+              className='grid size-9 place-items-center rounded-xl bg-[oklch(0.22_0.018_255)] text-xs font-bold tracking-[-0.04em] text-white'
+            >
+              P&amp;
+            </span>
+            <span>P&amp;AI Status</span>
+          </a>
+          <span className='inline-flex items-center gap-2 text-[13px] font-medium whitespace-nowrap text-[oklch(0.49_0.018_255)]'>
+            <span
+              aria-hidden='true'
+              className={
+                presentation.tone === 'operational'
+                  ? 'size-2.5 rounded-full bg-[oklch(0.58_0.16_153)] shadow-[0_0_0_4px_oklch(0.94_0.052_153)]'
+                  : presentation.tone === 'degraded'
+                    ? 'size-2.5 rounded-full bg-[oklch(0.63_0.18_45)] shadow-[0_0_0_4px_oklch(0.95_0.045_75)]'
+                    : 'size-2.5 rounded-full bg-[oklch(0.6_0.012_250)] shadow-[0_0_0_4px_oklch(0.93_0.006_250)]'
+              }
+            />
+            {presentation.liveLabel}
+          </span>
+        </header>
+
+        <div aria-live='polite' className='grid gap-12'>
+          <section aria-labelledby='status-heading' className='max-w-2xl'>
+            <p className='mb-4 text-[13px] font-semibold tracking-[0.08em] text-[oklch(0.49_0.018_255)] uppercase'>
+              Current status
+            </p>
+            <h1
+              className='m-0 max-w-[14ch] text-[clamp(2.5rem,8vw,4.75rem)] leading-[1.02] font-semibold tracking-[-0.055em] text-balance'
+              id='status-heading'
+            >
+              {presentation.headline}
+            </h1>
+            <p className='mt-6 max-w-[60ch] text-[clamp(1rem,2.5vw,1.125rem)] leading-[1.6] text-pretty text-[oklch(0.49_0.018_255)]'>
+              {presentation.summary}
+            </p>
+          </section>
+
+          <section
+            aria-busy={viewState.kind === 'loading'}
+            aria-labelledby='systems-heading'
+            className='rounded-3xl bg-white/92 p-5 shadow-[0_0_0_1px_oklch(0_0_0/0.06),0_1.5rem_4rem_oklch(0.3_0.03_250/0.08)] sm:p-8'
+          >
+            <h2
+              className='mb-7 text-base leading-tight font-semibold'
+              id='systems-heading'
+            >
+              System status
+            </h2>
+            <ul className='m-0 grid list-none gap-7 p-0'>
+              {presentation.components.map((component) => (
+                <StatusRow component={component} key={component.id} />
+              ))}
+            </ul>
+          </section>
+        </div>
+
+        <footer className='mt-8 flex flex-wrap justify-between gap-x-8 gap-y-4 text-[13px] leading-5 text-[oklch(0.49_0.018_255)]'>
+          <p className='m-0 max-w-[52ch]'>
+            Availability is reported across P&amp;AI’s shared services.
+          </p>
+          <a
+            className='min-h-11 rounded-sm py-3 underline decoration-from-font underline-offset-4 outline-offset-4 focus-visible:outline-2'
+            href='/health/api'
+          >
+            View JSON status
+          </a>
+        </footer>
+      </div>
+    </div>
+  )
+}
+
+function StatusRow({ component }: { component: StatusRowModel }) {
+  const copy = componentCopy[component.id]
+  const operational = component.status === 'operational'
+  const unavailable = component.status === 'unavailable'
+  const label = operational
+    ? 'Operational'
+    : unavailable
+      ? 'Unavailable'
+      : component.status === 'checking'
+        ? 'Checking'
+        : 'Unknown'
+
+  return (
+    <li className='grid items-center gap-4 min-[32rem]:grid-cols-[minmax(0,1fr)_auto]'>
+      <div className='min-w-0'>
+        <h3 className='m-0 text-base leading-[1.3] font-semibold'>
+          {copy.name}
+        </h3>
+        <p className='mt-1.5 text-sm leading-6 text-pretty text-[oklch(0.49_0.018_255)]'>
+          {copy.description}
+        </p>
+      </div>
+      <span
+        className={
+          operational
+            ? 'inline-flex min-h-8 w-fit items-center gap-2 rounded-full bg-[oklch(0.94_0.052_153)] px-3 text-[13px] font-semibold whitespace-nowrap text-[oklch(0.39_0.13_153)]'
+            : unavailable
+              ? 'inline-flex min-h-8 w-fit items-center gap-2 rounded-full bg-[oklch(0.95_0.045_75)] px-3 text-[13px] font-semibold whitespace-nowrap text-[oklch(0.46_0.16_42)]'
+              : 'inline-flex min-h-8 w-fit items-center gap-2 rounded-full bg-[oklch(0.95_0.006_250)] px-3 text-[13px] font-semibold whitespace-nowrap text-[oklch(0.46_0.018_255)]'
+        }
+      >
+        <span aria-hidden='true' className='size-2 rounded-full bg-current' />
+        {label}
+      </span>
+    </li>
+  )
+}
+
+function statusPresentation(viewState: StatusViewState): {
+  readonly headline: string
+  readonly summary: string
+  readonly components: ReadonlyArray<StatusRowModel>
+  readonly liveLabel: string
+  readonly tone: 'operational' | 'degraded' | 'neutral'
+} {
+  if (viewState.kind === 'loading') {
+    return {
+      headline: 'Checking system status',
+      summary: 'Reading the latest availability from P&AI services.',
+      components: [{ id: 'application', status: 'checking' }],
+      liveLabel: 'Checking status',
+      tone: 'neutral',
+    }
+  }
+
+  if (viewState.kind === 'error') {
+    return {
+      headline: 'Status currently unavailable',
+      summary:
+        'The status service could not be reached. This does not necessarily mean the application is down.',
+      components: [{ id: 'application', status: 'unknown' }],
+      liveLabel: 'Status unavailable',
+      tone: 'neutral',
+    }
+  }
+
+  return viewState.snapshot.status === 'ok'
+    ? {
+        headline: 'All systems operational',
+        summary: 'P&AI is online and serving requests normally.',
+        components: viewState.snapshot.components,
+        liveLabel: 'Live status',
+        tone: 'operational',
+      }
+    : {
+        headline: 'Some systems unavailable',
+        summary:
+          'The application is online, but one or more supporting services may be affected.',
+        components: viewState.snapshot.components,
+        liveLabel: 'Service advisory',
+        tone: 'degraded',
+      }
+}

--- a/admin-spa/src/lib/public-status-client.test.ts
+++ b/admin-spa/src/lib/public-status-client.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { PublicStatusError, readPublicStatus } from './public-status-client'
+
+describe('readPublicStatus', () => {
+  it('reads the no-store public status contract', async () => {
+    const fetcher = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: 'ok',
+          components: [{ id: 'application', status: 'operational' }],
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    )
+
+    await expect(readPublicStatus(fetcher)).resolves.toEqual({
+      status: 'ok',
+      components: [{ id: 'application', status: 'operational' }],
+    })
+    expect(fetcher).toHaveBeenCalledWith('/health/status', {
+      cache: 'no-store',
+      headers: { Accept: 'application/json' },
+    })
+  })
+
+  it('returns a safe error for a failed response', async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValue(new Response('private detail', { status: 503 }))
+
+    await expect(readPublicStatus(fetcher)).rejects.toEqual(
+      new PublicStatusError('Public status is unavailable'),
+    )
+  })
+})

--- a/admin-spa/src/lib/public-status-client.ts
+++ b/admin-spa/src/lib/public-status-client.ts
@@ -1,0 +1,32 @@
+import { readPublicStatusSnapshot } from './public-status-types'
+import type { PublicStatusSnapshot } from './public-status-types'
+
+export class PublicStatusError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'PublicStatusError'
+  }
+}
+
+export async function readPublicStatus(
+  fetcher: typeof fetch = fetch,
+): Promise<PublicStatusSnapshot> {
+  const response = await fetcher('/health/status', {
+    cache: 'no-store',
+    headers: {
+      Accept: 'application/json',
+    },
+  })
+
+  if (!response.ok) {
+    throw new PublicStatusError('Public status is unavailable')
+  }
+
+  const payload: unknown = await response.json()
+  const status = readPublicStatusSnapshot(payload)
+  if (!status) {
+    throw new PublicStatusError('Invalid public status response')
+  }
+
+  return status
+}

--- a/admin-spa/src/lib/public-status-types.test.ts
+++ b/admin-spa/src/lib/public-status-types.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import { readPublicStatusSnapshot } from './public-status-types'
+
+describe('readPublicStatusSnapshot', () => {
+  it('parses a coherent operational response', () => {
+    expect(
+      readPublicStatusSnapshot({
+        status: 'ok',
+        components: [
+          { id: 'application', status: 'operational' },
+          { id: 'ai', status: 'operational' },
+        ],
+      }),
+    ).toEqual({
+      status: 'ok',
+      components: [
+        { id: 'application', status: 'operational' },
+        { id: 'ai', status: 'operational' },
+      ],
+    })
+  })
+
+  it.each([
+    {
+      status: 'ok',
+      components: [{ id: 'ai', status: 'operational' }],
+    },
+    {
+      status: 'ok',
+      components: [
+        { id: 'application', status: 'operational' },
+        { id: 'application', status: 'operational' },
+      ],
+    },
+    {
+      status: 'ok',
+      components: [{ id: 'application', status: 'unavailable' }],
+    },
+    {
+      status: 'degraded',
+      components: [{ id: 'application', status: 'operational' }],
+    },
+  ])('rejects an invalid or contradictory response', (payload) => {
+    expect(readPublicStatusSnapshot(payload)).toBeNull()
+  })
+})

--- a/admin-spa/src/lib/public-status-types.ts
+++ b/admin-spa/src/lib/public-status-types.ts
@@ -1,0 +1,57 @@
+import { Schema } from 'effect'
+import type { Schema as EffectSchema } from 'effect/Schema'
+
+export const PublicServiceIDSchema = Schema.Literals(['application', 'ai'])
+export const PublicServiceStateSchema = Schema.Literals([
+  'operational',
+  'unavailable',
+])
+
+export const PublicStatusComponentSchema = Schema.Struct({
+  id: PublicServiceIDSchema,
+  status: PublicServiceStateSchema,
+})
+
+export interface PublicStatusComponent extends EffectSchema.Type<
+  typeof PublicStatusComponentSchema
+> {}
+
+export const PublicStatusSnapshotSchema = Schema.Struct({
+  status: Schema.Literals(['ok', 'degraded']),
+  components: Schema.Array(PublicStatusComponentSchema),
+})
+
+export interface PublicStatusSnapshot extends EffectSchema.Type<
+  typeof PublicStatusSnapshotSchema
+> {}
+
+const matchesPublicStatusSnapshot = Schema.is(PublicStatusSnapshotSchema)
+
+/** Parses a coherent public status response from the backend boundary. */
+export function readPublicStatusSnapshot(
+  value: unknown,
+): PublicStatusSnapshot | null {
+  if (!matchesPublicStatusSnapshot(value)) {
+    return null
+  }
+
+  const componentIDs = value.components.map((component) => component.id)
+  if (
+    componentIDs.filter((id) => id === 'application').length !== 1 ||
+    new Set(componentIDs).size !== componentIDs.length
+  ) {
+    return null
+  }
+
+  const hasUnavailableComponent = value.components.some(
+    (component) => component.status === 'unavailable',
+  )
+  if (
+    (value.status === 'ok' && hasUnavailableComponent) ||
+    (value.status === 'degraded' && !hasUnavailableComponent)
+  ) {
+    return null
+  }
+
+  return value
+}

--- a/admin-spa/src/main.tsx
+++ b/admin-spa/src/main.tsx
@@ -8,6 +8,9 @@ import './styles.css'
 import { TooltipProvider } from '@/components/ui/tooltip'
 
 const rootElement = document.getElementById('root')
+const isPublicStatusPage =
+  window.location.pathname === '/health' ||
+  window.location.pathname === '/health/'
 
 if (!rootElement) {
   throw new Error('Root element not found')
@@ -15,7 +18,7 @@ if (!rootElement) {
 
 createRoot(rootElement).render(
   <StrictMode>
-    <AuthProvider>
+    <AuthProvider readSession={!isPublicStatusPage}>
       <TooltipProvider>
         <AdminApp />
       </TooltipProvider>

--- a/admin-spa/src/routeTree.gen.ts
+++ b/admin-spa/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as HealthRouteImport } from './routes/health'
 import { Route as ActivateRouteImport } from './routes/activate'
 import { Route as AuthenticatedRouteImport } from './routes/_authenticated'
 import { Route as IndexRouteImport } from './routes/index'
@@ -28,6 +29,11 @@ import { Route as AuthenticatedDashboardMetricsRouteImport } from './routes/_aut
 import { Route as AuthenticatedDashboardClassesRouteImport } from './routes/_authenticated/dashboard/classes'
 import { Route as AuthenticatedDashboardAiUsageRouteImport } from './routes/_authenticated/dashboard/ai-usage'
 
+const HealthRoute = HealthRouteImport.update({
+  id: '/health',
+  path: '/health',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ActivateRoute = ActivateRouteImport.update({
   id: '/activate',
   path: '/activate',
@@ -131,6 +137,7 @@ const AuthenticatedDashboardAiUsageRoute =
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/activate': typeof ActivateRoute
+  '/health': typeof HealthRoute
   '/export': typeof AuthenticatedExportRoute
   '/join/$slug': typeof JoinSlugRoute
   '/dashboard/ai-usage': typeof AuthenticatedDashboardAiUsageRoute
@@ -150,6 +157,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/activate': typeof ActivateRoute
+  '/health': typeof HealthRoute
   '/export': typeof AuthenticatedExportRoute
   '/join/$slug': typeof JoinSlugRoute
   '/dashboard/ai-usage': typeof AuthenticatedDashboardAiUsageRoute
@@ -171,6 +179,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/_authenticated': typeof AuthenticatedRouteWithChildren
   '/activate': typeof ActivateRoute
+  '/health': typeof HealthRoute
   '/_authenticated/export': typeof AuthenticatedExportRoute
   '/join/$slug': typeof JoinSlugRoute
   '/_authenticated/dashboard/ai-usage': typeof AuthenticatedDashboardAiUsageRoute
@@ -192,6 +201,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/activate'
+    | '/health'
     | '/export'
     | '/join/$slug'
     | '/dashboard/ai-usage'
@@ -211,6 +221,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/activate'
+    | '/health'
     | '/export'
     | '/join/$slug'
     | '/dashboard/ai-usage'
@@ -231,6 +242,7 @@ export interface FileRouteTypes {
     | '/'
     | '/_authenticated'
     | '/activate'
+    | '/health'
     | '/_authenticated/export'
     | '/join/$slug'
     | '/_authenticated/dashboard/ai-usage'
@@ -252,11 +264,19 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AuthenticatedRoute: typeof AuthenticatedRouteWithChildren
   ActivateRoute: typeof ActivateRoute
+  HealthRoute: typeof HealthRoute
   JoinSlugRoute: typeof JoinSlugRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/health': {
+      id: '/health'
+      path: '/health'
+      fullPath: '/health'
+      preLoaderRoute: typeof HealthRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/activate': {
       id: '/activate'
       path: '/activate'
@@ -429,6 +449,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AuthenticatedRoute: AuthenticatedRouteWithChildren,
   ActivateRoute: ActivateRoute,
+  HealthRoute: HealthRoute,
   JoinSlugRoute: JoinSlugRoute,
 }
 export const routeTree = rootRouteImport

--- a/admin-spa/src/routes/health.tsx
+++ b/admin-spa/src/routes/health.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { PublicStatusPage } from '@/components/status/public-status-page'
+
+export const Route = createFileRoute('/health')({
+  component: PublicStatusPage,
+})

--- a/admin-spa/vite.config.ts
+++ b/admin-spa/vite.config.ts
@@ -30,6 +30,16 @@ export default defineConfig({
         changeOrigin: true,
         xfwd: true,
       },
+      '/health/api': {
+        target: process.env.VITE_API_URL ?? 'http://127.0.0.1:8080',
+        changeOrigin: true,
+        xfwd: true,
+      },
+      '/health/status': {
+        target: process.env.VITE_API_URL ?? 'http://127.0.0.1:8080',
+        changeOrigin: true,
+        xfwd: true,
+      },
       '/embed': {
         target: process.env.VITE_API_URL ?? 'http://127.0.0.1:8080',
         changeOrigin: false,

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -129,6 +129,7 @@ func main() {
 			// Initialize AI router with configured providers.
 			initialAI := settings.MergeAI(cfg.AI, settingsStore.Current())
 			router := airouter.SetupWithCodexAuth(initialAI, codexDeviceAuth)
+			aiHealthCheck := server.NewCachedHealthCheck(router.HealthCheck, time.Minute, 5*time.Second)
 			if !router.HasProvider() {
 				if cfg.Runtime.DevMode {
 					slog.Warn("no AI providers configured; continuing in dev mode without AI-backed chat responses")
@@ -551,6 +552,14 @@ func main() {
 				JWTSecret:             cfg.Auth.JWTSecret,
 				AccessTokenTTL:        defaultAccessTokenTTL,
 				FocusedPageHandler:    focusedPageHandler,
+				PublicHealthEnabled: func() bool {
+					return flagsProvider().Enabled(featureflags.PublicHealth)
+				},
+				AIHealthEnabled: func() bool {
+					return flagsProvider().Enabled(featureflags.AIHealth)
+				},
+				AIHealthToken: cfg.Runtime.AIHealthToken,
+				AIHealthCheck: aiHealthCheck,
 			})
 
 			return http.Handler(topMux), func(ctx context.Context) error {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -129,7 +129,11 @@ func main() {
 			// Initialize AI router with configured providers.
 			initialAI := settings.MergeAI(cfg.AI, settingsStore.Current())
 			router := airouter.SetupWithCodexAuth(initialAI, codexDeviceAuth)
-			aiHealthCheck := server.NewCachedHealthCheck(router.HealthCheck, time.Minute, 5*time.Second)
+			aiHealthCheck := server.NewCachedHealthCheck(
+				server.NewAIHealthCheck(router),
+				time.Minute,
+				5*time.Second,
+			)
 			if !router.HasProvider() {
 				if cfg.Runtime.DevMode {
 					slog.Warn("no AI providers configured; continuing in dev mode without AI-backed chat responses")

--- a/deploy/caddy/Caddyfile
+++ b/deploy/caddy/Caddyfile
@@ -9,6 +9,14 @@
 		reverse_proxy app:8080
 	}
 
+	handle /health {
+		reverse_proxy app:8080
+	}
+
+	handle /health/ai {
+		reverse_proxy app:8080
+	}
+
 	handle /ws/* {
 		reverse_proxy app:8080
 	}

--- a/deploy/caddy/Caddyfile
+++ b/deploy/caddy/Caddyfile
@@ -9,7 +9,11 @@
 		reverse_proxy app:8080
 	}
 
-	handle /health {
+	handle /health/api {
+		reverse_proxy app:8080
+	}
+
+	handle /health/status {
 		reverse_proxy app:8080
 	}
 

--- a/deploy/caddy/Caddyfile.http
+++ b/deploy/caddy/Caddyfile.http
@@ -11,7 +11,11 @@
 		reverse_proxy app:8080
 	}
 
-	handle /health {
+	handle /health/api {
+		reverse_proxy app:8080
+	}
+
+	handle /health/status {
 		reverse_proxy app:8080
 	}
 

--- a/deploy/caddy/Caddyfile.http
+++ b/deploy/caddy/Caddyfile.http
@@ -11,6 +11,14 @@
 		reverse_proxy app:8080
 	}
 
+	handle /health {
+		reverse_proxy app:8080
+	}
+
+	handle /health/ai {
+		reverse_proxy app:8080
+	}
+
 	handle /ws/* {
 		reverse_proxy app:8080
 	}

--- a/deploy/caddy/Caddyfile.https
+++ b/deploy/caddy/Caddyfile.https
@@ -7,7 +7,11 @@
 		reverse_proxy app:8080
 	}
 
-	handle /health {
+	handle /health/api {
+		reverse_proxy app:8080
+	}
+
+	handle /health/status {
 		reverse_proxy app:8080
 	}
 

--- a/deploy/caddy/Caddyfile.https
+++ b/deploy/caddy/Caddyfile.https
@@ -7,6 +7,14 @@
 		reverse_proxy app:8080
 	}
 
+	handle /health {
+		reverse_proxy app:8080
+	}
+
+	handle /health/ai {
+		reverse_proxy app:8080
+	}
+
 	handle /ws/* {
 		reverse_proxy app:8080
 	}

--- a/deploy/helm/pai/templates/configmap.yaml
+++ b/deploy/helm/pai/templates/configmap.yaml
@@ -13,6 +13,7 @@ data:
   LEARN_TENANT_MODE: {{ .Values.config.tenantMode | quote }}
   LEARN_CURRICULUM_PATH: {{ .Values.config.curriculumPath | quote }}
   LEARN_DEV_MODE: {{ .Values.config.devMode | quote }}
+  PAI_FEATURES: {{ .Values.config.featureFlags | quote }}
   LEARN_DISABLE_MULTI_LANGUAGE: {{ .Values.config.disableMultiLanguage | quote }}
   LEARN_AI_PERSONALIZED_NUDGES_ENABLED: {{ .Values.config.personalizedNudgesEnabled | quote }}
   LEARN_EMBED_BASE_URL: {{ .Values.config.embedBaseUrl | quote }}

--- a/deploy/helm/pai/templates/ingress.yaml
+++ b/deploy/helm/pai/templates/ingress.yaml
@@ -40,7 +40,14 @@ spec:
                 name: {{ include "pai.fullname" . }}-app
                 port:
                   name: http
-          - path: /health
+          - path: /health/api
+            pathType: Exact
+            backend:
+              service:
+                name: {{ include "pai.fullname" . }}-app
+                port:
+                  name: http
+          - path: /health/status
             pathType: Exact
             backend:
               service:

--- a/deploy/helm/pai/templates/ingress.yaml
+++ b/deploy/helm/pai/templates/ingress.yaml
@@ -40,6 +40,20 @@ spec:
                 name: {{ include "pai.fullname" . }}-app
                 port:
                   name: http
+          - path: /health
+            pathType: Exact
+            backend:
+              service:
+                name: {{ include "pai.fullname" . }}-app
+                port:
+                  name: http
+          - path: /health/ai
+            pathType: Exact
+            backend:
+              service:
+                name: {{ include "pai.fullname" . }}-app
+                port:
+                  name: http
           - path: /readyz
             pathType: Exact
             backend:

--- a/deploy/helm/pai/templates/secret.yaml
+++ b/deploy/helm/pai/templates/secret.yaml
@@ -8,6 +8,9 @@ metadata:
 type: Opaque
 stringData:
   PAI_AUTH_SECRET: {{ .Values.secrets.authSecret | quote }}
+  {{- if .Values.secrets.aiHealthToken }}
+  PAI_AI_HEALTH_TOKEN: {{ .Values.secrets.aiHealthToken | quote }}
+  {{- end }}
   {{- if .Values.secrets.telegramBotToken }}
   LEARN_TELEGRAM_BOT_TOKEN: {{ .Values.secrets.telegramBotToken | quote }}
   {{- end }}

--- a/deploy/helm/pai/values.yaml
+++ b/deploy/helm/pai/values.yaml
@@ -95,6 +95,7 @@ config:
   # -- Dev mode (disables Telegram/AI provider requirement)
   devMode: false
   # -- Feature flags
+  featureFlags: ""
   disableMultiLanguage: false
   personalizedNudgesEnabled: true
   # -- Optional public origin for widget assets. Defaults to the ingress/request origin.
@@ -107,6 +108,8 @@ secrets:
   # (rotate back to recover, or re-enter via the admin UI); storing keys is refused
   # while this is the default. MUST override in production.
   authSecret: change-me-in-production
+  # -- Bearer token for the feature-gated /health/ai monitor.
+  aiHealthToken: ""
   # -- Telegram bot token (required unless devMode)
   telegramBotToken: ""
   # -- AI provider keys (at least one required unless devMode)

--- a/deploy/nginx/pai-bot.conf
+++ b/deploy/nginx/pai-bot.conf
@@ -23,7 +23,13 @@ server {
         access_log off;
     }
 
-    location = /health {
+    location = /health/api {
+        proxy_pass http://app;
+        proxy_set_header Host $host;
+        access_log off;
+    }
+
+    location = /health/status {
         proxy_pass http://app;
         proxy_set_header Host $host;
         access_log off;

--- a/deploy/nginx/pai-bot.conf
+++ b/deploy/nginx/pai-bot.conf
@@ -23,6 +23,18 @@ server {
         access_log off;
     }
 
+    location = /health {
+        proxy_pass http://app;
+        proxy_set_header Host $host;
+        access_log off;
+    }
+
+    location = /health/ai {
+        proxy_pass http://app;
+        proxy_set_header Host $host;
+        access_log off;
+    }
+
     location /readyz {
         proxy_pass http://app;
         proxy_set_header Host $host;

--- a/deploy/once/nginx.conf
+++ b/deploy/once/nginx.conf
@@ -42,7 +42,7 @@ server {
     proxy_pass http://127.0.0.1:8080;
   }
 
-  location ~ ^/(health|health/ai|healthz|readyz|docs|openapi\.json)$ {
+  location ~ ^/(health/(api|status|ai)|healthz|readyz|docs|openapi\.json)$ {
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Host $host;

--- a/deploy/once/nginx.conf
+++ b/deploy/once/nginx.conf
@@ -42,7 +42,7 @@ server {
     proxy_pass http://127.0.0.1:8080;
   }
 
-  location ~ ^/(healthz|readyz|docs|openapi\.json)$ {
+  location ~ ^/(health|health/ai|healthz|readyz|docs|openapi\.json)$ {
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Host $host;

--- a/internal/ai/router.go
+++ b/internal/ai/router.go
@@ -296,6 +296,32 @@ func (r *Router) HasProvider() bool {
 	return len(r.providers) > 0
 }
 
+// HealthCheck reports whether at least one configured routing fallback is
+// operational without mutating completion circuit state.
+func (r *Router) HealthCheck(ctx context.Context) error {
+	providers, order, _ := r.snapshotProviders()
+	if len(order) == 0 {
+		return fmt.Errorf("AI health check failed: no providers registered")
+	}
+
+	var failures []string
+	for _, name := range order {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		provider := providers[name]
+		if provider == nil {
+			continue
+		}
+		if err := provider.HealthCheck(ctx); err != nil {
+			failures = append(failures, name)
+			continue
+		}
+		return nil
+	}
+	return fmt.Errorf("AI health check failed for providers: %s", strings.Join(failures, ", "))
+}
+
 // HasNativeProvider reports whether any configured provider preserves native tool calls.
 func (r *Router) HasNativeProvider() bool {
 	r.mu.RLock()

--- a/internal/ai/router_health_test.go
+++ b/internal/ai/router_health_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ai_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/p-n-ai/pai-bot/internal/ai"
+)
+
+type healthProvider struct {
+	mu    sync.Mutex
+	calls int
+	err   error
+}
+
+func (*healthProvider) Complete(context.Context, ai.CompletionRequest) (ai.CompletionResponse, error) {
+	return ai.CompletionResponse{}, errors.New("not implemented")
+}
+
+func (*healthProvider) StreamComplete(context.Context, ai.CompletionRequest) (<-chan ai.StreamChunk, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (*healthProvider) Models() []ai.ModelInfo { return nil }
+
+func (p *healthProvider) HealthCheck(context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls++
+	return p.err
+}
+
+func (p *healthProvider) callCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.calls
+}
+
+func TestRouterHealthCheckUsesFallbackOrder(t *testing.T) {
+	router := ai.NewRouter()
+	preferred := &healthProvider{err: errors.New("preferred unavailable")}
+	fallback := &healthProvider{}
+	unreached := &healthProvider{}
+	router.ReplaceProviders([]ai.ProviderRegistration{
+		{Name: "preferred", Provider: preferred},
+		{Name: "fallback", Provider: fallback},
+		{Name: "unreached", Provider: unreached},
+	})
+
+	if err := router.HealthCheck(context.Background()); err != nil {
+		t.Fatalf("HealthCheck() error = %v", err)
+	}
+	if preferred.callCount() != 1 || fallback.callCount() != 1 || unreached.callCount() != 0 {
+		t.Fatalf(
+			"health calls preferred=%d fallback=%d unreached=%d, want 1,1,0",
+			preferred.callCount(),
+			fallback.callCount(),
+			unreached.callCount(),
+		)
+	}
+}
+
+func TestRouterHealthCheckFailsWithoutHealthyProvider(t *testing.T) {
+	tests := []struct {
+		name   string
+		router *ai.Router
+	}{
+		{name: "no providers", router: ai.NewRouter()},
+		{name: "all fail", router: func() *ai.Router {
+			router := ai.NewRouter()
+			router.Register("failed", &healthProvider{err: errors.New("unavailable")})
+			return router
+		}()},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.router.HealthCheck(context.Background()); err == nil {
+				t.Fatal("HealthCheck() error = nil, want failure")
+			}
+		})
+	}
+}
+
+func TestRouterHealthCheckHonorsCancellation(t *testing.T) {
+	router := ai.NewRouter()
+	router.Register("provider", &healthProvider{})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := router.HealthCheck(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("HealthCheck() error = %v, want context canceled", err)
+	}
+}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -48,6 +48,7 @@ type RuntimeConfig struct {
 	DisableMultiLanguage        bool
 	AIPersonalizedNudgesEnabled bool
 	DevMode                     bool
+	AIHealthToken               string
 }
 
 // ServerConfig holds HTTP server settings.
@@ -375,6 +376,7 @@ func Load() (*Config, error) {
 			DevMode:                     envBool("LEARN_DEV_MODE", false),
 			DisableMultiLanguage:        envBool("LEARN_DISABLE_MULTI_LANGUAGE", false),
 			AIPersonalizedNudgesEnabled: envBool("LEARN_AI_PERSONALIZED_NUDGES_ENABLED", true),
+			AIHealthToken:               envStr("PAI_AI_HEALTH_TOKEN", ""),
 		},
 		FeatureFlags:   parsedFeatureFlags,
 		CurriculumPath: envStr("LEARN_CURRICULUM_PATH", "./oss"),

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -80,6 +80,7 @@ func clearEnv(t *testing.T) {
 		"LEARN_CURRICULUM_PATH",
 		"LEARN_DEV_MODE",
 		"PAI_FEATURES",
+		"PAI_AI_HEALTH_TOKEN",
 		"LEARN_AI_PERSONALIZED_NUDGES_ENABLED",
 		"LEARN_AI_MOCK_RESPONSE",
 	}
@@ -87,6 +88,19 @@ func clearEnv(t *testing.T) {
 		_ = os.Unsetenv(v)
 	}
 	t.Setenv("LEARN_AI_CODEX_HOME", filepath.Join(t.TempDir(), "codex"))
+}
+
+func TestLoadAIHealthToken(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("PAI_AI_HEALTH_TOKEN", "monitor-secret")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Runtime.AIHealthToken != "monitor-secret" {
+		t.Fatal("AI health token was not loaded")
+	}
 }
 
 func TestLoad_FeatureFlagsRejectUnknown(t *testing.T) {

--- a/internal/platform/featureflags/featureflags.go
+++ b/internal/platform/featureflags/featureflags.go
@@ -26,7 +26,7 @@ const (
 	TurnHooks Feature = "turn_hooks"
 	// AgentCore enables native sequential tool continuation for teaching turns.
 	AgentCore Feature = "agent_core"
-	// PublicHealth exposes the public /health liveness alias.
+	// PublicHealth exposes the public status and external liveness routes.
 	PublicHealth Feature = "public_health"
 	// AIHealth exposes the authenticated /health/ai provider check.
 	AIHealth Feature = "ai_health"

--- a/internal/platform/featureflags/featureflags.go
+++ b/internal/platform/featureflags/featureflags.go
@@ -26,6 +26,10 @@ const (
 	TurnHooks Feature = "turn_hooks"
 	// AgentCore enables native sequential tool continuation for teaching turns.
 	AgentCore Feature = "agent_core"
+	// PublicHealth exposes the public /health liveness alias.
+	PublicHealth Feature = "public_health"
+	// AIHealth exposes the authenticated /health/ai provider check.
+	AIHealth Feature = "ai_health"
 )
 
 // Spec describes a known feature flag.
@@ -48,6 +52,16 @@ var registry = map[Feature]Spec{
 	},
 	AgentCore: {
 		Feature:        AgentCore,
+		Status:         UnderDevelopment,
+		DefaultEnabled: false,
+	},
+	PublicHealth: {
+		Feature:        PublicHealth,
+		Status:         UnderDevelopment,
+		DefaultEnabled: false,
+	},
+	AIHealth: {
+		Feature:        AIHealth,
 		Status:         UnderDevelopment,
 		DefaultEnabled: false,
 	},

--- a/internal/platform/featureflags/featureflags_test.go
+++ b/internal/platform/featureflags/featureflags_test.go
@@ -16,6 +16,12 @@ func TestParseEmptyFeatureSet(t *testing.T) {
 	if features.Enabled(AgentCore) {
 		t.Fatal("agent_core should default to disabled")
 	}
+	if features.Enabled(PublicHealth) {
+		t.Fatal("public_health should default to disabled")
+	}
+	if features.Enabled(AIHealth) {
+		t.Fatal("ai_health should default to disabled")
+	}
 	if features.Enabled(Feature("missing")) {
 		t.Fatal("missing feature should not be enabled")
 	}
@@ -52,6 +58,26 @@ func TestParseAgentCoreFeature(t *testing.T) {
 	}
 	if !features.Enabled(AgentCore) {
 		t.Fatal("agent_core should be enabled")
+	}
+}
+
+func TestParsePublicHealthFeature(t *testing.T) {
+	features, err := Parse("public_health")
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if !features.Enabled(PublicHealth) {
+		t.Fatal("public_health should be enabled")
+	}
+}
+
+func TestParseAIHealthFeature(t *testing.T) {
+	features, err := Parse("ai_health")
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if !features.Enabled(AIHealth) {
+		t.Fatal("ai_health should be enabled")
 	}
 }
 
@@ -110,5 +136,11 @@ func TestDefaults(t *testing.T) {
 	}
 	if enabled, ok := defaults["agent_core"]; !ok || enabled {
 		t.Fatalf("Defaults()[agent_core] = %v, %v; want false, present", enabled, ok)
+	}
+	if enabled, ok := defaults["public_health"]; !ok || enabled {
+		t.Fatalf("Defaults()[public_health] = %v, %v; want false, present", enabled, ok)
+	}
+	if enabled, ok := defaults["ai_health"]; !ok || enabled {
+		t.Fatalf("Defaults()[ai_health] = %v, %v; want false, present", enabled, ok)
 	}
 }

--- a/internal/server/ai_health_check.go
+++ b/internal/server/ai_health_check.go
@@ -1,0 +1,51 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/p-n-ai/pai-bot/internal/ai"
+	"github.com/p-n-ai/pai-bot/internal/i18n"
+)
+
+// NewAIHealthCheck verifies the routed AI completion path used by learners.
+func NewAIHealthCheck(router *ai.Router) func(context.Context) error {
+	return func(ctx context.Context) error {
+		if router == nil {
+			return fmt.Errorf("AI completion health check failed: router unavailable")
+		}
+
+		response, err := router.Complete(ctx, ai.CompletionRequest{
+			Messages: []ai.Message{
+				{Role: "user", Content: "Reply with only OK."},
+			},
+			MaxTokens:   8,
+			Temperature: 0,
+			Task:        ai.TaskAnalysis,
+		})
+		if err != nil {
+			return fmt.Errorf("AI completion health check failed: %w", err)
+		}
+		if strings.TrimSpace(response.Content) == "" {
+			return fmt.Errorf("AI completion health check failed: empty response")
+		}
+		if isTechnicalIssueMessage(response.Content) {
+			return fmt.Errorf("AI completion health check failed: fallback response")
+		}
+		return nil
+	}
+}
+
+func isTechnicalIssueMessage(response string) bool {
+	response = strings.TrimSpace(response)
+	for _, locale := range []string{"en", "ms", "zh"} {
+		if response == i18n.S(locale, i18n.MsgTechnicalIssue) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/server/ai_health_check_test.go
+++ b/internal/server/ai_health_check_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/p-n-ai/pai-bot/internal/ai"
+	"github.com/p-n-ai/pai-bot/internal/i18n"
+)
+
+func TestAIHealthCheckUsesCompletionPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+		err      error
+		wantErr  bool
+	}{
+		{name: "operational", response: "OK"},
+		{name: "empty response", response: " ", wantErr: true},
+		{
+			name:     "technical issue fallback",
+			response: i18n.S("en", i18n.MsgTechnicalIssue),
+			wantErr:  true,
+		},
+		{name: "provider failure", err: context.DeadlineExceeded, wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			router := ai.NewRouterWithConfig(ai.RouterConfig{
+				RetryBackoff: []time.Duration{time.Nanosecond},
+			})
+			router.Register("provider", &ai.MockProvider{
+				Response: test.response,
+				Err:      test.err,
+			})
+
+			err := NewAIHealthCheck(router)(context.Background())
+			if (err != nil) != test.wantErr {
+				t.Fatalf("NewAIHealthCheck() error = %v, wantErr %v", err, test.wantErr)
+			}
+		})
+	}
+}

--- a/internal/server/cached_health_check.go
+++ b/internal/server/cached_health_check.go
@@ -1,0 +1,76 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+type cachedHealthCheck struct {
+	check   func(context.Context) error
+	ttl     time.Duration
+	timeout time.Duration
+	now     func() time.Time
+
+	mu       sync.Mutex
+	valid    bool
+	err      error
+	expires  time.Time
+	inFlight chan struct{}
+}
+
+// NewCachedHealthCheck bounds and coalesces an external health check.
+func NewCachedHealthCheck(check func(context.Context) error, ttl, timeout time.Duration) func(context.Context) error {
+	return newCachedHealthCheck(check, ttl, timeout, time.Now).Check
+}
+
+func newCachedHealthCheck(check func(context.Context) error, ttl, timeout time.Duration, now func() time.Time) *cachedHealthCheck {
+	return &cachedHealthCheck{
+		check:   check,
+		ttl:     ttl,
+		timeout: timeout,
+		now:     now,
+	}
+}
+
+func (c *cachedHealthCheck) Check(ctx context.Context) error {
+	if c == nil || c.check == nil {
+		return errors.New("health check is unavailable")
+	}
+	for {
+		c.mu.Lock()
+		if c.valid && c.now().Before(c.expires) {
+			err := c.err
+			c.mu.Unlock()
+			return err
+		}
+		if wait := c.inFlight; wait != nil {
+			c.mu.Unlock()
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-wait:
+				continue
+			}
+		}
+		c.inFlight = make(chan struct{})
+		c.mu.Unlock()
+
+		checkCtx, cancel := context.WithTimeout(context.Background(), c.timeout)
+		err := c.check(checkCtx)
+		cancel()
+
+		c.mu.Lock()
+		c.valid = true
+		c.err = err
+		c.expires = c.now().Add(c.ttl)
+		close(c.inFlight)
+		c.inFlight = nil
+		c.mu.Unlock()
+		return err
+	}
+}

--- a/internal/server/cached_health_check_test.go
+++ b/internal/server/cached_health_check_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestCachedHealthCheckCachesResultUntilTTL(t *testing.T) {
+	now := time.Unix(100, 0)
+	var calls atomic.Int32
+	checker := newCachedHealthCheck(func(context.Context) error {
+		calls.Add(1)
+		return nil
+	}, time.Minute, time.Second, func() time.Time { return now })
+
+	if err := checker.Check(context.Background()); err != nil {
+		t.Fatalf("first check error = %v", err)
+	}
+	if err := checker.Check(context.Background()); err != nil {
+		t.Fatalf("cached check error = %v", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("calls within TTL = %d, want 1", got)
+	}
+
+	now = now.Add(time.Minute)
+	if err := checker.Check(context.Background()); err != nil {
+		t.Fatalf("expired check error = %v", err)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("calls after TTL = %d, want 2", got)
+	}
+}
+
+func TestCachedHealthCheckCoalescesConcurrentRequests(t *testing.T) {
+	var calls atomic.Int32
+	started := make(chan struct{})
+	release := make(chan struct{})
+	checker := NewCachedHealthCheck(func(context.Context) error {
+		if calls.Add(1) == 1 {
+			close(started)
+		}
+		<-release
+		return nil
+	}, time.Minute, time.Second)
+
+	const requestCount = 8
+	var wg sync.WaitGroup
+	errs := make(chan error, requestCount)
+	for range requestCount {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- checker(context.Background())
+		}()
+	}
+	<-started
+	close(release)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent check error = %v", err)
+		}
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("concurrent calls = %d, want 1", got)
+	}
+}
+
+func TestCachedHealthCheckBoundsUpstreamTimeout(t *testing.T) {
+	checker := NewCachedHealthCheck(func(ctx context.Context) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}, time.Minute, 10*time.Millisecond)
+
+	err := checker(context.Background())
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("check error = %v, want deadline exceeded", err)
+	}
+}

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -5,6 +5,8 @@ package server
 
 import (
 	"context"
+	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/csv"
 	"encoding/json"
 	"errors"
@@ -93,10 +95,33 @@ type TopMuxOptions struct {
 	AccessTokenTTL        time.Duration
 	FocusedPageHandler    http.Handler
 	ChatWebhooks          map[string]http.Handler
+	PublicHealthEnabled   func() bool
+	AIHealthEnabled       func() bool
+	AIHealthToken         string
+	AIHealthCheck         func(context.Context) error
 }
 
 func NewTopMux(opts TopMuxOptions) http.Handler {
 	topMux := http.NewServeMux()
+	topMux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
+		if opts.PublicHealthEnabled == nil || !opts.PublicHealthEnabled() {
+			http.NotFound(w, r)
+			return
+		}
+		handleHealthz(w, r)
+	})
+	topMux.HandleFunc("GET /health/ai", func(w http.ResponseWriter, r *http.Request) {
+		if opts.AIHealthEnabled == nil || !opts.AIHealthEnabled() ||
+			opts.AIHealthCheck == nil || !healthBearerMatches(opts.AIHealthToken, r.Header.Get("Authorization")) {
+			http.NotFound(w, r)
+			return
+		}
+		if err := opts.AIHealthCheck(r.Context()); err != nil {
+			writeHealthStatus(w, http.StatusServiceUnavailable, "unavailable")
+			return
+		}
+		writeHealthStatus(w, http.StatusOK, "ok")
+	})
 	if opts.WSChannel != nil {
 		topMux.Handle("GET /ws/chat", opts.WSChannel.Handler())
 	}
@@ -696,15 +721,27 @@ func registerRetrievalRoutes(
 }
 
 func handleHealthz(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte(`{"status":"ok"}`))
+	writeHealthStatus(w, http.StatusOK, "ok")
 }
 
 func handleReadyz(w http.ResponseWriter, r *http.Request) {
+	writeHealthStatus(w, http.StatusOK, "ready")
+}
+
+func writeHealthStatus(w http.ResponseWriter, status int, value string) {
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte(`{"status":"ready"}`))
+	w.WriteHeader(status)
+	_, _ = fmt.Fprintf(w, `{"status":%q}`, value)
+}
+
+func healthBearerMatches(expected, authorization string) bool {
+	const prefix = "Bearer "
+	if expected == "" || !strings.HasPrefix(authorization, prefix) {
+		return false
+	}
+	expectedHash := sha256.Sum256([]byte(expected))
+	actualHash := sha256.Sum256([]byte(strings.TrimPrefix(authorization, prefix)))
+	return subtle.ConstantTimeCompare(expectedHash[:], actualHash[:]) == 1
 }
 
 func handleOpenAPI(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -103,12 +103,19 @@ type TopMuxOptions struct {
 
 func NewTopMux(opts TopMuxOptions) http.Handler {
 	topMux := http.NewServeMux()
-	topMux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
+	topMux.HandleFunc("GET /health/api", func(w http.ResponseWriter, r *http.Request) {
 		if opts.PublicHealthEnabled == nil || !opts.PublicHealthEnabled() {
 			http.NotFound(w, r)
 			return
 		}
 		handleHealthz(w, r)
+	})
+	topMux.HandleFunc("GET /health/status", func(w http.ResponseWriter, r *http.Request) {
+		if opts.PublicHealthEnabled == nil || !opts.PublicHealthEnabled() {
+			http.NotFound(w, r)
+			return
+		}
+		handlePublicStatus(w, r, opts)
 	})
 	topMux.HandleFunc("GET /health/ai", func(w http.ResponseWriter, r *http.Request) {
 		if opts.AIHealthEnabled == nil || !opts.AIHealthEnabled() ||

--- a/internal/server/public_health_test.go
+++ b/internal/server/public_health_test.go
@@ -21,7 +21,7 @@ func TestPublicHealthFeature(t *testing.T) {
 		},
 	})
 
-	assertResponse := func(path string, wantStatus int, wantBody string) {
+	assertResponse := func(path string, wantStatus int, wantBody string) *httptest.ResponseRecorder {
 		t.Helper()
 		request := httptest.NewRequest(http.MethodGet, path, nil)
 		response := httptest.NewRecorder()
@@ -32,14 +32,60 @@ func TestPublicHealthFeature(t *testing.T) {
 		if response.Body.String() != wantBody {
 			t.Fatalf("%s body = %q, want %q", path, response.Body.String(), wantBody)
 		}
+		return response
 	}
 
-	assertResponse("/health", http.StatusNotFound, "404 page not found\n")
+	assertResponse("/health/api", http.StatusNotFound, "404 page not found\n")
+	assertResponse("/health/status", http.StatusNotFound, "404 page not found\n")
 	assertResponse("/healthz", http.StatusOK, `{"status":"ok"}`)
 
 	enabled = true
-	assertResponse("/health", http.StatusOK, `{"status":"ok"}`)
+	assertResponse("/health/api", http.StatusOK, `{"status":"ok"}`)
+	assertResponse(
+		"/health/status",
+		http.StatusOK,
+		"{\"status\":\"ok\",\"components\":[{\"id\":\"application\",\"status\":\"operational\"}]}\n",
+	)
 	assertResponse("/healthz", http.StatusOK, `{"status":"ok"}`)
+}
+
+func TestPublicStatusPageIncludesCoarseAIState(t *testing.T) {
+	checkErr := error(nil)
+	handler := NewTopMux(TopMuxOptions{
+		PublicHealthEnabled: func() bool { return true },
+		AIHealthEnabled:     func() bool { return true },
+		AIHealthCheck: func(context.Context) error {
+			return checkErr
+		},
+	})
+
+	request := func() string {
+		t.Helper()
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/health/status", nil))
+		if response.Code != http.StatusOK {
+			t.Fatalf("/health/status status = %d, want 200", response.Code)
+		}
+		return response.Body.String()
+	}
+
+	healthyBody := request()
+	for _, expected := range []string{`"status":"ok"`, `"id":"ai"`, `"status":"operational"`} {
+		if !strings.Contains(healthyBody, expected) {
+			t.Fatalf("healthy public status missing %q", expected)
+		}
+	}
+
+	checkErr = errors.New("private provider detail")
+	unavailableBody := request()
+	for _, expected := range []string{`"status":"degraded"`, `"status":"unavailable"`} {
+		if !strings.Contains(unavailableBody, expected) {
+			t.Fatalf("unavailable public status missing %q", expected)
+		}
+	}
+	if strings.Contains(unavailableBody, checkErr.Error()) {
+		t.Fatal("public status exposed provider error")
+	}
 }
 
 func TestAIHealthFeatureAndAuthentication(t *testing.T) {

--- a/internal/server/public_health_test.go
+++ b/internal/server/public_health_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestPublicHealthFeature(t *testing.T) {
+	enabled := false
+	handler := NewTopMux(TopMuxOptions{
+		APIHandler: http.HandlerFunc(handleHealthz),
+		PublicHealthEnabled: func() bool {
+			return enabled
+		},
+	})
+
+	assertResponse := func(path string, wantStatus int, wantBody string) {
+		t.Helper()
+		request := httptest.NewRequest(http.MethodGet, path, nil)
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, request)
+		if response.Code != wantStatus {
+			t.Fatalf("%s status = %d, want %d", path, response.Code, wantStatus)
+		}
+		if response.Body.String() != wantBody {
+			t.Fatalf("%s body = %q, want %q", path, response.Body.String(), wantBody)
+		}
+	}
+
+	assertResponse("/health", http.StatusNotFound, "404 page not found\n")
+	assertResponse("/healthz", http.StatusOK, `{"status":"ok"}`)
+
+	enabled = true
+	assertResponse("/health", http.StatusOK, `{"status":"ok"}`)
+	assertResponse("/healthz", http.StatusOK, `{"status":"ok"}`)
+}
+
+func TestAIHealthFeatureAndAuthentication(t *testing.T) {
+	enabled := false
+	checkCalls := 0
+	checkErr := error(nil)
+	handler := NewTopMux(TopMuxOptions{
+		AIHealthEnabled: func() bool {
+			return enabled
+		},
+		AIHealthToken: "monitor-secret",
+		AIHealthCheck: func(context.Context) error {
+			checkCalls++
+			return checkErr
+		},
+	})
+
+	request := func(token string) *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, "/health/ai", nil)
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		return rec
+	}
+
+	if rec := request("monitor-secret"); rec.Code != http.StatusNotFound {
+		t.Fatalf("disabled status = %d, want 404", rec.Code)
+	}
+	enabled = true
+	for _, token := range []string{"", "wrong-secret"} {
+		if rec := request(token); rec.Code != http.StatusNotFound {
+			t.Fatalf("token %q status = %d, want 404", token, rec.Code)
+		}
+	}
+	if checkCalls != 0 {
+		t.Fatalf("unauthorized check calls = %d, want 0", checkCalls)
+	}
+
+	rec := request("monitor-secret")
+	if rec.Code != http.StatusOK || rec.Body.String() != `{"status":"ok"}` {
+		t.Fatalf("healthy response = %d %q", rec.Code, rec.Body.String())
+	}
+
+	checkErr = errors.New("provider secret detail")
+	rec = request("monitor-secret")
+	if rec.Code != http.StatusServiceUnavailable || rec.Body.String() != `{"status":"unavailable"}` {
+		t.Fatalf("unavailable response = %d %q", rec.Code, rec.Body.String())
+	}
+	if got := rec.Body.String(); strings.Contains(got, checkErr.Error()) {
+		t.Fatal("public response exposed provider error")
+	}
+}

--- a/internal/server/public_status.go
+++ b/internal/server/public_status.go
@@ -1,0 +1,42 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"net/http"
+)
+
+type publicStatusComponent struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+}
+
+type publicStatusResponse struct {
+	Status     string                  `json:"status"`
+	Components []publicStatusComponent `json:"components"`
+}
+
+func handlePublicStatus(w http.ResponseWriter, r *http.Request, opts TopMuxOptions) {
+	response := publicStatusResponse{
+		Status: "ok",
+		Components: []publicStatusComponent{
+			{ID: "application", Status: "operational"},
+		},
+	}
+
+	if opts.AIHealthEnabled != nil && opts.AIHealthEnabled() && opts.AIHealthCheck != nil {
+		aiStatus := "operational"
+		if err := opts.AIHealthCheck(r.Context()); err != nil {
+			aiStatus = "unavailable"
+			response.Status = "degraded"
+		}
+		response.Components = append(
+			response.Components,
+			publicStatusComponent{ID: "ai", Status: aiStatus},
+		)
+	}
+
+	w.Header().Set("Cache-Control", "no-store")
+	writeJSON(w, http.StatusOK, response)
+}

--- a/internal/server/run.go
+++ b/internal/server/run.go
@@ -36,7 +36,7 @@ func Run(ctx context.Context, opts Options) error {
 	}
 
 	var handler atomic.Pointer[http.Handler]
-	initialHandler := http.Handler(http.HandlerFunc(handleHealthz))
+	initialHandler := http.Handler(http.HandlerFunc(handleBootstrapHealth))
 	handler.Store(&initialHandler)
 
 	srv := &http.Server{
@@ -93,6 +93,14 @@ func Run(ctx context.Context, opts Options) error {
 		return err
 	}
 	return nil
+}
+
+func handleBootstrapHealth(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet || r.URL.Path != "/healthz" {
+		http.NotFound(w, r)
+		return
+	}
+	handleHealthz(w, r)
 }
 
 func shutdownAfterStartupError(srv *http.Server, timeout time.Duration, runErr error) error {

--- a/internal/server/run_test.go
+++ b/internal/server/run_test.go
@@ -89,6 +89,8 @@ func TestBootstrapHealthOnlyServesInternalLiveness(t *testing.T) {
 	}{
 		{method: http.MethodGet, path: "/healthz", wantStatus: http.StatusOK},
 		{method: http.MethodGet, path: "/health", wantStatus: http.StatusNotFound},
+		{method: http.MethodGet, path: "/health/api", wantStatus: http.StatusNotFound},
+		{method: http.MethodGet, path: "/health/status", wantStatus: http.StatusNotFound},
 		{method: http.MethodGet, path: "/health/ai", wantStatus: http.StatusNotFound},
 		{method: http.MethodPost, path: "/healthz", wantStatus: http.StatusNotFound},
 	}

--- a/internal/server/run_test.go
+++ b/internal/server/run_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -47,7 +48,7 @@ func TestRunServesHealthBeforeSwapAndBuiltHandlerAfterSwap(t *testing.T) {
 		})
 	}()
 
-	if body := getEventually(t, "http://"+addr+"/anything"); body != `{"status":"ok"}` {
+	if body := getEventually(t, "http://"+addr+"/healthz"); body != `{"status":"ok"}` {
 		t.Fatalf("health body before swap = %q, want health JSON", body)
 	}
 
@@ -77,6 +78,29 @@ func TestRunServesHealthBeforeSwapAndBuiltHandlerAfterSwap(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for Run shutdown")
+	}
+}
+
+func TestBootstrapHealthOnlyServesInternalLiveness(t *testing.T) {
+	tests := []struct {
+		method     string
+		path       string
+		wantStatus int
+	}{
+		{method: http.MethodGet, path: "/healthz", wantStatus: http.StatusOK},
+		{method: http.MethodGet, path: "/health", wantStatus: http.StatusNotFound},
+		{method: http.MethodGet, path: "/health/ai", wantStatus: http.StatusNotFound},
+		{method: http.MethodPost, path: "/healthz", wantStatus: http.StatusNotFound},
+	}
+	for _, test := range tests {
+		t.Run(test.method+" "+test.path, func(t *testing.T) {
+			request := httptest.NewRequest(test.method, test.path, nil)
+			response := httptest.NewRecorder()
+			handleBootstrapHealth(response, request)
+			if response.Code != test.wantStatus {
+				t.Fatalf("status = %d, want %d", response.Code, test.wantStatus)
+			}
+		})
 	}
 }
 

--- a/scripts/test_uptime_config.py
+++ b/scripts/test_uptime_config.py
@@ -23,13 +23,16 @@ class UptimeRoutingTests(unittest.TestCase):
         ):
             with self.subTest(path=path):
                 config = source(path)
-                self.assertIn("handle /health {", config)
+                self.assertIn("handle /health/api {", config)
+                self.assertIn("handle /health/status {", config)
                 self.assertIn("handle /health/ai {", config)
-                self.assertGreaterEqual(config.count("reverse_proxy app:8080"), 3)
+                self.assertNotIn("handle /health {", config)
+                self.assertGreaterEqual(config.count("reverse_proxy app:8080"), 4)
 
     def test_helm_routes_both_public_health_paths(self) -> None:
         ingress = source("deploy/helm/pai/templates/ingress.yaml")
-        self.assertIn("- path: /health\n            pathType: Exact", ingress)
+        self.assertIn("- path: /health/api\n            pathType: Exact", ingress)
+        self.assertIn("- path: /health/status\n            pathType: Exact", ingress)
         self.assertIn("- path: /health/ai\n            pathType: Exact", ingress)
 
     def test_nginx_surfaces_route_both_public_health_paths(self) -> None:
@@ -38,7 +41,11 @@ class UptimeRoutingTests(unittest.TestCase):
             source("deploy/nginx/pai-bot.conf"),
         )
         self.assertIn(
-            "health/ai",
+            "location = /health/status",
+            source("deploy/nginx/pai-bot.conf"),
+        )
+        self.assertIn(
+            "health/(api|status|ai)",
             source("deploy/once/nginx.conf"),
         )
 

--- a/scripts/test_uptime_config.py
+++ b/scripts/test_uptime_config.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Repository contract tests for external uptime routing and workflows."""
+
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def source(path: str) -> str:
+    return (ROOT / path).read_text()
+
+
+class UptimeRoutingTests(unittest.TestCase):
+    def test_caddy_routes_app_and_ai_health_to_backend(self) -> None:
+        for path in (
+            "deploy/caddy/Caddyfile",
+            "deploy/caddy/Caddyfile.http",
+            "deploy/caddy/Caddyfile.https",
+        ):
+            with self.subTest(path=path):
+                config = source(path)
+                self.assertIn("handle /health {", config)
+                self.assertIn("handle /health/ai {", config)
+                self.assertGreaterEqual(config.count("reverse_proxy app:8080"), 3)
+
+    def test_helm_routes_both_public_health_paths(self) -> None:
+        ingress = source("deploy/helm/pai/templates/ingress.yaml")
+        self.assertIn("- path: /health\n            pathType: Exact", ingress)
+        self.assertIn("- path: /health/ai\n            pathType: Exact", ingress)
+
+    def test_nginx_surfaces_route_both_public_health_paths(self) -> None:
+        self.assertIn(
+            "location = /health/ai",
+            source("deploy/nginx/pai-bot.conf"),
+        )
+        self.assertIn(
+            "health/ai",
+            source("deploy/once/nginx.conf"),
+        )
+
+    def test_deploy_passes_feature_flags_and_ai_token(self) -> None:
+        workflow = source(".github/workflows/deploy.yml")
+        self.assertIn('"PAI_FEATURES=${FEATURES}"', workflow)
+        self.assertIn('"PAI_AI_HEALTH_TOKEN=${AI_HEALTH_TOKEN}"', workflow)
+        self.assertIn("FEATURES: ${{ vars.PAI_FEATURES }}", workflow)
+        self.assertIn(
+            "AI_HEALTH_TOKEN: ${{ secrets.PAI_AI_HEALTH_TOKEN }}",
+            workflow,
+        )
+
+    def test_uptime_jobs_are_independently_feature_gated(self) -> None:
+        workflow = source(".github/workflows/uptime.yml")
+        self.assertIn("vars.PAI_UPTIME_ENABLED == 'true'", workflow)
+        self.assertIn("vars.PAI_AI_UPTIME_ENABLED == 'true'", workflow)
+        self.assertIn("cancel-in-progress: false", workflow)
+        self.assertIn("--deliberate-failure", workflow)
+        self.assertIn("--check ai", workflow)
+        self.assertNotIn("target_url:", workflow)
+        self.assertIn(
+            "PAI_AI_HEALTH_TOKEN: ${{ secrets.PAI_AI_HEALTH_TOKEN }}",
+            workflow,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_uptime_probe.py
+++ b/scripts/test_uptime_probe.py
@@ -21,7 +21,7 @@ class ResponseHandler(http.server.BaseHTTPRequestHandler):
     expected_token = ""
 
     def do_GET(self) -> None:
-        if self.path not in {"/health", "/health/ai"}:
+        if self.path not in {"/health/api", "/health/ai"}:
             self.send_error(404)
             return
         if self.path == "/health/ai" and self.headers.get("Authorization") != f"Bearer {self.expected_token}":
@@ -81,7 +81,7 @@ class ProbeTests(unittest.TestCase):
         with serve() as target:
             self.assertEqual(
                 uptime_probe.probe(target, timeout=1, allow_http=True),
-                f"{target}/health",
+                f"{target}/health/api",
             )
 
     def test_rejects_non_200_without_exposing_body(self) -> None:
@@ -122,7 +122,7 @@ class ProbeTests(unittest.TestCase):
                 uptime_probe.probe(target, timeout=0.05, allow_http=True)
 
     def test_rejects_redirect(self) -> None:
-        with serve(redirect_to="https://example.com/health") as target:
+        with serve(redirect_to="https://example.com/health/api") as target:
             with self.assertRaisesRegex(
                 uptime_probe.ProbeError, "returned HTTP 302"
             ):

--- a/scripts/test_uptime_probe.py
+++ b/scripts/test_uptime_probe.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Behavior tests for the external uptime probe."""
+
+from __future__ import annotations
+
+import contextlib
+import http.server
+import threading
+import time
+import unittest
+
+import uptime_probe
+
+
+class ResponseHandler(http.server.BaseHTTPRequestHandler):
+    status = 200
+    content_type = "application/json"
+    body = b'{"status":"ok"}'
+    delay = 0.0
+    redirect_to = ""
+    expected_token = ""
+
+    def do_GET(self) -> None:
+        if self.path not in {"/health", "/health/ai"}:
+            self.send_error(404)
+            return
+        if self.path == "/health/ai" and self.headers.get("Authorization") != f"Bearer {self.expected_token}":
+            self.send_error(404)
+            return
+        time.sleep(self.delay)
+        if self.redirect_to:
+            self.send_response(302)
+            self.send_header("Location", self.redirect_to)
+            self.end_headers()
+            return
+        self.send_response(self.status)
+        self.send_header("Content-Type", self.content_type)
+        self.end_headers()
+        with contextlib.suppress(BrokenPipeError):
+            self.wfile.write(self.body)
+
+    def log_message(self, format: str, *args: object) -> None:
+        pass
+
+
+@contextlib.contextmanager
+def serve(
+    *,
+    status: int = 200,
+    content_type: str = "application/json",
+    body: bytes = b'{"status":"ok"}',
+    delay: float = 0.0,
+    redirect_to: str = "",
+    expected_token: str = "",
+):
+    handler = type(
+        "ConfiguredResponseHandler",
+        (ResponseHandler,),
+        {
+            "status": status,
+            "content_type": content_type,
+            "body": body,
+            "delay": delay,
+            "redirect_to": redirect_to,
+            "expected_token": expected_token,
+        },
+    )
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+class ProbeTests(unittest.TestCase):
+    def test_accepts_exact_health_contract(self) -> None:
+        with serve() as target:
+            self.assertEqual(
+                uptime_probe.probe(target, timeout=1, allow_http=True),
+                f"{target}/health",
+            )
+
+    def test_rejects_non_200_without_exposing_body(self) -> None:
+        secret = b"do-not-log-this"
+        with serve(status=503, body=secret) as target:
+            with self.assertRaisesRegex(
+                uptime_probe.ProbeError, "returned HTTP 503"
+            ) as raised:
+                uptime_probe.probe(target, timeout=1, allow_http=True)
+        self.assertNotIn(secret.decode(), str(raised.exception))
+
+    def test_rejects_wrong_json_contract_without_exposing_body(self) -> None:
+        secret = b'{"status":"degraded","detail":"do-not-log-this"}'
+        with serve(body=secret) as target:
+            with self.assertRaisesRegex(
+                uptime_probe.ProbeError, "wrong status contract"
+            ) as raised:
+                uptime_probe.probe(target, timeout=1, allow_http=True)
+        self.assertNotIn(secret.decode(), str(raised.exception))
+
+    def test_rejects_wrong_content_type(self) -> None:
+        with serve(content_type="text/plain") as target:
+            with self.assertRaisesRegex(
+                uptime_probe.ProbeError, "did not return application/json"
+            ):
+                uptime_probe.probe(target, timeout=1, allow_http=True)
+
+    def test_rejects_oversized_response(self) -> None:
+        with serve(body=b"x" * (uptime_probe.MAX_RESPONSE_BYTES + 1)) as target:
+            with self.assertRaisesRegex(
+                uptime_probe.ProbeError, "response exceeded 4096 bytes"
+            ):
+                uptime_probe.probe(target, timeout=1, allow_http=True)
+
+    def test_rejects_timeout(self) -> None:
+        with serve(delay=0.2) as target:
+            with self.assertRaisesRegex(uptime_probe.ProbeError, "timed out"):
+                uptime_probe.probe(target, timeout=0.05, allow_http=True)
+
+    def test_rejects_redirect(self) -> None:
+        with serve(redirect_to="https://example.com/health") as target:
+            with self.assertRaisesRegex(
+                uptime_probe.ProbeError, "returned HTTP 302"
+            ):
+                uptime_probe.probe(target, timeout=1, allow_http=True)
+
+    def test_deliberate_failure_requires_healthy_owned_origin(self) -> None:
+        with serve() as target:
+            with self.assertRaisesRegex(
+                uptime_probe.ProbeError,
+                "deliberate verification failure after healthy response",
+            ):
+                uptime_probe.probe(
+                    target,
+                    timeout=1,
+                    allow_http=True,
+                    deliberate_failure=True,
+                )
+
+    def test_ai_health_uses_authenticated_ai_path(self) -> None:
+        with serve(expected_token="monitor-secret") as target:
+            self.assertEqual(
+                uptime_probe.probe(
+                    target,
+                    timeout=1,
+                    allow_http=True,
+                    check="ai",
+                    token="monitor-secret",
+                ),
+                f"{target}/health/ai",
+            )
+
+    def test_ai_health_requires_token(self) -> None:
+        with serve(expected_token="monitor-secret") as target:
+            with self.assertRaisesRegex(
+                uptime_probe.ProbeError, "AI health token is required"
+            ):
+                uptime_probe.probe(
+                    target,
+                    timeout=1,
+                    allow_http=True,
+                    check="ai",
+                )
+
+    def test_requires_https_outside_local_tests(self) -> None:
+        with self.assertRaisesRegex(uptime_probe.ProbeError, "must use HTTPS"):
+            uptime_probe.health_url("http://example.com")
+
+    def test_rejects_credentials_and_unexpected_paths(self) -> None:
+        invalid_targets = (
+            "https://user:password@example.com",
+            "https://example.com/admin",
+            "https://example.com?token=secret",
+        )
+        for target in invalid_targets:
+            with self.subTest(target=target):
+                with self.assertRaises(uptime_probe.ProbeError):
+                    uptime_probe.health_url(target)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/uptime_probe.py
+++ b/scripts/uptime_probe.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Probe pai-bot's public liveness contract from an external runner."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+MAX_RESPONSE_BYTES = 4096
+
+
+class ProbeError(Exception):
+    """An expected uptime contract failure safe to show in monitoring logs."""
+
+
+class NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Refuse redirects so another endpoint cannot satisfy the health contract."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+def health_url(target: str, *, check: str = "app", allow_http: bool = False) -> str:
+    """Return the canonical health URL for a public origin or health URL."""
+    parsed = urllib.parse.urlsplit(target)
+    allowed_schemes = {"https"}
+    if allow_http:
+        allowed_schemes.add("http")
+    if parsed.scheme not in allowed_schemes:
+        raise ProbeError("target must use HTTPS")
+    if not parsed.hostname or parsed.username or parsed.password:
+        raise ProbeError("target must be a public origin without credentials")
+    if parsed.query or parsed.fragment:
+        raise ProbeError("target must not contain a query or fragment")
+    if parsed.path not in {"", "/", "/api", "/api/", "/health", "/health/ai"}:
+        raise ProbeError("target must be an origin, API base URL, or health URL")
+    path = "/health/ai" if check == "ai" else "/health"
+    return urllib.parse.urlunsplit(
+        (parsed.scheme, parsed.netloc, path, "", "")
+    )
+
+
+def probe(
+    target: str,
+    *,
+    timeout: float,
+    allow_http: bool = False,
+    deliberate_failure: bool = False,
+    check: str = "app",
+    token: str = "",
+) -> str:
+    """Probe the target and return its normalized URL when healthy."""
+    url = health_url(target, check=check, allow_http=allow_http)
+    headers = {
+        "Accept": "application/json",
+        "User-Agent": "pai-uptime-monitor/1",
+    }
+    if check == "ai":
+        if not token:
+            raise ProbeError("AI health token is required")
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(
+        url,
+        headers=headers,
+        method="GET",
+    )
+
+    try:
+        opener = urllib.request.build_opener(NoRedirectHandler())
+        with opener.open(request, timeout=timeout) as response:
+            status = response.status
+            content_type = response.headers.get_content_type()
+            body = response.read(MAX_RESPONSE_BYTES + 1)
+    except urllib.error.HTTPError as error:
+        status = error.code
+        error.close()
+        raise ProbeError(f"health endpoint returned HTTP {status}") from None
+    except TimeoutError:
+        raise ProbeError("health endpoint timed out") from None
+    except urllib.error.URLError as error:
+        if isinstance(error.reason, TimeoutError):
+            raise ProbeError("health endpoint timed out") from None
+        raise ProbeError("health endpoint unreachable") from None
+
+    if status != 200:
+        raise ProbeError(f"health endpoint returned HTTP {status}")
+    if content_type != "application/json":
+        raise ProbeError("health endpoint did not return application/json")
+    if len(body) > MAX_RESPONSE_BYTES:
+        raise ProbeError("health response exceeded 4096 bytes")
+
+    try:
+        payload = json.loads(body)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        raise ProbeError("health endpoint returned invalid JSON") from None
+    if payload != {"status": "ok"}:
+        raise ProbeError("health endpoint returned the wrong status contract")
+    if deliberate_failure:
+        raise ProbeError("deliberate verification failure after healthy response")
+    return url
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line input at the process boundary."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("target", help="Public HTTPS origin, API base, or /health URL")
+    parser.add_argument("--check", choices=("app", "ai"), default="app")
+    parser.add_argument("--timeout", type=float, default=10.0)
+    parser.add_argument(
+        "--allow-http",
+        action="store_true",
+        help="Permit HTTP for local testing only",
+    )
+    parser.add_argument(
+        "--deliberate-failure",
+        action="store_true",
+        help="Fail after a healthy owned-origin response for rollout verification",
+    )
+    args = parser.parse_args()
+    if args.timeout <= 0:
+        parser.error("--timeout must be greater than zero")
+    return args
+
+
+def main() -> int:
+    """Run one probe and emit only safe, bounded diagnostics."""
+    args = parse_args()
+    try:
+        url = probe(
+            args.target,
+            timeout=args.timeout,
+            allow_http=args.allow_http,
+            deliberate_failure=args.deliberate_failure,
+            check=args.check,
+            token=os.environ.get("PAI_AI_HEALTH_TOKEN", ""),
+        )
+    except ProbeError as error:
+        print(f"uptime probe failed: {error}", file=sys.stderr)
+        return 1
+    print(f"uptime probe passed: {url}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/uptime_probe.py
+++ b/scripts/uptime_probe.py
@@ -37,9 +37,17 @@ def health_url(target: str, *, check: str = "app", allow_http: bool = False) -> 
         raise ProbeError("target must be a public origin without credentials")
     if parsed.query or parsed.fragment:
         raise ProbeError("target must not contain a query or fragment")
-    if parsed.path not in {"", "/", "/api", "/api/", "/health", "/health/ai"}:
+    if parsed.path not in {
+        "",
+        "/",
+        "/api",
+        "/api/",
+        "/health",
+        "/health/api",
+        "/health/ai",
+    }:
         raise ProbeError("target must be an origin, API base URL, or health URL")
-    path = "/health/ai" if check == "ai" else "/health"
+    path = "/health/ai" if check == "ai" else "/health/api"
     return urllib.parse.urlunsplit(
         (parsed.scheme, parsed.netloc, path, "", "")
     )
@@ -108,7 +116,10 @@ def probe(
 def parse_args() -> argparse.Namespace:
     """Parse command-line input at the process boundary."""
     parser = argparse.ArgumentParser()
-    parser.add_argument("target", help="Public HTTPS origin, API base, or /health URL")
+    parser.add_argument(
+        "target",
+        help="Public HTTPS origin, API base, or health URL",
+    )
     parser.add_argument("--check", choices=("app", "ai"), default="app")
     parser.add_argument("--timeout", type=float, default=10.0)
     parser.add_argument(

--- a/site/src/content/docs/deployment/deployment.md
+++ b/site/src/content/docs/deployment/deployment.md
@@ -273,6 +273,47 @@ Graceful shutdown on `SIGTERM` with a 15-second termination grace period.
 
 ## Monitoring
 
+### External uptime
+
+The `Uptime` GitHub Actions workflow checks the feature-gated public `/health`
+endpoint every five minutes from outside the application host. It derives the
+current origin from the production `NEXT_PUBLIC_API_URL` secret and does not
+accept manual origin overrides.
+
+AI availability is monitored separately at authenticated `/health/ai`. Enable
+the `ai_health` feature alongside `public_health`, store a dedicated
+`PAI_AI_HEALTH_TOKEN` production secret for both the app and workflow, and
+enable its schedule independently:
+
+The server checks configured providers in routing order until one is healthy,
+with a five-second bound and a one-minute cache that coalesces concurrent
+requests. Public responses never expose provider names or upstream errors.
+Anthropic's current provider check performs a one-token completion if routing
+falls through to it, so keep the AI schedule disabled when that cost is not
+acceptable.
+
+Roll out both checks in this order:
+
+1. Merge the workflow while `PAI_UPTIME_ENABLED` and
+   `PAI_AI_UPTIME_ENABLED` are unset or `false`.
+2. Read the existing feature list with
+   `gh variable get PAI_FEATURES --env production`, then append
+   `public_health,ai_health` without removing any existing flags.
+3. Store a generated monitor secret with
+   `gh secret set PAI_AI_HEALTH_TOKEN --env production`.
+4. Run the `Deploy` workflow so the app receives the flags and bearer secret.
+5. Dispatch `Uptime` in `healthy` and `deliberate-failure` mode for both `app`
+   and `ai`. The failed runs prove GitHub retains useful diagnostics; no paging
+   destination is configured by this workflow.
+6. Enable schedules only after those checks pass:
+   `gh variable set PAI_UPTIME_ENABLED --body true` and
+   `gh variable set PAI_AI_UPTIME_ENABLED --body true`.
+7. Confirm a completed scheduled run for both jobs.
+
+Set either schedule variable to `false` to stop that monitor. To remove the
+public routes, remove only `public_health` and/or `ai_health` from the preserved
+feature list and redeploy.
+
 ### Logs
 
 Structured JSON logs via `slog`:

--- a/site/src/content/docs/deployment/deployment.md
+++ b/site/src/content/docs/deployment/deployment.md
@@ -275,10 +275,13 @@ Graceful shutdown on `SIGTERM` with a 15-second termination grace period.
 
 ### External uptime
 
-The `Uptime` GitHub Actions workflow checks the feature-gated public `/health`
-endpoint every five minutes from outside the application host. It derives the
-current origin from the production `NEXT_PUBLIC_API_URL` secret and does not
-accept manual origin overrides.
+The feature-gated public `/health` page shows coarse application and AI
+availability without requiring an admin session. Its data comes from
+`/health/status`; provider names and upstream errors are never exposed. The
+`Uptime` GitHub Actions workflow separately checks the strict `/health/api`
+JSON contract every five minutes from outside the application host. It derives
+the current origin from the production `NEXT_PUBLIC_API_URL` secret and does
+not accept manual origin overrides.
 
 AI availability is monitored separately at authenticated `/health/ai`. Enable
 the `ai_health` feature alongside `public_health`, store a dedicated


### PR DESCRIPTION
Summary
- add a feature-gated public `/health` endpoint while preserving internal `/healthz`
- add authenticated, cached `/health/ai` checks across configured AI fallbacks
- add independent GitHub Actions monitors with disabled-by-default schedule controls
- route health endpoints through supported ingress configurations and document rollout/rollback

Testing
- `go test ./... -short -count=1`
- focused `go test -race` for AI and server health paths
- `go vet` for changed Go packages
- `python3 scripts/test_uptime_probe.py -v`
- `python3 scripts/test_uptime_config.py -v`
- workflow YAML parse and `git diff --check`