### PR TITLE
Harden server startup, shutdown, and production authentication

### DIFF
--- a/cmd/server/lifecycle_test.go
+++ b/cmd/server/lifecycle_test.go
@@ -1,0 +1,34 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestCloseAllRunsInReverseOrderAndJoinsErrors(t *testing.T) {
+	firstErr := errors.New("first close")
+	secondErr := errors.New("second close")
+	var order []string
+
+	err := closeAll([]func() error{
+		func() error {
+			order = append(order, "first")
+			return firstErr
+		},
+		func() error {
+			order = append(order, "second")
+			return secondErr
+		},
+	})
+
+	if !reflect.DeepEqual(order, []string{"second", "first"}) {
+		t.Fatalf("cleanup order = %v, want reverse acquisition order", order)
+	}
+	if !errors.Is(err, firstErr) || !errors.Is(err, secondErr) {
+		t.Fatalf("closeAll() error = %v, want both cleanup errors", err)
+	}
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -86,14 +87,20 @@ func main() {
 	// Graceful shutdown on SIGTERM/SIGINT.
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
-	var cleanup []func()
+
+	if err := run(ctx, cfg); err != nil {
+		slog.Error("server stopped", "error", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, cfg *config.Config) (runErr error) {
+	var cleanup []func() error
 	defer func() {
-		for i := len(cleanup) - 1; i >= 0; i-- {
-			cleanup[i]()
-		}
+		runErr = errors.Join(runErr, closeAll(cleanup))
 	}()
 
-	if err := server.Run(ctx, server.Options{
+	return server.Run(ctx, server.Options{
 		Addr:            fmt.Sprintf(":%d", cfg.Server.Port),
 		ReadTimeout:     10 * time.Second,
 		WriteTimeout:    30 * time.Second,
@@ -102,22 +109,23 @@ func main() {
 		BuildHandler: func(ctx context.Context) (http.Handler, func(context.Context) error, error) {
 
 			// Initialize PostgreSQL-backed conversation store.
-			db, err := database.New(context.Background(), cfg.Database.URL, cfg.Database.MaxConns, cfg.Database.MinConns)
+			db, err := database.New(ctx, cfg.Database.URL, cfg.Database.MaxConns, cfg.Database.MinConns)
 			if err != nil {
-				slog.Error("failed to connect to database", "error", err)
-				os.Exit(1)
+				return nil, nil, fmt.Errorf("connect to database: %w", err)
 			}
-			cleanup = append(cleanup, db.Close)
+			cleanup = append(cleanup, func() error {
+				db.Close()
+				return nil
+			})
 
 			// In single-tenant mode, ensure the default tenant exists for runtime dependencies.
-			if _, err := tenant.EnsureDefaultTenantForPool(context.Background(), cfg.Tenant.Mode, db.Pool); err != nil {
-				slog.Error("failed to bootstrap tenant mode", "mode", cfg.Tenant.Mode, "error", err)
-				os.Exit(1)
+			if _, err := tenant.EnsureDefaultTenantForPool(ctx, cfg.Tenant.Mode, db.Pool); err != nil {
+				return nil, nil, fmt.Errorf("bootstrap tenant mode %q: %w", cfg.Tenant.Mode, err)
 			}
 
 			// Runtime settings overlay env config; admin saves re-apply live.
 			settingsStore := settings.New(db.Pool, cfg.Auth.JWTSecret, cfg.AI, cfg.FeatureFlags)
-			if err := settingsStore.Start(context.Background()); err != nil {
+			if err := settingsStore.Start(ctx); err != nil {
 				// Degrade to env-only config: a crash loop here would lock
 				// admins out of the very UI that repairs the stored settings.
 				slog.Warn("runtime settings unavailable; using env config", "error", err)
@@ -135,8 +143,7 @@ func main() {
 				} else if canAwaitCodexDeviceAuth(cfg, codexDeviceAuth) {
 					slog.Warn("no AI providers authenticated; continuing so an admin can connect Codex")
 				} else {
-					slog.Error("no AI providers configured")
-					os.Exit(1)
+					return nil, nil, errors.New("no AI providers configured")
 				}
 			}
 			applySettings := func(st settings.Settings) {
@@ -167,21 +174,22 @@ func main() {
 
 			// Initialize cache (warn if unavailable, don't fail).
 			if cfg.Cache.URL != "" {
-				c, err := cache.New(context.Background(), cfg.Cache.URL)
+				c, err := cache.New(ctx, cfg.Cache.URL)
 				if err != nil {
 					slog.Warn("cache not connected", "error", err)
 				} else {
-					cleanup = append(cleanup, func() { _ = c.Close() })
+					cleanup = append(cleanup, func() error {
+						return c.Close()
+					})
 					slog.Info("cache connected")
 				}
 			} else {
 				slog.Warn("cache not configured, running without cache")
 			}
 
-			store, err := agent.NewPostgresStore(context.Background(), db.Pool)
+			store, err := agent.NewPostgresStore(ctx, db.Pool)
 			if err != nil {
-				slog.Error("failed to initialize conversation store", "error", err)
-				os.Exit(1)
+				return nil, nil, fmt.Errorf("initialize conversation store: %w", err)
 			}
 			focusedPageStore := focusedpage.NewPostgresStore(db.Pool)
 			focusedPageCleanup, err := server.NewFocusedPageCleanupWorker(focusedPageStore, nil)
@@ -279,8 +287,7 @@ func main() {
 			if strings.TrimSpace(cfg.Telegram.BotToken) != "" {
 				tg, err := chat.NewTelegramChannel(cfg.Telegram.BotToken)
 				if err != nil {
-					slog.Error("failed to create Telegram channel", "error", err)
-					os.Exit(1)
+					return nil, nil, fmt.Errorf("create Telegram channel: %w", err)
 				}
 				tg.SetDevMode(cfg.Runtime.DevMode)
 				gw.Register("telegram", tg)
@@ -333,8 +340,7 @@ func main() {
 					var waErr error
 					waCloudChannel, waErr = chat.NewWhatsAppChannel(cfg.WhatsApp.AccessToken, cfg.WhatsApp.PhoneID, cfg.WhatsApp.VerifyToken)
 					if waErr != nil {
-						slog.Error("failed to create WhatsApp Cloud API channel", "error", waErr)
-						os.Exit(1)
+						return nil, nil, fmt.Errorf("create WhatsApp Cloud API channel: %w", waErr)
 					}
 					gw.Register("whatsapp", waCloudChannel)
 					slog.Info("whatsapp backend: Cloud API")
@@ -342,8 +348,7 @@ func main() {
 					var waErr error
 					waMeowChannel, waErr = chat.NewWhatsAppMeowChannel(cfg.WhatsApp.MeowDBPath)
 					if waErr != nil {
-						slog.Error("failed to create WhatsApp meow channel", "error", waErr)
-						os.Exit(1)
+						return nil, nil, fmt.Errorf("create WhatsApp meow channel: %w", waErr)
 					}
 					gw.Register("whatsapp", waMeowChannel)
 					slog.Info("whatsapp backend: whatsmeow")
@@ -487,19 +492,17 @@ func main() {
 					FromName:    cfg.Email.FromName,
 				})
 				if err != nil {
-					slog.Error("failed to create invite mailer", "error", err)
-					os.Exit(1)
+					return nil, nil, fmt.Errorf("create invite mailer: %w", err)
 				}
 				authService.ConfigureInviteEmail(inviteMailer)
 			}
 			createdBootstrapAdmin, err := authService.EnsureBootstrapPlatformAdmin(
-				context.Background(),
+				ctx,
 				cfg.Auth.BootstrapAdmin.Email,
 				cfg.Auth.BootstrapAdmin.Password,
 			)
 			if err != nil {
-				slog.Error("failed to ensure bootstrap platform admin", "error", err)
-				os.Exit(1)
+				return nil, nil, fmt.Errorf("ensure bootstrap platform admin: %w", err)
 			}
 			if createdBootstrapAdmin {
 				slog.Info("bootstrap platform admin created", "email", cfg.Auth.BootstrapAdmin.Email)
@@ -565,12 +568,11 @@ func main() {
 					<-ingressDone
 					return err
 				}
-				cleanup = append(cleanup, func() {
-					if err := gw.StopAll(); err != nil {
-						slog.Warn("failed to stop chat channels cleanly", "error", err)
-					}
+				cleanup = append(cleanup, func() error {
+					err := gw.StopAll()
 					cancelIngress()
 					<-ingressDone
+					return err
 				})
 				if focusedPageDeliveries != nil {
 					workerCtx, cancelWorker := context.WithCancel(ctx)
@@ -579,9 +581,10 @@ func main() {
 						defer close(workerDone)
 						focusedPageDeliveries.Run(workerCtx)
 					}()
-					cleanup = append(cleanup, func() {
+					cleanup = append(cleanup, func() error {
 						cancelWorker()
 						<-workerDone
+						return nil
 					})
 				}
 				focusedPageCleanupDone := make(chan struct{})
@@ -589,15 +592,25 @@ func main() {
 					defer close(focusedPageCleanupDone)
 					focusedPageCleanup.Run(ctx)
 				}()
-				cleanup = append(cleanup, func() { <-focusedPageCleanupDone })
+				cleanup = append(cleanup, func() error {
+					<-focusedPageCleanupDone
+					return nil
+				})
 				slog.Info("P&AI Bot is running")
 				return nil
 			}, nil
 		},
-	}); err != nil {
-		slog.Error("server stopped", "error", err)
-		os.Exit(1)
+	})
+}
+
+func closeAll(cleanup []func() error) error {
+	var cleanupErrs []error
+	for i := len(cleanup) - 1; i >= 0; i-- {
+		if err := cleanup[i](); err != nil {
+			cleanupErrs = append(cleanupErrs, err)
+		}
 	}
+	return errors.Join(cleanupErrs...)
 }
 
 const (

--- a/internal/agent/scheduler.go
+++ b/internal/agent/scheduler.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/p-n-ai/pai-bot/internal/ai"
@@ -226,14 +227,23 @@ func (s *Scheduler) Start(ctx context.Context, userIDs []string) {
 func (s *Scheduler) StartForRecipients(ctx context.Context, recipients []ScheduledRecipient) {
 	ticker := time.NewTicker(s.config.CheckInterval)
 	defer ticker.Stop()
+	var timers sync.WaitGroup
+	defer timers.Wait()
+	startTimer := func(run func()) {
+		timers.Add(1)
+		go func() {
+			defer timers.Done()
+			run()
+		}()
+	}
 
 	// Start daily summary on a precise timer (22:00 MYT), not a polling tick.
-	go s.runDailySummaryTimer(ctx, recipients)
-	go s.runWeeklyParentReportTimer(ctx)
+	startTimer(func() { s.runDailySummaryTimer(ctx, recipients) })
+	startTimer(func() { s.runWeeklyParentReportTimer(ctx) })
 
 	// Start weekly leaderboard recap on Monday 8:00 AM MYT.
 	if s.groups != nil {
-		go s.runWeeklyLeaderboardTimer(ctx)
+		startTimer(func() { s.runWeeklyLeaderboardTimer(ctx) })
 	}
 
 	s.logger.Info("scheduler started", "interval", s.config.CheckInterval)

--- a/internal/chat/telegram.go
+++ b/internal/chat/telegram.go
@@ -30,7 +30,9 @@ type TelegramChannel struct {
 	stop     chan struct{}
 	stopOnce sync.Once
 
-	devMode bool
+	devMode     bool
+	lifecycleMu sync.Mutex
+	done        chan struct{}
 }
 
 // NewTelegramChannel creates a Telegram channel adapter.
@@ -170,7 +172,18 @@ func (t *TelegramChannel) Start(ctx context.Context, handler func(InboundMessage
 	if err := t.syncCommands(); err != nil {
 		slog.Warn("failed to sync Telegram commands", "error", err)
 	}
-	go t.pollLoop(ctx, handler)
+	t.lifecycleMu.Lock()
+	if t.done != nil {
+		t.lifecycleMu.Unlock()
+		return nil
+	}
+	done := make(chan struct{})
+	t.done = done
+	t.lifecycleMu.Unlock()
+	go func() {
+		defer close(done)
+		t.pollLoop(ctx, handler)
+	}()
 	return nil
 }
 
@@ -178,6 +191,12 @@ func (t *TelegramChannel) Stop() error {
 	t.stopOnce.Do(func() {
 		close(t.stop)
 	})
+	t.lifecycleMu.Lock()
+	done := t.done
+	t.lifecycleMu.Unlock()
+	if done != nil {
+		<-done
+	}
 	return nil
 }
 

--- a/internal/chat/whatsapp_meow.go
+++ b/internal/chat/whatsapp_meow.go
@@ -34,6 +34,10 @@ type WhatsAppMeowChannel struct {
 	// latestQR holds the current QR code string for the HTTP endpoint.
 	latestQR string
 	qrMu     sync.RWMutex
+
+	lifecycleMu sync.Mutex
+	qrCancel    context.CancelFunc
+	qrDone      chan struct{}
 }
 
 // NewWhatsAppMeowChannel creates a WhatsApp channel backed by whatsmeow.
@@ -96,19 +100,31 @@ func (w *WhatsAppMeowChannel) SendTyping(ctx context.Context, userID string) err
 
 // Start connects to WhatsApp. If not yet authenticated, it generates a QR code
 // available via the QRHandler HTTP endpoint.
-func (w *WhatsAppMeowChannel) Start(_ context.Context, handler func(InboundMessage)) error {
+func (w *WhatsAppMeowChannel) Start(ctx context.Context, handler func(InboundMessage)) error {
 	w.mu.Lock()
 	w.handler = handler
 	w.mu.Unlock()
 
 	if w.client.Store.ID == nil {
 		// Not yet authenticated — need QR code scan.
-		qrChan, _ := w.client.GetQRChannel(context.Background())
+		qrCtx, cancelQR := context.WithCancel(ctx)
+		qrChan, err := w.client.GetQRChannel(qrCtx)
+		if err != nil {
+			cancelQR()
+			return fmt.Errorf("whatsmeow QR channel: %w", err)
+		}
 		if err := w.client.Connect(); err != nil {
+			cancelQR()
 			return fmt.Errorf("whatsmeow connect: %w", err)
 		}
+		qrDone := make(chan struct{})
+		w.lifecycleMu.Lock()
+		w.qrCancel = cancelQR
+		w.qrDone = qrDone
+		w.lifecycleMu.Unlock()
 		// Process QR events in background.
 		go func() {
+			defer close(qrDone)
 			for evt := range qrChan {
 				switch evt.Event {
 				case "code":
@@ -142,7 +158,19 @@ func (w *WhatsAppMeowChannel) Start(_ context.Context, handler func(InboundMessa
 
 // Stop disconnects from WhatsApp.
 func (w *WhatsAppMeowChannel) Stop() error {
+	w.lifecycleMu.Lock()
+	cancelQR := w.qrCancel
+	qrDone := w.qrDone
+	w.qrCancel = nil
+	w.qrDone = nil
+	w.lifecycleMu.Unlock()
+	if cancelQR != nil {
+		cancelQR()
+	}
 	w.client.Disconnect()
+	if qrDone != nil {
+		<-qrDone
+	}
 	return nil
 }
 

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -20,6 +20,11 @@ import (
 // never be encrypted under it.
 const DefaultAuthSecret = "change-me-in-production"
 
+const (
+	defaultBootstrapAdminEmail    = "platform-admin@example.com"
+	defaultBootstrapAdminPassword = "demo-password"
+)
+
 // Config holds all application configuration.
 type Config struct {
 	Server         ServerConfig
@@ -360,8 +365,8 @@ func Load() (*Config, error) {
 				AdminBaseURL:          envStr("PAI_AUTH_GOOGLE_ADMIN_BASE_URL", ""),
 			},
 			BootstrapAdmin: BootstrapAdminConfig{
-				Email:    envStr("PAI_AUTH_BOOTSTRAP_ADMIN_EMAIL", "platform-admin@example.com"),
-				Password: envStr("PAI_AUTH_BOOTSTRAP_ADMIN_PASSWORD", "demo-password"),
+				Email:    envStr("PAI_AUTH_BOOTSTRAP_ADMIN_EMAIL", defaultBootstrapAdminEmail),
+				Password: envStr("PAI_AUTH_BOOTSTRAP_ADMIN_PASSWORD", defaultBootstrapAdminPassword),
 			},
 		},
 		Tenant: TenantConfig{
@@ -394,6 +399,17 @@ func (c *Config) Validate() error {
 	}
 	if !c.HasAIProvider() && !c.CodexDeviceAuthAvailable() && !c.Runtime.DevMode {
 		return fmt.Errorf("at least one AI provider must be configured")
+	}
+	if !c.Runtime.DevMode {
+		if strings.TrimSpace(c.Auth.JWTSecret) == "" || c.Auth.JWTSecret == DefaultAuthSecret {
+			return fmt.Errorf("PAI_AUTH_SECRET must be set to a private secret in production")
+		}
+		if strings.TrimSpace(c.Auth.BootstrapAdmin.Email) == "" ||
+			strings.TrimSpace(c.Auth.BootstrapAdmin.Password) == "" ||
+			strings.EqualFold(strings.TrimSpace(c.Auth.BootstrapAdmin.Email), defaultBootstrapAdminEmail) ||
+			c.Auth.BootstrapAdmin.Password == defaultBootstrapAdminPassword {
+			return fmt.Errorf("PAI_AUTH_BOOTSTRAP_ADMIN_EMAIL and PAI_AUTH_BOOTSTRAP_ADMIN_PASSWORD must be set to private credentials in production")
+		}
 	}
 	if c.AI.DefaultProvider != "" && !isKnownAIProvider(c.AI.DefaultProvider) {
 		return fmt.Errorf("unsupported LEARN_AI_DEFAULT_PROVIDER %q", c.AI.DefaultProvider)

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -89,6 +89,13 @@ func clearEnv(t *testing.T) {
 	t.Setenv("LEARN_AI_CODEX_HOME", filepath.Join(t.TempDir(), "codex"))
 }
 
+func setPrivateProductionAuth(t *testing.T) {
+	t.Helper()
+	t.Setenv("PAI_AUTH_SECRET", "private-test-secret")
+	t.Setenv("PAI_AUTH_BOOTSTRAP_ADMIN_EMAIL", "owner@example.com")
+	t.Setenv("PAI_AUTH_BOOTSTRAP_ADMIN_PASSWORD", "private-bootstrap-password")
+}
+
 func TestLoad_FeatureFlagsRejectUnknown(t *testing.T) {
 	clearEnv(t)
 	t.Setenv("PAI_FEATURES", "unknown_feature")
@@ -413,6 +420,43 @@ func TestValidate_DefaultProvider_Invalid(t *testing.T) {
 	}
 }
 
+func TestValidate_ProductionRequiresPrivateAuthConfiguration(t *testing.T) {
+	base := Config{
+		Runtime: RuntimeConfig{DevMode: false},
+		Tenant:  TenantConfig{Mode: "single"},
+		Telegram: TelegramConfig{
+			BotToken: "telegram-token",
+		},
+		AI: AIConfig{
+			Ollama: OllamaConfig{Enabled: true},
+		},
+		Auth: AuthConfig{
+			JWTSecret: DefaultAuthSecret,
+			BootstrapAdmin: BootstrapAdminConfig{
+				Email:    "platform-admin@example.com",
+				Password: "demo-password",
+			},
+		},
+	}
+
+	if err := base.Validate(); err == nil || !strings.Contains(err.Error(), "PAI_AUTH_SECRET") {
+		t.Fatalf("default auth secret error = %v", err)
+	}
+
+	base.Auth.JWTSecret = "private-test-secret"
+	if err := base.Validate(); err == nil || !strings.Contains(err.Error(), "PAI_AUTH_BOOTSTRAP") {
+		t.Fatalf("default bootstrap credentials error = %v", err)
+	}
+
+	base.Auth.BootstrapAdmin = BootstrapAdminConfig{
+		Email:    "owner@example.com",
+		Password: "private-bootstrap-password",
+	}
+	if err := base.Validate(); err != nil {
+		t.Fatalf("private production auth config error = %v", err)
+	}
+}
+
 func TestValidate_MissingBotToken(t *testing.T) {
 	clearEnv(t)
 	t.Setenv("LEARN_AI_OLLAMA_ENABLED", "true")
@@ -462,6 +506,7 @@ func TestValidate_AllowsProductionWithoutTelegram(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			clearEnv(t)
+			setPrivateProductionAuth(t)
 			t.Setenv("LEARN_AI_OLLAMA_ENABLED", "true")
 			for name, value := range tt.env {
 				t.Setenv(name, value)
@@ -692,6 +737,7 @@ func TestValidateEmbedBaseURLRequiresOrigin(t *testing.T) {
 
 func TestValidate_Success(t *testing.T) {
 	clearEnv(t)
+	setPrivateProductionAuth(t)
 	t.Setenv("LEARN_TELEGRAM_BOT_TOKEN", "test-token")
 	t.Setenv("LEARN_AI_OLLAMA_ENABLED", "true")
 
@@ -765,6 +811,7 @@ func TestHasAIProviderRejectsCodexDeviceSetupWithoutHome(t *testing.T) {
 
 func TestValidateAllowsAdminCodexSetupWithoutExistingProvider(t *testing.T) {
 	clearEnv(t)
+	setPrivateProductionAuth(t)
 	t.Setenv("LEARN_TELEGRAM_BOT_TOKEN", "test-token")
 	t.Setenv("LEARN_AI_CODEX_ENABLED", "true")
 

--- a/internal/server/run.go
+++ b/internal/server/run.go
@@ -26,17 +26,14 @@ func Run(ctx context.Context, opts Options) error {
 	if ctx == nil {
 		return errors.New("context is required")
 	}
+	if err := validateOptions(opts); err != nil {
+		return err
+	}
 	runCtx, cancelRun := context.WithCancel(ctx)
 	defer cancelRun()
-	if opts.BuildHandler == nil {
-		return errors.New("build handler is required")
-	}
-	if opts.ShutdownTimeout <= 0 {
-		opts.ShutdownTimeout = 10 * time.Second
-	}
 
 	var handler atomic.Pointer[http.Handler]
-	initialHandler := http.Handler(http.HandlerFunc(handleHealthz))
+	initialHandler := http.Handler(startupHandler())
 	handler.Store(&initialHandler)
 
 	srv := &http.Server{
@@ -93,6 +90,39 @@ func Run(ctx context.Context, opts Options) error {
 		return err
 	}
 	return nil
+}
+
+func validateOptions(opts Options) error {
+	if opts.Addr == "" {
+		return errors.New("server address is required")
+	}
+	if opts.ReadTimeout <= 0 {
+		return errors.New("read timeout must be positive")
+	}
+	if opts.WriteTimeout <= 0 {
+		return errors.New("write timeout must be positive")
+	}
+	if opts.IdleTimeout <= 0 {
+		return errors.New("idle timeout must be positive")
+	}
+	if opts.ShutdownTimeout <= 0 {
+		return errors.New("shutdown timeout must be positive")
+	}
+	if opts.BuildHandler == nil {
+		return errors.New("build handler is required")
+	}
+	return nil
+}
+
+func startupHandler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /healthz", handleHealthz)
+	mux.HandleFunc("GET /readyz", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"status":"starting"}`))
+	})
+	return mux
 }
 
 func shutdownAfterStartupError(srv *http.Server, timeout time.Duration, runErr error) error {

--- a/internal/server/run_test.go
+++ b/internal/server/run_test.go
@@ -47,9 +47,10 @@ func TestRunServesHealthBeforeSwapAndBuiltHandlerAfterSwap(t *testing.T) {
 		})
 	}()
 
-	if body := getEventually(t, "http://"+addr+"/anything"); body != `{"status":"ok"}` {
+	if body := getEventually(t, "http://"+addr+"/healthz"); body != `{"status":"ok"}` {
 		t.Fatalf("health body before swap = %q, want health JSON", body)
 	}
+	getStatusEventually(t, "http://"+addr+"/readyz", http.StatusServiceUnavailable)
 
 	close(allowBuild)
 	go func() {
@@ -80,6 +81,40 @@ func TestRunServesHealthBeforeSwapAndBuiltHandlerAfterSwap(t *testing.T) {
 	}
 }
 
+func TestRunRejectsUnsafeOptions(t *testing.T) {
+	valid := Options{
+		Addr:            "127.0.0.1:8080",
+		ReadTimeout:     time.Second,
+		WriteTimeout:    time.Second,
+		IdleTimeout:     time.Second,
+		ShutdownTimeout: time.Second,
+		BuildHandler: func(context.Context) (http.Handler, func(context.Context) error, error) {
+			return http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), nil, nil
+		},
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*Options)
+	}{
+		{name: "empty address", mutate: func(opts *Options) { opts.Addr = "" }},
+		{name: "zero read timeout", mutate: func(opts *Options) { opts.ReadTimeout = 0 }},
+		{name: "negative write timeout", mutate: func(opts *Options) { opts.WriteTimeout = -time.Second }},
+		{name: "zero idle timeout", mutate: func(opts *Options) { opts.IdleTimeout = 0 }},
+		{name: "zero shutdown timeout", mutate: func(opts *Options) { opts.ShutdownTimeout = 0 }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := valid
+			tt.mutate(&opts)
+			if err := Run(t.Context(), opts); err == nil {
+				t.Fatal("Run() succeeded with unsafe options")
+			}
+		})
+	}
+}
+
 func TestRunCancelsPostSwapWorkWhenServerExits(t *testing.T) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -99,6 +134,9 @@ func TestRunCancelsPostSwapWorkWhenServerExits(t *testing.T) {
 	started := make(chan struct{})
 	runErr := Run(context.Background(), Options{
 		Addr:            listener.Addr().String(),
+		ReadTimeout:     time.Second,
+		WriteTimeout:    time.Second,
+		IdleTimeout:     time.Second,
 		ShutdownTimeout: time.Second,
 		BuildHandler: func(context.Context) (http.Handler, func(context.Context) error, error) {
 			return http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), func(ctx context.Context) error {
@@ -162,4 +200,24 @@ func getEventually(t *testing.T, url string) string {
 	}
 	t.Fatalf("GET %s did not succeed: %v", url, lastErr)
 	return ""
+}
+
+func getStatusEventually(t *testing.T, url string, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == want {
+				return
+			}
+			lastErr = fmt.Errorf("status %d", resp.StatusCode)
+		} else {
+			lastErr = err
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("GET %s did not return %d: %v", url, want, lastErr)
 }


### PR DESCRIPTION
## Summary

- Validate server options and expose explicit startup readiness behavior.
- Propagate initialization errors instead of terminating from nested setup callbacks.
- Make cleanup error-aware and preserve reverse-order shutdown.
- Ensure scheduler and chat channel goroutines finish during shutdown.
- Require private authentication secrets and bootstrap credentials in production.

## Testing

- Added coverage for cleanup ordering and joined errors.
- Added server option validation and startup readiness tests.
- Added production authentication validation tests.
- Not run (not requested).