### PR TITLE
feat(admin-spa): improve route loading states

### DIFF
--- a/admin-spa/src/components/ai-usage/ai-usage-load-boundary.tsx
+++ b/admin-spa/src/components/ai-usage/ai-usage-load-boundary.tsx
@@ -3,12 +3,14 @@ import type { ReactNode } from 'react'
 
 import type { AIUsageLoadState } from '@/hooks/use-ai-usage-state'
 import type { AIUsageSummary } from '@/lib/ai-usage-types'
+import type { ContentSkeletonVariant } from '@/components/shared/content-skeleton'
 import { LoadState } from '@/components/shared/load-state'
 
 export function AIUsageLoadBoundary({
   children,
   errorTitle,
   loadingTitle,
+  loadingVariant = 'analytics',
   setState,
   state,
 }: {
@@ -18,6 +20,7 @@ export function AIUsageLoadBoundary({
   }) => ReactNode
   errorTitle: string
   loadingTitle: string
+  loadingVariant?: ContentSkeletonVariant
   setState: (state: AIUsageLoadState) => void
   state: AIUsageLoadState
 }) {
@@ -34,6 +37,7 @@ export function AIUsageLoadBoundary({
         error={state.error}
         errorTitle={errorTitle}
         loadingTitle={loadingTitle}
+        loadingVariant={loadingVariant}
         status={state.status}
       />
     )

--- a/admin-spa/src/components/classes/classes-management.tsx
+++ b/admin-spa/src/components/classes/classes-management.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/components/ui/select'
 import { DataTable } from '@/components/shared/data-table'
 import { LoadingStatus, StatePanel } from '@/components/shared/state-panel'
+import { ContentSkeleton } from '@/components/shared/content-skeleton'
 import { StatItem } from '@/components/shared/stat-item'
 import { SurfaceSection } from '@/components/shared/surface-section'
 import { getGroupDetail } from '@/lib/admin-api'
@@ -86,7 +87,7 @@ export function ClassesContent({
   }, [onCreated])
 
   if (isInitialClassLoad(state)) {
-    return <LoadingStatus>Loading classes…</LoadingStatus>
+    return <ContentSkeleton label='Loading classes' variant='classes' />
   }
 
   if (state.status === 'error' && state.groups.length === 0) {

--- a/admin-spa/src/components/settings/ai-settings-panel.tsx
+++ b/admin-spa/src/components/settings/ai-settings-panel.tsx
@@ -259,6 +259,7 @@ export function AISettingsPanel() {
         error={state.status === 'error' ? state.message : null}
         errorTitle='Could not load AI settings'
         loadingTitle='Loading AI settings'
+        loadingVariant='settings'
         status={state.status}
       />
     )

--- a/admin-spa/src/components/settings/embed-config-panel.tsx
+++ b/admin-spa/src/components/settings/embed-config-panel.tsx
@@ -205,6 +205,7 @@ export function EmbedConfigPanel() {
         error={error}
         errorTitle='Could not load embed settings'
         loadingTitle='Loading embed settings'
+        loadingVariant='settings'
         status={status}
       />
     )

--- a/admin-spa/src/components/settings/whatsapp-setup-panel.tsx
+++ b/admin-spa/src/components/settings/whatsapp-setup-panel.tsx
@@ -80,6 +80,7 @@ function WhatsAppStatusView({
         error={statusState.loadError}
         errorTitle='Could not load WhatsApp status'
         loadingTitle='Loading WhatsApp status'
+        loadingVariant='settings'
         status={statusState.loadState}
       />
     )

--- a/admin-spa/src/components/shared/admin-sidebar.tsx
+++ b/admin-spa/src/components/shared/admin-sidebar.tsx
@@ -58,8 +58,9 @@ export function AdminSidebar() {
       <SidebarHeader className='px-4 pt-4 pb-3'>
         <div className='flex min-h-11 items-center gap-2'>
           <Link
-            className='flex min-w-0 flex-1 items-center gap-3 rounded-xl px-2 py-1 text-sm font-semibold text-[#101828] no-underline transition-[background-color,box-shadow,transform] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:bg-[#f8fafc] focus-visible:ring-3 focus-visible:ring-[#2f80ed]/35 focus-visible:outline-none active:scale-[0.96]'
+            className='flex min-w-0 flex-1 items-center gap-3 rounded-xl px-2 py-1 text-sm font-semibold text-[#101828] no-underline transition-[background-color,box-shadow,transform] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:bg-[#f8fafc] focus-visible:ring-3 focus-visible:ring-[#2f80ed]/35 focus-visible:outline-none active:scale-[0.96] motion-reduce:transform-none motion-reduce:transition-none'
             onClick={handleCloseNavigation}
+            preload='intent'
             search={dashboardSearch}
             to='/dashboard'
           >
@@ -158,12 +159,14 @@ function AdminNavigationLink({
     <SidebarMenuItem>
       <SidebarMenuButton
         asChild
-        className='relative h-11 gap-3 rounded-lg px-3 text-[#667085] transition-[background-color,color,box-shadow,transform] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:bg-[#f4f7fb] hover:text-[#101828] focus-visible:ring-3 focus-visible:ring-[#2f80ed]/35 active:scale-[0.96] data-active:bg-[#eaf2ff] data-active:font-semibold data-active:text-[#175cd3]'
+        className='relative h-11 gap-3 rounded-lg px-3 text-[#667085] transition-[background-color,color,box-shadow,transform] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:bg-[#f4f7fb] hover:text-[#101828] focus-visible:ring-3 focus-visible:ring-[#2f80ed]/35 active:scale-[0.96] motion-reduce:transform-none motion-reduce:transition-none data-active:bg-[#eaf2ff] data-active:font-semibold data-active:text-[#175cd3]'
         isActive={isActive}
       >
         <Link
           aria-current={isActive ? 'page' : undefined}
           onClick={onNavigate}
+          preload='intent'
+          search={href === '/dashboard' ? dashboardSearch : undefined}
           to={href}
         >
           <span

--- a/admin-spa/src/components/shared/content-skeleton.test.tsx
+++ b/admin-spa/src/components/shared/content-skeleton.test.tsx
@@ -1,0 +1,28 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom/vitest'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { ContentSkeleton } from './content-skeleton'
+
+afterEach(cleanup)
+
+describe('ContentSkeleton', () => {
+  it.each(['analytics', 'budget', 'classes', 'settings', 'users'] as const)(
+    'announces and identifies the %s loading shape',
+    (variant) => {
+      const { container } = render(
+        <ContentSkeleton label={`Loading ${variant}`} variant={variant} />,
+      )
+
+      expect(screen.getByRole('status')).toHaveAttribute('aria-busy', 'true')
+      expect(screen.getByText(`Loading ${variant}`)).toHaveClass('sr-only')
+      expect(
+        container.querySelector(`[data-skeleton-variant="${variant}"]`),
+      ).toBeInTheDocument()
+    },
+  )
+})

--- a/admin-spa/src/components/shared/content-skeleton.tsx
+++ b/admin-spa/src/components/shared/content-skeleton.tsx
@@ -1,0 +1,140 @@
+import type { ReactNode } from 'react'
+
+import { Skeleton } from '@/components/ui/skeleton'
+import { cn } from '@/lib/utils'
+
+const FOUR_ITEMS = ['one', 'two', 'three', 'four'] as const
+const FIVE_ITEMS = [...FOUR_ITEMS, 'five'] as const
+
+export type ContentSkeletonVariant =
+  | 'analytics'
+  | 'budget'
+  | 'classes'
+  | 'settings'
+  | 'users'
+
+/** Reserves the shape of route content while its initial data is loading. */
+export function ContentSkeleton({
+  label,
+  variant,
+}: {
+  label: string
+  variant: ContentSkeletonVariant
+}) {
+  return (
+    <div
+      aria-busy='true'
+      className='mt-6'
+      data-skeleton-variant={variant}
+      role='status'
+    >
+      <span className='sr-only'>{label}</span>
+      {getSkeletonContent(variant)}
+    </div>
+  )
+}
+
+function getSkeletonContent(variant: ContentSkeletonVariant): ReactNode {
+  const views: Record<ContentSkeletonVariant, ReactNode> = {
+    analytics: (
+      <div className='grid gap-5'>
+        <StatGrid count={4} />
+        <Surface rows={3} />
+        <Surface className='min-h-64' rows={2} />
+        <Surface rows={4} />
+      </div>
+    ),
+    budget: (
+      <Surface>
+        <StatGrid count={3} />
+        <div className='mt-7 grid gap-4'>
+          <Skeleton className='h-4 w-36' />
+          <Skeleton className='h-11 w-full' />
+          <Skeleton className='h-11 w-32' />
+        </div>
+      </Surface>
+    ),
+    classes: (
+      <div className='grid gap-5'>
+        <StatGrid count={2} />
+        <div className='grid items-start gap-5 lg:grid-cols-[minmax(220px,0.34fr)_minmax(0,1fr)]'>
+          <Surface rows={4} />
+          <Surface rows={5} />
+        </div>
+      </div>
+    ),
+    settings: (
+      <div className='grid gap-5 xl:grid-cols-[minmax(0,1fr)_24rem]'>
+        <Surface rows={5} />
+        <div className='grid gap-5'>
+          <Surface rows={3} />
+          <Surface rows={2} />
+        </div>
+      </div>
+    ),
+    users: (
+      <div className='grid gap-5'>
+        <StatGrid count={5} />
+        <Surface>
+          <div className='flex flex-col gap-3 sm:flex-row sm:justify-between'>
+            <Skeleton className='h-11 w-full sm:max-w-sm' />
+            <Skeleton className='h-11 w-full sm:w-36' />
+          </div>
+          <div className='mt-6 grid gap-2'>
+            {FIVE_ITEMS.map((item) => (
+              <Skeleton className='h-12 w-full' key={item} />
+            ))}
+          </div>
+        </Surface>
+      </div>
+    ),
+  }
+
+  return views[variant]
+}
+
+function StatGrid({ count }: { count: number }) {
+  const items = count === 5 ? FIVE_ITEMS : FOUR_ITEMS.slice(0, count)
+
+  return (
+    <div className='grid gap-3 sm:grid-cols-2 xl:grid-cols-4'>
+      {items.map((item) => (
+        <div className='rounded-xl border border-border bg-card p-5' key={item}>
+          <Skeleton className='h-4 w-24' />
+          <Skeleton className='mt-4 h-8 w-16' />
+          <Skeleton className='mt-3 h-3 w-32 max-w-full' />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function Surface({
+  children,
+  className,
+  rows = 0,
+}: {
+  children?: ReactNode
+  className?: string
+  rows?: number
+}) {
+  return (
+    <div
+      className={cn(
+        'rounded-xl border border-border bg-card p-5 sm:p-6',
+        className,
+      )}
+    >
+      <Skeleton className='h-5 w-40' />
+      <Skeleton className='mt-2 h-4 w-full max-w-md' />
+      {children}
+      {rows > 0 ? (
+        <div className='mt-6 grid gap-3'>
+          {FIVE_ITEMS.slice(0, rows).map((item) => (
+            <Skeleton className='h-11 w-full' key={item} />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/admin-spa/src/components/shared/load-state.tsx
+++ b/admin-spa/src/components/shared/load-state.tsx
@@ -1,14 +1,18 @@
 import { LoadingStatus, StatePanel } from './state-panel'
+import { ContentSkeleton } from './content-skeleton'
+import type { ContentSkeletonVariant } from './content-skeleton'
 
 export function LoadState({
   error,
   errorTitle,
   loadingTitle,
+  loadingVariant,
   status,
 }: {
   error: string | null
   errorTitle: string
   loadingTitle: string
+  loadingVariant?: ContentSkeletonVariant
   status: 'loading' | 'ready' | 'error'
 }) {
   const views = {
@@ -17,7 +21,11 @@ export function LoadState({
         {error ?? 'Request failed'}
       </StatePanel>
     ),
-    loading: <LoadingStatus>{loadingTitle}</LoadingStatus>,
+    loading: loadingVariant ? (
+      <ContentSkeleton label={loadingTitle} variant={loadingVariant} />
+    ) : (
+      <LoadingStatus>{loadingTitle}</LoadingStatus>
+    ),
     ready: null,
   }
 

--- a/admin-spa/src/components/ui/skeleton.tsx
+++ b/admin-spa/src/components/ui/skeleton.tsx
@@ -4,7 +4,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot='skeleton'
-      className={cn('animate-pulse rounded-md bg-muted', className)}
+      className={cn('rounded-md bg-muted motion-safe:animate-pulse', className)}
       {...props}
     />
   )

--- a/admin-spa/src/components/users/user-management-panel.tsx
+++ b/admin-spa/src/components/users/user-management-panel.tsx
@@ -100,6 +100,7 @@ export function UserManagementPanel() {
         error={state.error}
         errorTitle='User management unavailable'
         loadingTitle='Loading users and invites...'
+        loadingVariant='users'
         status={state.status}
       />
     )

--- a/admin-spa/src/lib/admin-navigation.test.ts
+++ b/admin-spa/src/lib/admin-navigation.test.ts
@@ -23,12 +23,14 @@ describe('admin sidebar navigation', () => {
     expect(groups[0]?.items.map(({ label }) => label)).toEqual([
       'Today',
       'My classes',
-      'Learning progress',
     ])
     expect(groups[1]?.items.map(({ label }) => label)).toEqual(['AI activity'])
     expect(
       groups.flatMap(({ items }) => items).map(({ href }) => href),
     ).not.toContain('/dashboard/retrieval-lab')
+    expect(
+      groups.flatMap(({ items }) => items).map(({ href }) => href),
+    ).not.toContain('/dashboard/metrics')
   })
 
   it('shows school administration only to roles with access', () => {

--- a/admin-spa/src/lib/admin-navigation.ts
+++ b/admin-spa/src/lib/admin-navigation.ts
@@ -1,5 +1,4 @@
 import {
-  BarChart3Icon,
   BookOpenCheckIcon,
   BotIcon,
   CableIcon,
@@ -27,11 +26,6 @@ const navigationGroups = [
         Icon: BookOpenCheckIcon,
         href: '/dashboard/classes',
         label: 'My classes',
-      },
-      {
-        Icon: BarChart3Icon,
-        href: '/dashboard/metrics',
-        label: 'Learning progress',
       },
     ],
   },

--- a/admin-spa/src/router.tsx
+++ b/admin-spa/src/router.tsx
@@ -6,6 +6,7 @@ import { routeTree } from './routeTree.gen'
 export const router = createRouter({
   routeTree,
   context: initialAuthContext,
+  defaultPreload: 'intent',
 })
 
 declare module '@tanstack/react-router' {

--- a/admin-spa/src/routes/_authenticated/settings/budget.tsx
+++ b/admin-spa/src/routes/_authenticated/settings/budget.tsx
@@ -24,6 +24,7 @@ function BudgetSettingsRoute() {
       <AIUsageLoadBoundary
         errorTitle='Unable to load token budget'
         loadingTitle='Loading token budget...'
+        loadingVariant='budget'
         setState={setState}
         state={state}
       >


### PR DESCRIPTION
## Summary
- add accessible, route-shaped loading skeletons for admin analytics, budget, classes, settings, and user management
- preload sidebar destinations on intent and clear stale dashboard detail search state when returning to Today
- remove the retired Learning progress navigation item that redirected to AI activity
- respect reduced-motion preferences for skeleton and sidebar motion

## Testing
- `cd admin-spa && pnpm check`
- 58 test files passed, 274 tests passed
- production build passed