### PR TITLE
Probe primary AI provider without fallback

### DIFF
--- a/internal/ai/router.go
+++ b/internal/ai/router.go
@@ -322,6 +322,29 @@ func (r *Router) HealthCheck(ctx context.Context) error {
 	return fmt.Errorf("AI health check failed for providers: %s", strings.Join(failures, ", "))
 }
 
+// ProbePrimaryCompletion calls the primary configured provider exactly once
+// without fallback, retry, tracing, or circuit-breaker mutation.
+func (r *Router) ProbePrimaryCompletion(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
+	providers, order, _ := r.snapshotProviders()
+	if len(order) == 0 {
+		return CompletionResponse{}, fmt.Errorf("AI completion probe failed: no providers registered")
+	}
+
+	name := order[0]
+	provider := providers[name]
+	if provider == nil {
+		return CompletionResponse{}, fmt.Errorf("AI completion probe failed: primary provider unavailable")
+	}
+	if req.Model == "" {
+		req.Model = r.defaultModelForProvider(name)
+	}
+	response, err := provider.Complete(ctx, req)
+	if err != nil {
+		return CompletionResponse{}, fmt.Errorf("AI completion probe failed: %w", err)
+	}
+	return response, nil
+}
+
 // HasNativeProvider reports whether any configured provider preserves native tool calls.
 func (r *Router) HasNativeProvider() bool {
 	r.mu.RLock()

--- a/internal/ai/router_health_test.go
+++ b/internal/ai/router_health_test.go
@@ -16,10 +16,14 @@ type healthProvider struct {
 	mu    sync.Mutex
 	calls int
 	err   error
+	resp  ai.CompletionResponse
 }
 
-func (*healthProvider) Complete(context.Context, ai.CompletionRequest) (ai.CompletionResponse, error) {
-	return ai.CompletionResponse{}, errors.New("not implemented")
+func (p *healthProvider) Complete(context.Context, ai.CompletionRequest) (ai.CompletionResponse, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls++
+	return p.resp, p.err
 }
 
 func (*healthProvider) StreamComplete(context.Context, ai.CompletionRequest) (<-chan ai.StreamChunk, error) {
@@ -93,5 +97,25 @@ func TestRouterHealthCheckHonorsCancellation(t *testing.T) {
 	cancel()
 	if err := router.HealthCheck(ctx); !errors.Is(err, context.Canceled) {
 		t.Fatalf("HealthCheck() error = %v, want context canceled", err)
+	}
+}
+
+func TestProbePrimaryCompletionDoesNotRetryOrFallback(t *testing.T) {
+	router := ai.NewRouter()
+	primary := &healthProvider{err: errors.New("primary unavailable")}
+	fallback := &healthProvider{resp: ai.CompletionResponse{Content: "fallback"}}
+	router.ReplaceProviders([]ai.ProviderRegistration{
+		{Name: "primary", Provider: primary},
+		{Name: "fallback", Provider: fallback},
+	})
+
+	if _, err := router.ProbePrimaryCompletion(context.Background(), ai.CompletionRequest{}); err == nil {
+		t.Fatal("ProbePrimaryCompletion() error = nil, want primary failure")
+	}
+	if primary.callCount() != 1 {
+		t.Fatalf("primary calls = %d, want 1", primary.callCount())
+	}
+	if fallback.callCount() != 0 {
+		t.Fatalf("fallback calls = %d, want 0", fallback.callCount())
 	}
 }

--- a/internal/server/ai_health_check.go
+++ b/internal/server/ai_health_check.go
@@ -19,7 +19,7 @@ func NewAIHealthCheck(router *ai.Router) func(context.Context) error {
 			return fmt.Errorf("AI completion health check failed: router unavailable")
 		}
 
-		response, err := router.Complete(ctx, ai.CompletionRequest{
+		response, err := router.ProbePrimaryCompletion(ctx, ai.CompletionRequest{
 			Messages: []ai.Message{
 				{Role: "user", Content: "Reply with only OK."},
 			},

--- a/internal/server/ai_health_check_test.go
+++ b/internal/server/ai_health_check_test.go
@@ -6,7 +6,6 @@ package server
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/p-n-ai/pai-bot/internal/ai"
 	"github.com/p-n-ai/pai-bot/internal/i18n"
@@ -31,9 +30,7 @@ func TestAIHealthCheckUsesCompletionPath(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			router := ai.NewRouterWithConfig(ai.RouterConfig{
-				RetryBackoff: []time.Duration{time.Nanosecond},
-			})
+			router := ai.NewRouter()
 			router.Register("provider", &ai.MockProvider{
 				Response: test.response,
 				Err:      test.err,


### PR DESCRIPTION
Summary
- probe only the primary configured AI provider
- perform one completion attempt with no retry or fallback
- keep health probes from mutating circuit-breaker or trace state

Testing
- `GOCACHE=/tmp/pai-go-build-cache go test ./internal/ai ./internal/server -run 'Test(RouterHealthCheck|ProbePrimaryCompletion|AIHealthCheck|CachedHealthCheck|PublicStatus)' -count=1`\n- `GOCACHE=/tmp/pai-go-build-cache go test -race ./internal/ai ./internal/server -run 'Test(ProbePrimaryCompletionDoesNotRetryOrFallback|AIHealthCheckUsesCompletionPath|CachedHealthCheckCoalescesConcurrentRequests)$' -count=1`\n- `GOCACHE=/tmp/pai-go-build-cache go vet ./internal/ai ./internal/server ./cmd/server`\n- `git diff --check origin/main...HEAD`