### PR TITLE
feat(harness): model natural conversation dynamics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ output/
 # Local agent working artifacts (never commit)
 .humanlayer/
 .agents/
+.codex/chat-codex-candidate/

--- a/README.md
+++ b/README.md
@@ -657,13 +657,17 @@ Terminal chat workflow:
 
 ```bash
 just chat-terminal
+# Codex-only local chat, with device login when needed:
+just chat-codex
 # or:
 docker compose run --rm --entrypoint /pai-terminal-chat app --user-id demo-user --lang en
 # for an ephemeral local-only session:
 docker compose run --rm --entrypoint /pai-terminal-chat app --memory
 ```
 
-The terminal chat uses the same `agent.Engine` and AI router as the app. By default it uses PostgreSQL-backed conversation state for production parity; pass `--memory` for an ephemeral local-only session.
+The terminal chat uses the same `agent.Engine` and AI router as the app. By default it uses PostgreSQL-backed conversation state for production parity; pass `--memory` for an ephemeral local-only session. `just chat-codex` pins the session to the managed Codex provider with no fallback. It uses PaiBot's isolated Codex home, not personal `~/.codex` credentials, and prints the existing OpenAI device URL and one-time code if that home is not connected yet.
+
+`just chat-codex` also enables the interactive test controls `/status`, `/new`, `/reload`, `/character <id>`, and `/interrupt <message>`. Normal messages entered during a reply are queued FIFO. It watches `.codex/chat-codex-candidate/candidate.yaml`, but applies a valid candidate only after `/reload` starts a fresh in-memory session. `/status` identifies the active candidate only by `sha256:<hash>`.
 
 Terminal nudge workflow:
 

--- a/cmd/conversation-harness/main.go
+++ b/cmd/conversation-harness/main.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -21,6 +22,7 @@ import (
 	"github.com/p-n-ai/pai-bot/internal/agent"
 	"github.com/p-n-ai/pai-bot/internal/ai"
 	"github.com/p-n-ai/pai-bot/internal/chat"
+	"github.com/p-n-ai/pai-bot/internal/conversationharness"
 	"github.com/p-n-ai/pai-bot/internal/curriculum"
 	"github.com/p-n-ai/pai-bot/internal/platform/airouter"
 	"github.com/p-n-ai/pai-bot/internal/platform/config"
@@ -39,20 +41,57 @@ const (
 type fixtureFile struct {
 	Version       int                `yaml:"version"`
 	Provider      string             `yaml:"provider"`
+	Characters    []characterSpec    `yaml:"characters"`
 	Conversations []conversationSpec `yaml:"conversations"`
 }
 
+type characterSpec struct {
+	ID        string `yaml:"id"`
+	FirstName string `yaml:"first_name"`
+	Username  string `yaml:"username"`
+	Language  string `yaml:"language"`
+}
+
 type conversationSpec struct {
-	ID       string         `yaml:"id"`
-	Title    string         `yaml:"title"`
-	Tags     []string       `yaml:"tags"`
-	Evidence []evidenceSpec `yaml:"evidence"`
-	Turns    []turnSpec     `yaml:"turns"`
-	Checks   behaviorChecks `yaml:"checks"`
+	ID                string         `yaml:"id"`
+	Title             string         `yaml:"title"`
+	Tags              []string       `yaml:"tags"`
+	CharacterID       string         `yaml:"character"`
+	Evidence          []evidenceSpec `yaml:"evidence"`
+	Turns             []turnSpec     `yaml:"turns"`
+	Checks            behaviorChecks `yaml:"checks"`
+	resolvedCharacter characterSpec
 }
 
 type turnSpec struct {
-	User string `yaml:"user"`
+	User         string                       `yaml:"user"`
+	Delivery     conversationharness.Delivery `yaml:"delivery"`
+	After        durationSpec                 `yaml:"after"`
+	ExpectStatus conversationharness.Status   `yaml:"expect_status"`
+	Checks       behaviorChecks               `yaml:"checks"`
+}
+
+type durationSpec struct {
+	time.Duration
+}
+
+func (d *durationSpec) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind != yaml.ScalarNode {
+		return fmt.Errorf("duration must be a string")
+	}
+	if strings.TrimSpace(node.Value) == "" {
+		d.Duration = 0
+		return nil
+	}
+	parsed, err := time.ParseDuration(node.Value)
+	if err != nil {
+		return fmt.Errorf("parse duration %q: %w", node.Value, err)
+	}
+	if parsed < 0 {
+		return fmt.Errorf("duration must not be negative")
+	}
+	d.Duration = parsed
+	return nil
 }
 
 type evidenceSpec struct {
@@ -84,12 +123,22 @@ type behaviorChecks struct {
 }
 
 type caseResult struct {
-	ID       string   `json:"id"`
-	Title    string   `json:"title"`
-	Tags     []string `json:"tags,omitempty"`
-	Passed   bool     `json:"passed"`
-	Turns    int      `json:"turns"`
-	Failures []string `json:"failures,omitempty"`
+	ID          string              `json:"id"`
+	Title       string              `json:"title"`
+	Tags        []string            `json:"tags,omitempty"`
+	Passed      bool                `json:"passed"`
+	Turns       int                 `json:"turns"`
+	Delivered   int                 `json:"delivered"`
+	Interrupted int                 `json:"interrupted,omitempty"`
+	Outcomes    []turnOutcomeResult `json:"outcomes"`
+	Failures    []string            `json:"failures,omitempty"`
+}
+
+type turnOutcomeResult struct {
+	Turn       int                          `json:"turn"`
+	Delivery   conversationharness.Delivery `json:"delivery"`
+	Status     conversationharness.Status   `json:"status"`
+	DurationMS int64                        `json:"duration_ms"`
 }
 
 type requestDumpRecord struct {
@@ -190,7 +239,7 @@ func main() {
 
 	results := make([]caseResult, 0, len(conversations))
 	for _, conv := range conversations {
-		result := runConversation(engine, conv, timeout, showResponses, !requestOnly)
+		result := runConversation(engine.ProcessMessage, conv, timeout, showResponses, !requestOnly)
 		results = append(results, result)
 		if jsonl {
 			_ = json.NewEncoder(os.Stdout).Encode(result)
@@ -275,18 +324,155 @@ func validateRequestOnlyMode(requestOnly bool, dumpRequestsPath string) error {
 }
 
 func loadFixture(path string) (fixtureFile, error) {
-	b, err := os.ReadFile(path)
+	file, err := os.Open(path)
 	if err != nil {
 		return fixtureFile{}, err
 	}
+	defer file.Close()
+
+	decoder := yaml.NewDecoder(file)
+	decoder.KnownFields(true)
 	var fixture fixtureFile
-	if err := yaml.Unmarshal(b, &fixture); err != nil {
+	if err := decoder.Decode(&fixture); err != nil {
 		return fixtureFile{}, err
 	}
-	if fixture.Version != 1 {
-		return fixtureFile{}, fmt.Errorf("version = %d, want 1", fixture.Version)
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return fixtureFile{}, fmt.Errorf("multiple YAML documents are not supported")
+		}
+		return fixtureFile{}, err
+	}
+	if err := validateFixture(&fixture); err != nil {
+		return fixtureFile{}, err
 	}
 	return fixture, nil
+}
+
+func validateFixture(fixture *fixtureFile) error {
+	if fixture == nil {
+		return fmt.Errorf("fixture is required")
+	}
+	if fixture.Version != 1 && fixture.Version != 2 {
+		return fmt.Errorf("version = %d, want 1 or 2", fixture.Version)
+	}
+	characters := make(map[string]characterSpec, len(fixture.Characters))
+	for index, character := range fixture.Characters {
+		character.ID = strings.TrimSpace(character.ID)
+		character.FirstName = strings.TrimSpace(character.FirstName)
+		character.Username = strings.TrimSpace(character.Username)
+		character.Language = strings.TrimSpace(character.Language)
+		if character.ID == "" {
+			return fmt.Errorf("character %d: id is required", index+1)
+		}
+		if _, exists := characters[character.ID]; exists {
+			return fmt.Errorf("duplicate character id %q", character.ID)
+		}
+		fixture.Characters[index] = character
+		characters[character.ID] = character
+	}
+
+	conversationIDs := make(map[string]struct{}, len(fixture.Conversations))
+	for conversationIndex := range fixture.Conversations {
+		conversation := &fixture.Conversations[conversationIndex]
+		conversation.ID = strings.TrimSpace(conversation.ID)
+		if conversation.ID == "" {
+			return fmt.Errorf("conversation %d: id is required", conversationIndex+1)
+		}
+		if _, exists := conversationIDs[conversation.ID]; exists {
+			return fmt.Errorf("duplicate conversation id %q", conversation.ID)
+		}
+		conversationIDs[conversation.ID] = struct{}{}
+		if strings.TrimSpace(conversation.Title) == "" {
+			return fmt.Errorf("conversation %s: title is required", conversation.ID)
+		}
+		if len(conversation.Turns) == 0 {
+			return fmt.Errorf("conversation %s: at least one turn is required", conversation.ID)
+		}
+		if err := validateBehaviorChecks(
+			fmt.Sprintf("conversation %s checks", conversation.ID),
+			conversation.Checks,
+			len(conversation.Turns),
+		); err != nil {
+			return err
+		}
+		conversation.CharacterID = strings.TrimSpace(conversation.CharacterID)
+		if conversation.CharacterID != "" {
+			character, exists := characters[conversation.CharacterID]
+			if !exists {
+				return fmt.Errorf("conversation %s: unknown character %q", conversation.ID, conversation.CharacterID)
+			}
+			conversation.resolvedCharacter = character
+		}
+		for turnIndex, turn := range conversation.Turns {
+			if strings.TrimSpace(turn.User) == "" {
+				return fmt.Errorf("conversation %s turn %d: user text is required", conversation.ID, turnIndex+1)
+			}
+			switch normalizedDelivery(turn.Delivery) {
+			case conversationharness.DeliveryWait, conversationharness.DeliveryQueue, conversationharness.DeliveryInterrupt:
+			default:
+				return fmt.Errorf(
+					"conversation %s turn %d: unsupported delivery %q",
+					conversation.ID,
+					turnIndex+1,
+					turn.Delivery,
+				)
+			}
+			switch turn.ExpectStatus {
+			case "", conversationharness.StatusDelivered, conversationharness.StatusInterrupted, conversationharness.StatusFailed:
+			default:
+				return fmt.Errorf(
+					"conversation %s turn %d: unsupported expect_status %q",
+					conversation.ID,
+					turnIndex+1,
+					turn.ExpectStatus,
+				)
+			}
+			if err := validateBehaviorChecks(
+				fmt.Sprintf("conversation %s turn %d checks", conversation.ID, turnIndex+1),
+				turn.Checks,
+				len(conversation.Turns),
+			); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func validateBehaviorChecks(label string, checks behaviorChecks, turnCount int) error {
+	switch checks.ExpectedLanguage {
+	case "", "bm_or_mixed", "en_or_mixed":
+	default:
+		return fmt.Errorf("%s: unsupported expected_language %q", label, checks.ExpectedLanguage)
+	}
+	if checks.MaxResponseLines < 0 {
+		return fmt.Errorf("%s: max_response_lines must not be negative", label)
+	}
+	if checks.MaxResponseChars < 0 {
+		return fmt.Errorf("%s: max_response_chars must not be negative", label)
+	}
+	for _, entry := range []struct {
+		name  string
+		turns []int
+	}{
+		{name: "forbid_final_answer_on_turn", turns: checks.ForbidFinalAnswerOnTurn},
+		{name: "forbid_section_labels_on_turn", turns: checks.ForbidSectionLabelsOnTurn},
+	} {
+		for _, turn := range entry.turns {
+			if turn < 1 || turn > turnCount {
+				return fmt.Errorf("%s: %s contains out-of-range turn %d", label, entry.name, turn)
+			}
+		}
+	}
+	return nil
+}
+
+func normalizedDelivery(delivery conversationharness.Delivery) conversationharness.Delivery {
+	if delivery == "" {
+		return conversationharness.DeliveryWait
+	}
+	return delivery
 }
 
 func buildEngine(memory bool, mockResponse string, progressSideEffects bool, traceFunc func(ai.CompletionTrace), evidenceRetriever retrieval.TutorEvidenceRetriever) (*agent.Engine, func(), error) {
@@ -427,43 +613,120 @@ func selectConversations(conversations []conversationSpec, caseID, tag string, m
 	return selected
 }
 
-func runConversation(engine *agent.Engine, conv conversationSpec, timeout time.Duration, showResponses bool, runChecks bool) caseResult {
+func runConversation(
+	process conversationharness.Processor,
+	conv conversationSpec,
+	timeout time.Duration,
+	showResponses bool,
+	runChecks bool,
+) caseResult {
 	userID := "harness-" + strings.ToLower(conv.ID) + "-" + fmt.Sprint(time.Now().UnixNano())
 	responses := make([]string, 0, len(conv.Turns))
 	failures := []string{}
-
-	for i, turn := range conv.Turns {
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
-		resp, err := engine.ProcessMessage(ctx, chat.InboundMessage{
-			Channel: "harness",
-			UserID:  userID,
-			Text:    turn.User,
+	turns := make([]conversationharness.Turn, 0, len(conv.Turns))
+	for _, turn := range conv.Turns {
+		turns = append(turns, conversationharness.Turn{
+			Delivery: normalizedDelivery(turn.Delivery),
+			After:    turn.After.Duration,
+			Timeout:  timeout,
+			Message: chat.InboundMessage{
+				Channel:   "harness",
+				UserID:    userID,
+				Text:      turn.User,
+				FirstName: conv.resolvedCharacter.FirstName,
+				Username:  conv.resolvedCharacter.Username,
+				Language:  conv.resolvedCharacter.Language,
+			},
 		})
-		cancel()
-		if err != nil {
-			failures = append(failures, fmt.Sprintf("turn %d: ProcessMessage error: %v", i+1, err))
+	}
+	outcomes, err := conversationharness.Run(
+		context.Background(),
+		process,
+		turns,
+	)
+	if err != nil {
+		failures = append(failures, fmt.Sprintf("conversation runner error: %v", err))
+	}
+
+	delivered := 0
+	interrupted := 0
+	turnOutcomes := make([]turnOutcomeResult, 0, len(outcomes))
+	for i, outcome := range outcomes {
+		turn := conv.Turns[i]
+		turnOutcomes = append(turnOutcomes, turnOutcomeResult{
+			Turn:       i + 1,
+			Delivery:   normalizedDelivery(turn.Delivery),
+			Status:     outcome.Status,
+			DurationMS: outcome.Duration.Milliseconds(),
+		})
+		expectedStatus := turn.ExpectStatus
+		if expectedStatus == "" {
+			expectedStatus = conversationharness.StatusDelivered
+		}
+		if outcome.Status != expectedStatus {
+			failures = append(failures, fmt.Sprintf(
+				"turn %d: status %q, want %q",
+				i+1,
+				outcome.Status,
+				expectedStatus,
+			))
+		}
+		switch outcome.Status {
+		case conversationharness.StatusInterrupted:
+			interrupted++
+		case conversationharness.StatusFailed:
+			if expectedStatus != conversationharness.StatusFailed {
+				failures = append(failures, fmt.Sprintf("turn %d: ProcessMessage error: %v", i+1, outcome.Err))
+			}
+		case conversationharness.StatusDelivered:
+			delivered++
+			responses = append(responses, outcome.Response)
+		}
+		if showResponses {
+			fmt.Printf(
+				"\n[%s turn %d, %s]\n%s: %s\n",
+				conv.ID,
+				i+1,
+				outcome.Status,
+				characterLabel(conv.resolvedCharacter),
+				turn.User,
+			)
+			if outcome.Status == conversationharness.StatusDelivered {
+				fmt.Printf("Assistant: %s\n", outcome.Response)
+			}
+		}
+		if outcome.Status != conversationharness.StatusDelivered || !runChecks {
 			continue
 		}
-		responses = append(responses, resp)
-		if showResponses {
-			fmt.Printf("\n[%s turn %d]\nUser: %s\nAssistant: %s\n", conv.ID, i+1, turn.User, resp)
-		}
-		if runChecks {
-			failures = append(failures, checkTurn(i+1, resp, conv.Checks)...)
-		}
+		failures = append(failures, checkTurn(i+1, outcome.Response, conv.Checks)...)
+		failures = append(failures, checkTurn(i+1, outcome.Response, turn.Checks)...)
+		failures = append(failures, checkConversation(turn.Checks, []string{outcome.Response})...)
 	}
 	if runChecks {
 		failures = append(failures, checkConversation(conv.Checks, responses)...)
 	}
 
 	return caseResult{
-		ID:       conv.ID,
-		Title:    conv.Title,
-		Tags:     conv.Tags,
-		Passed:   len(failures) == 0,
-		Turns:    len(conv.Turns),
-		Failures: failures,
+		ID:          conv.ID,
+		Title:       conv.Title,
+		Tags:        conv.Tags,
+		Passed:      len(failures) == 0,
+		Turns:       len(conv.Turns),
+		Delivered:   delivered,
+		Interrupted: interrupted,
+		Outcomes:    turnOutcomes,
+		Failures:    failures,
 	}
+}
+
+func characterLabel(character characterSpec) string {
+	if character.FirstName != "" {
+		return character.FirstName
+	}
+	if character.Username != "" {
+		return character.Username
+	}
+	return "User"
 }
 
 func checkTurn(turn int, resp string, checks behaviorChecks) []string {

--- a/cmd/conversation-harness/main.go
+++ b/cmd/conversation-harness/main.go
@@ -328,7 +328,7 @@ func loadFixture(path string) (fixtureFile, error) {
 	if err != nil {
 		return fixtureFile{}, err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	decoder := yaml.NewDecoder(file)
 	decoder.KnownFields(true)

--- a/cmd/conversation-harness/main_test.go
+++ b/cmd/conversation-harness/main_test.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"reflect"
 	"strings"
@@ -239,6 +240,174 @@ conversations:
 	}
 }
 
+func TestLoadFixtureRejectsMultipleDocuments(t *testing.T) {
+	path := t.TempDir() + "/fixture.yaml"
+	fixture := `version: 2
+provider: mock
+conversations:
+  - id: NAT01
+    title: First document
+    turns:
+      - user: hello
+---
+version: 2
+provider: mock
+conversations: []
+`
+	if err := os.WriteFile(path, []byte(fixture), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	_, err := loadFixture(path)
+	if err == nil {
+		t.Fatal("loadFixture() should reject multiple YAML documents")
+	}
+	if !strings.Contains(err.Error(), "multiple YAML documents are not supported") {
+		t.Fatalf("loadFixture() error = %q, want multiple-document detail", err)
+	}
+}
+
+func TestValidateFixtureRejectsInvalidContracts(t *testing.T) {
+	validConversation := func(id string) conversationSpec {
+		return conversationSpec{
+			ID:    id,
+			Title: "Valid conversation",
+			Turns: []turnSpec{{User: "hello"}},
+		}
+	}
+
+	for _, test := range []struct {
+		name    string
+		fixture fixtureFile
+		want    string
+	}{
+		{
+			name: "duplicate character after trimming",
+			fixture: fixtureFile{
+				Version:    2,
+				Characters: []characterSpec{{ID: "aina"}, {ID: " aina "}},
+			},
+			want: `duplicate character id "aina"`,
+		},
+		{
+			name: "duplicate conversation",
+			fixture: fixtureFile{
+				Version:       2,
+				Conversations: []conversationSpec{validConversation("NAT01"), validConversation("NAT01")},
+			},
+			want: `duplicate conversation id "NAT01"`,
+		},
+		{
+			name: "unsupported expected status",
+			fixture: fixtureFile{
+				Version: 2,
+				Conversations: []conversationSpec{{
+					ID:    "NAT01",
+					Title: "Invalid status",
+					Turns: []turnSpec{{User: "hello", ExpectStatus: "waiting"}},
+				}},
+			},
+			want: `unsupported expect_status "waiting"`,
+		},
+		{
+			name: "out-of-range turn check",
+			fixture: fixtureFile{
+				Version: 2,
+				Conversations: []conversationSpec{{
+					ID:     "NAT01",
+					Title:  "Invalid turn reference",
+					Turns:  []turnSpec{{User: "hello"}},
+					Checks: behaviorChecks{ForbidSectionLabelsOnTurn: []int{2}},
+				}},
+			},
+			want: "out-of-range turn 2",
+		},
+		{
+			name:    "unsupported version",
+			fixture: fixtureFile{Version: 3},
+			want:    "version = 3, want 1 or 2",
+		},
+		{
+			name: "unsupported delivery",
+			fixture: fixtureFile{
+				Version: 2,
+				Conversations: []conversationSpec{{
+					ID:    "NAT01",
+					Title: "Invalid delivery",
+					Turns: []turnSpec{{User: "hello", Delivery: "later"}},
+				}},
+			},
+			want: `unsupported delivery "later"`,
+		},
+		{
+			name: "unsupported language check",
+			fixture: fixtureFile{
+				Version: 2,
+				Conversations: []conversationSpec{{
+					ID:     "NAT01",
+					Title:  "Invalid language check",
+					Turns:  []turnSpec{{User: "hello"}},
+					Checks: behaviorChecks{ExpectedLanguage: "fr"},
+				}},
+			},
+			want: `unsupported expected_language "fr"`,
+		},
+		{
+			name: "negative response limit",
+			fixture: fixtureFile{
+				Version: 2,
+				Conversations: []conversationSpec{{
+					ID:     "NAT01",
+					Title:  "Invalid response limit",
+					Turns:  []turnSpec{{User: "hello"}},
+					Checks: behaviorChecks{MaxResponseChars: -1},
+				}},
+			},
+			want: "max_response_chars must not be negative",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateFixture(&test.fixture)
+			if err == nil {
+				t.Fatal("validateFixture() should reject an invalid contract")
+			}
+			if !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("validateFixture() error = %q, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestRunConversationAcceptsExpectedFailedTurn(t *testing.T) {
+	processErr := errors.New("expected processor failure")
+	result := runConversation(
+		func(context.Context, chat.InboundMessage) (string, error) {
+			return "unsafe partial response", processErr
+		},
+		conversationSpec{
+			ID:    "NAT01",
+			Title: "Expected failure",
+			Turns: []turnSpec{{
+				User:         "trigger failure",
+				ExpectStatus: conversationharness.StatusFailed,
+			}},
+		},
+		testTurnTimeout,
+		false,
+		false,
+	)
+
+	if !result.Passed || len(result.Failures) != 0 {
+		t.Fatalf("runConversation() result = %#v, want expected failure to pass", result)
+	}
+	if result.Delivered != 0 || result.Interrupted != 0 {
+		t.Fatalf("delivered/interrupted = %d/%d, want 0/0", result.Delivered, result.Interrupted)
+	}
+	if len(result.Outcomes) != 1 || result.Outcomes[0].Status != conversationharness.StatusFailed {
+		t.Fatalf("outcomes = %#v, want one failed turn", result.Outcomes)
+	}
+}
+
 func TestLoadFixtureParsesTurnDelay(t *testing.T) {
 	path := t.TempDir() + "/fixture.yaml"
 	fixture := `version: 2
@@ -319,6 +488,46 @@ conversations:
 	}
 	if loaded.Version != 1 || len(loaded.Conversations) != 1 {
 		t.Fatalf("loaded fixture = %#v, want one version 1 conversation", loaded)
+	}
+}
+
+func TestCaseResultJSONContainsOnlyStructuralOutcomes(t *testing.T) {
+	const learnerText = "learner-private-text"
+	const modelText = "model-private-response"
+
+	result := runConversation(
+		func(context.Context, chat.InboundMessage) (string, error) {
+			return modelText, nil
+		},
+		conversationSpec{
+			ID:    "NAT01",
+			Title: "Safe automation output",
+			Turns: []turnSpec{{User: learnerText}},
+		},
+		testTurnTimeout,
+		false,
+		false,
+	)
+
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	output := string(encoded)
+	for _, privateText := range []string{learnerText, modelText} {
+		if strings.Contains(output, privateText) {
+			t.Fatalf("JSON output exposed private conversation content %q: %s", privateText, output)
+		}
+	}
+	for _, structuralField := range []string{
+		`"delivered":1`,
+		`"turn":1`,
+		`"delivery":"wait"`,
+		`"status":"delivered"`,
+	} {
+		if !strings.Contains(output, structuralField) {
+			t.Fatalf("JSON output = %s, want structural field %s", output, structuralField)
+		}
 	}
 }
 

--- a/cmd/conversation-harness/main_test.go
+++ b/cmd/conversation-harness/main_test.go
@@ -8,9 +8,13 @@ import (
 	"encoding/json"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/p-n-ai/pai-bot/internal/ai"
+	"github.com/p-n-ai/pai-bot/internal/chat"
+	"github.com/p-n-ai/pai-bot/internal/conversationharness"
 	"github.com/p-n-ai/pai-bot/internal/retrieval"
 )
 
@@ -171,6 +175,238 @@ func TestHarnessEvidenceRetrieverRejectsUnscopedLearner(t *testing.T) {
 		t.Fatalf("unscoped learner received evidence: %#v", items)
 	}
 }
+
+func TestValidateFixtureResolvesCharacterAndDynamics(t *testing.T) {
+	fixture := fixtureFile{
+		Version: 2,
+		Characters: []characterSpec{{
+			ID: "aina", FirstName: "Aina", Language: "en",
+		}},
+		Conversations: []conversationSpec{{
+			ID: "NAT01", Title: "Natural interruption", CharacterID: "aina",
+			Turns: []turnSpec{
+				{User: "Explain everything", ExpectStatus: conversationharness.StatusInterrupted},
+				{
+					User: "Wait, one point only", Delivery: conversationharness.DeliveryInterrupt,
+					ExpectStatus: conversationharness.StatusDelivered,
+				},
+			},
+		}},
+	}
+
+	if err := validateFixture(&fixture); err != nil {
+		t.Fatalf("validateFixture() error = %v", err)
+	}
+	if got := fixture.Conversations[0].resolvedCharacter.FirstName; got != "Aina" {
+		t.Fatalf("resolved character name = %q, want Aina", got)
+	}
+}
+
+func TestValidateFixtureRejectsUnknownCharacter(t *testing.T) {
+	fixture := fixtureFile{
+		Version: 2,
+		Conversations: []conversationSpec{{
+			ID: "NAT01", Title: "Unknown character", CharacterID: "missing",
+			Turns: []turnSpec{{User: "hello"}},
+		}},
+	}
+	if err := validateFixture(&fixture); err == nil {
+		t.Fatal("validateFixture() should reject an unknown character")
+	}
+}
+
+func TestLoadFixtureRejectsUnknownFields(t *testing.T) {
+	path := t.TempDir() + "/fixture.yaml"
+	fixture := `version: 2
+provider: mock
+conversations:
+  - id: NAT01
+    title: Typo must fail
+    turns:
+      - user: hello
+        delivry: queue
+`
+	if err := os.WriteFile(path, []byte(fixture), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	_, err := loadFixture(path)
+	if err == nil {
+		t.Fatal("loadFixture() should reject an unknown field")
+	}
+	if !strings.Contains(err.Error(), "field delivry not found") {
+		t.Fatalf("loadFixture() error = %q, want unknown-field detail", err)
+	}
+}
+
+func TestLoadFixtureParsesTurnDelay(t *testing.T) {
+	path := t.TempDir() + "/fixture.yaml"
+	fixture := `version: 2
+provider: mock
+conversations:
+  - id: NAT01
+    title: Delayed follow-up
+    turns:
+      - user: hello
+        after: 25ms
+`
+	if err := os.WriteFile(path, []byte(fixture), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	loaded, err := loadFixture(path)
+	if err != nil {
+		t.Fatalf("loadFixture() error = %v", err)
+	}
+	if got := loaded.Conversations[0].Turns[0].After.Duration; got != 25*time.Millisecond {
+		t.Fatalf("turn delay = %v, want 25ms", got)
+	}
+}
+
+func TestLoadFixtureRejectsInvalidTurnDelay(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		after string
+		want  string
+	}{
+		{name: "malformed", after: "soon", want: `parse duration "soon"`},
+		{name: "negative", after: "-1s", want: "duration must not be negative"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			path := t.TempDir() + "/fixture.yaml"
+			fixture := `version: 2
+provider: mock
+conversations:
+  - id: NAT01
+    title: Invalid delay
+    turns:
+      - user: hello
+        after: ` + test.after + "\n"
+			if err := os.WriteFile(path, []byte(fixture), 0o600); err != nil {
+				t.Fatalf("WriteFile() error = %v", err)
+			}
+
+			_, err := loadFixture(path)
+			if err == nil {
+				t.Fatal("loadFixture() should reject an invalid turn delay")
+			}
+			if !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("loadFixture() error = %q, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestLoadFixtureKeepsVersionOneCompatibility(t *testing.T) {
+	path := t.TempDir() + "/fixture.yaml"
+	fixture := `version: 1
+provider: mock
+conversations:
+  - id: LEGACY01
+    title: Supported legacy fixture
+    turns:
+      - user: hello
+    checks:
+      require_non_empty_replies: true
+`
+	if err := os.WriteFile(path, []byte(fixture), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	loaded, err := loadFixture(path)
+	if err != nil {
+		t.Fatalf("loadFixture() error = %v", err)
+	}
+	if loaded.Version != 1 || len(loaded.Conversations) != 1 {
+		t.Fatalf("loaded fixture = %#v, want one version 1 conversation", loaded)
+	}
+}
+
+func TestRunConversationPassesCharacterProfileToEveryTurn(t *testing.T) {
+	var messages []chat.InboundMessage
+	result := runConversation(
+		func(_ context.Context, message chat.InboundMessage) (string, error) {
+			messages = append(messages, message)
+			return "short reply", nil
+		},
+		conversationSpec{
+			ID:    "NAT01",
+			Title: "Character profile",
+			resolvedCharacter: characterSpec{
+				FirstName: "Aina",
+				Username:  "aina",
+				Language:  "en",
+			},
+			Turns: []turnSpec{
+				{User: "first"},
+				{User: "second"},
+			},
+		},
+		testTurnTimeout,
+		false,
+		false,
+	)
+
+	if !result.Passed {
+		t.Fatalf("runConversation() failures = %#v", result.Failures)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("processed messages = %d, want 2", len(messages))
+	}
+	for index, message := range messages {
+		if message.FirstName != "Aina" || message.Username != "aina" || message.Language != "en" {
+			t.Fatalf("message %d profile = %#v, want Aina/aina/en", index+1, message)
+		}
+	}
+	if len(result.Outcomes) != 2 {
+		t.Fatalf("outcomes = %d, want 2", len(result.Outcomes))
+	}
+	for index, outcome := range result.Outcomes {
+		if outcome.Turn != index+1 ||
+			outcome.Delivery != conversationharness.DeliveryWait ||
+			outcome.Status != conversationharness.StatusDelivered {
+			t.Fatalf("outcome %d = %#v", index+1, outcome)
+		}
+	}
+}
+
+func TestRunConversationSuppressesInterruptedResponse(t *testing.T) {
+	engine, cleanup, err := buildEngine(true, "stale mock response", false, nil, nil)
+	if err != nil {
+		t.Fatalf("buildEngine() error = %v", err)
+	}
+	defer cleanup()
+
+	result := runConversation(engine.ProcessMessage, conversationSpec{
+		ID:    "NAT01",
+		Title: "Interrupt stale response",
+		Turns: []turnSpec{
+			{User: "long request", ExpectStatus: conversationharness.StatusInterrupted},
+			{
+				User: "replacement", Delivery: conversationharness.DeliveryInterrupt,
+				ExpectStatus: conversationharness.StatusDelivered,
+			},
+		},
+	}, testTurnTimeout, false, false)
+
+	if !result.Passed {
+		t.Fatalf("runConversation() failures = %#v", result.Failures)
+	}
+	if result.Delivered != 1 || result.Interrupted != 1 {
+		t.Fatalf(
+			"delivered/interrupted = %d/%d, want 1/1",
+			result.Delivered,
+			result.Interrupted,
+		)
+	}
+	if len(result.Outcomes) != 2 ||
+		result.Outcomes[0].Status != conversationharness.StatusInterrupted ||
+		result.Outcomes[1].Status != conversationharness.StatusDelivered {
+		t.Fatalf("outcomes = %#v, want interrupted then delivered", result.Outcomes)
+	}
+}
+
+const testTurnTimeout = 5 * time.Second
 
 func engineTrackerIsNil(engine any) bool {
 	field := reflect.ValueOf(engine).Elem().FieldByName("tracker")

--- a/cmd/terminal-chat/main.go
+++ b/cmd/terminal-chat/main.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"os/signal"
 	"strings"
 	"sync"
 	"time"
@@ -23,7 +24,6 @@ import (
 	"github.com/p-n-ai/pai-bot/internal/chat"
 	"github.com/p-n-ai/pai-bot/internal/curriculum"
 	"github.com/p-n-ai/pai-bot/internal/focusedpage"
-	"github.com/p-n-ai/pai-bot/internal/platform/airouter"
 	"github.com/p-n-ai/pai-bot/internal/platform/config"
 	"github.com/p-n-ai/pai-bot/internal/platform/featureflags"
 	"github.com/p-n-ai/pai-bot/internal/progress"
@@ -44,6 +44,9 @@ func main() {
 	var historyJSONPath string
 	var dumpJSONPath string
 	var dumpTurnLimit int
+	var selectedProvider string
+	var interactive bool
+	var candidateDirectory string
 
 	flag.StringVar(&userID, "user-id", "terminal-user", "stable user id for the terminal session")
 	flag.StringVar(&language, "lang", "", "preferred language override (en, ms, zh)")
@@ -58,6 +61,9 @@ func main() {
 	flag.StringVar(&historyJSONPath, "history-json", "", "write local terminal conversation history to a JSON file when the session ends")
 	flag.StringVar(&dumpJSONPath, "dump-json", "", "write local terminal conversation history plus model-facing AI request/response traces to a JSON file when the session ends")
 	flag.IntVar(&dumpTurnLimit, "turn-limit", 0, "limit exported conversation turns and model calls to the latest N items; 0 exports everything")
+	flag.StringVar(&selectedProvider, "provider", "", "use only this AI provider (for example, codex); disables provider fallback")
+	flag.BoolVar(&interactive, "interactive", false, "enable queue, interruption, character, and candidate reload controls")
+	flag.StringVar(&candidateDirectory, "candidate", "", "directory containing an optional candidate.yaml conversation candidate")
 	flag.Parse()
 
 	if wsURL != "" {
@@ -74,6 +80,27 @@ func main() {
 		}
 		return
 	}
+	if interactive {
+		if !memory {
+			fmt.Fprintln(os.Stderr, "--interactive requires --memory")
+			os.Exit(1)
+		}
+		if strings.ToLower(strings.TrimSpace(selectedProvider)) != "codex" {
+			fmt.Fprintln(os.Stderr, "--interactive requires --provider codex")
+			os.Exit(1)
+		}
+		if multi {
+			fmt.Fprintln(os.Stderr, "--interactive cannot be combined with --multi")
+			os.Exit(1)
+		}
+		if strings.TrimSpace(dumpJSONPath) != "" {
+			fmt.Fprintln(os.Stderr, "--interactive does not support --dump-json because candidate prompts must not be exported")
+			os.Exit(1)
+		}
+	}
+
+	sessionCtx, stopSession := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stopSession()
 
 	logLevel := slog.LevelError
 	if verbose {
@@ -89,14 +116,20 @@ func main() {
 		fmt.Fprintf(os.Stderr, "load config: %v\n", err)
 		os.Exit(1)
 	}
+	if interactive {
+		if err := cfg.Validate(); err != nil {
+			fmt.Fprintf(os.Stderr, "validate interactive config: %v\n", err)
+			os.Exit(1)
+		}
+	}
 	if !cfg.HasAIProvider() {
 		fmt.Fprintln(os.Stderr, "at least one AI provider must be configured")
 		os.Exit(1)
 	}
 
-	router := airouter.Setup(cfg.AI)
-	if !router.HasProvider() {
-		fmt.Fprintln(os.Stderr, "no AI providers configured")
+	router, err := buildTerminalAIRouter(sessionCtx, cfg.AI, selectedProvider, os.Stderr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "configure AI provider: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -106,7 +139,7 @@ func main() {
 		slog.Warn("curriculum not loaded", "path", cfg.CurriculumPath, "error", err)
 	}
 
-	state, cleanup, err := terminalchat.BuildState(context.Background(), cfg.Database, terminalchat.StateOptions{
+	state, cleanup, err := terminalchat.BuildState(sessionCtx, cfg.Database, terminalchat.StateOptions{
 		Memory:  memory,
 		Channel: channel,
 	}, terminalchat.StateDeps{})
@@ -169,30 +202,71 @@ func main() {
 		engineCfg.Streaks = progress.NewMemoryStreakTracker()
 		engineCfg.XP = progress.NewMemoryXPTracker()
 	}
-	engine := agent.NewEngine(engineCfg)
-
-	processor := terminalchat.Processor(engine)
 	var history *conversationHistory
 	if strings.TrimSpace(historyJSONPath) != "" || strings.TrimSpace(dumpJSONPath) != "" {
 		history = newConversationHistory(userID, channel)
-		processor = &historyProcessor{inner: processor, history: history}
 	}
 	if history != nil && strings.TrimSpace(dumpJSONPath) != "" {
 		router.SetTraceFunc(history.appendAITrace)
 	}
 
 	var runErr error
-	if multi {
-		runErr = terminalchat.RunMulti(context.Background(), os.Stdin, os.Stdout, processor, terminalchat.MultiConfig{
-			UserCount:  userCount,
-			UserPrefix: userID,
-			Channel:    channel,
-		})
-	} else {
-		runErr = terminalchat.Run(context.Background(), os.Stdin, os.Stdout, processor, terminalchat.Config{
+	if interactive {
+		factory := func(candidate terminalchat.Candidate) (terminalchat.Processor, error) {
+			localCfg := engineCfg
+			localCfg.Store = agent.NewMemoryStore()
+			localCfg.EventLogger = agent.NewMemoryEventLogger()
+			localCfg.Goals = agent.NewMemoryGoalStore()
+			localCfg.Challenges = agent.NewMemoryChallengeStore()
+			localCfg.TenantID = ""
+			localCfg.TutorPromptExtension = candidate.Prompt
+			localCfg.TurnHookNotice = nil
+			if progressSideEffects {
+				localCfg.Tracker = progress.NewMemoryTracker()
+				localCfg.Streaks = progress.NewMemoryStreakTracker()
+				localCfg.XP = progress.NewMemoryXPTracker()
+			}
+			if lang := strings.TrimSpace(language); lang != "" {
+				if err := localCfg.Store.SetUserPreferredLanguage(userID, lang); err != nil {
+					return nil, fmt.Errorf("set preferred language: %w", err)
+				}
+			}
+			processor := terminalchat.Processor(agent.NewEngine(localCfg))
+			if history != nil {
+				processor = &historyProcessor{inner: processor, history: history}
+			}
+			return processor, nil
+		}
+		session, err := newInteractiveTerminalSession(
+			terminalchat.NewCandidateSource(candidateDirectory),
+			selectedProvider,
+			factory,
+		)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "build interactive session: %v\n", err)
+			os.Exit(1)
+		}
+		runErr = terminalchat.RunInteractive(sessionCtx, os.Stdin, os.Stdout, session, terminalchat.InteractiveConfig{
 			UserID:  userID,
 			Channel: channel,
 		})
+	} else {
+		processor := terminalchat.Processor(agent.NewEngine(engineCfg))
+		if history != nil {
+			processor = &historyProcessor{inner: processor, history: history}
+		}
+		if multi {
+			runErr = terminalchat.RunMulti(sessionCtx, os.Stdin, os.Stdout, processor, terminalchat.MultiConfig{
+				UserCount:  userCount,
+				UserPrefix: userID,
+				Channel:    channel,
+			})
+		} else {
+			runErr = terminalchat.Run(sessionCtx, os.Stdin, os.Stdout, processor, terminalchat.Config{
+				UserID:  userID,
+				Channel: channel,
+			})
+		}
 	}
 	if history != nil {
 		for _, path := range []string{historyJSONPath, dumpJSONPath} {

--- a/cmd/terminal-chat/provider.go
+++ b/cmd/terminal-chat/provider.go
@@ -1,0 +1,196 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/p-n-ai/pai-bot/internal/ai"
+	"github.com/p-n-ai/pai-bot/internal/platform/airouter"
+	"github.com/p-n-ai/pai-bot/internal/platform/codexauth"
+	"github.com/p-n-ai/pai-bot/internal/platform/config"
+)
+
+const managedCodexPollInterval = 100 * time.Millisecond
+
+type managedCodexLogin interface {
+	ai.CodexAppServerClient
+	Start() (codexauth.Status, error)
+	Status() codexauth.Status
+}
+
+type terminalProviderDependencies struct {
+	findExecutable func(string) (string, error)
+	newCodexLogin  func(context.Context, string, string) managedCodexLogin
+	pollInterval   time.Duration
+}
+
+func defaultTerminalProviderDependencies() terminalProviderDependencies {
+	return terminalProviderDependencies{
+		findExecutable: exec.LookPath,
+		newCodexLogin: func(ctx context.Context, home, executable string) managedCodexLogin {
+			return codexauth.New(ctx, home, executable, nil)
+		},
+		pollInterval: managedCodexPollInterval,
+	}
+}
+
+func buildTerminalAIRouter(
+	ctx context.Context,
+	cfg config.AIConfig,
+	selectedProvider string,
+	statusOutput io.Writer,
+) (*ai.Router, error) {
+	return buildTerminalAIRouterWithDependencies(
+		ctx,
+		cfg,
+		selectedProvider,
+		statusOutput,
+		defaultTerminalProviderDependencies(),
+	)
+}
+
+func buildTerminalAIRouterWithDependencies(
+	ctx context.Context,
+	cfg config.AIConfig,
+	selectedProvider string,
+	statusOutput io.Writer,
+	deps terminalProviderDependencies,
+) (*ai.Router, error) {
+	if ctx == nil {
+		return nil, errors.New("context is required")
+	}
+	if statusOutput == nil {
+		statusOutput = io.Discard
+	}
+	selectedProvider = strings.ToLower(strings.TrimSpace(selectedProvider))
+
+	var codexLogin managedCodexLogin
+	if cfg.Codex.Enabled && (selectedProvider == "" || selectedProvider == "codex") {
+		executable, err := deps.findExecutable("codex")
+		if err != nil || strings.TrimSpace(executable) == "" {
+			if selectedProvider == "codex" || codexMustBeReady(cfg) {
+				return nil, errors.New("codex CLI is not installed or is not on PATH")
+			}
+		} else {
+			codexLogin = deps.newCodexLogin(ctx, cfg.Codex.Home, executable)
+			if codexLogin == nil || !codexLogin.Available() {
+				if selectedProvider == "codex" || codexMustBeReady(cfg) {
+					return nil, errors.New("managed Codex requires an isolated LEARN_AI_CODEX_HOME")
+				}
+				codexLogin = nil
+			}
+		}
+	}
+
+	if codexLogin != nil && (selectedProvider == "codex" || codexMustBeReady(cfg)) {
+		if err := ensureManagedCodexLogin(ctx, codexLogin, statusOutput, deps.pollInterval); err != nil {
+			return nil, err
+		}
+	}
+
+	router := ai.NewRouter()
+	if selectedProvider != "" {
+		plan, err := airouter.PrepareProviderWithCodexAuth(selectedProvider, cfg, codexLogin)
+		if err != nil {
+			return nil, err
+		}
+		plan.Apply(router)
+	} else {
+		router = airouter.SetupWithCodexAuth(cfg, codexLogin)
+	}
+	if !router.HasProvider() {
+		return nil, errors.New("no AI providers configured")
+	}
+	return router, nil
+}
+
+func codexMustBeReady(cfg config.AIConfig) bool {
+	if !cfg.Codex.Enabled {
+		return false
+	}
+	preferred := strings.ToLower(strings.TrimSpace(cfg.DefaultProvider))
+	if preferred != "" {
+		return preferred == "codex"
+	}
+	for _, name := range airouter.ProviderNames() {
+		if name == "codex" || name == "mock" {
+			continue
+		}
+		if airouter.HasProviderConfiguration(name, cfg) {
+			return false
+		}
+	}
+	return true
+}
+
+func ensureManagedCodexLogin(
+	ctx context.Context,
+	login managedCodexLogin,
+	statusOutput io.Writer,
+	pollInterval time.Duration,
+) error {
+	if login == nil {
+		return errors.New("managed Codex login is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := login.Refresh(ctx); err == nil {
+		_, _ = fmt.Fprintln(statusOutput, "Codex provider ready.")
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if _, err := login.Start(); err != nil {
+		status := login.Status()
+		if strings.TrimSpace(status.Message) != "" {
+			return errors.New(status.Message)
+		}
+		return fmt.Errorf("start Codex device login: %w", err)
+	}
+	if pollInterval <= 0 {
+		pollInterval = managedCodexPollInterval
+	}
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+	instructionsShown := false
+	for {
+		status := login.Status()
+		switch status.State {
+		case codexauth.StateConnected:
+			_, _ = fmt.Fprintln(statusOutput, "Codex connected.")
+			return nil
+		case codexauth.StateAwaiting:
+			if !instructionsShown {
+				_, _ = fmt.Fprintf(
+					statusOutput,
+					"Codex login required. Open %s and enter code %s.\nWaiting for authorization…\n",
+					status.VerificationURL,
+					status.UserCode,
+				)
+				instructionsShown = true
+			}
+		case codexauth.StateFailed:
+			if strings.TrimSpace(status.Message) != "" {
+				return errors.New(status.Message)
+			}
+			return errors.New("codex device login failed")
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}

--- a/cmd/terminal-chat/provider_test.go
+++ b/cmd/terminal-chat/provider_test.go
@@ -1,0 +1,215 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/p-n-ai/pai-bot/internal/ai"
+	"github.com/p-n-ai/pai-bot/internal/platform/codexauth"
+	"github.com/p-n-ai/pai-bot/internal/platform/config"
+)
+
+type fakeManagedCodexLogin struct {
+	mu              sync.Mutex
+	available       bool
+	refreshErr      error
+	startErr        error
+	statuses        []codexauth.Status
+	statusIndex     int
+	startCalls      int
+	completionCalls int
+	lastRequest     ai.CompletionRequest
+}
+
+func (f *fakeManagedCodexLogin) Available() bool {
+	return f.available
+}
+
+func (f *fakeManagedCodexLogin) Refresh(context.Context) error {
+	return f.refreshErr
+}
+
+func (f *fakeManagedCodexLogin) Complete(
+	_ context.Context,
+	request ai.CompletionRequest,
+) (ai.CompletionResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.completionCalls++
+	f.lastRequest = request
+	return ai.CompletionResponse{Content: "Codex reply", Model: request.Model}, nil
+}
+
+func (f *fakeManagedCodexLogin) Start() (codexauth.Status, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.startCalls++
+	if f.startErr != nil {
+		return f.currentStatus(), f.startErr
+	}
+	return f.currentStatus(), nil
+}
+
+func (f *fakeManagedCodexLogin) Status() codexauth.Status {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	status := f.currentStatus()
+	if f.statusIndex < len(f.statuses)-1 {
+		f.statusIndex++
+	}
+	return status
+}
+
+func (f *fakeManagedCodexLogin) currentStatus() codexauth.Status {
+	if len(f.statuses) == 0 {
+		return codexauth.Status{State: codexauth.StateDisconnected}
+	}
+	return f.statuses[f.statusIndex]
+}
+
+func TestBuildTerminalAIRouterPinsCodexWithoutFallback(t *testing.T) {
+	login := &fakeManagedCodexLogin{available: true}
+	cfg := config.AIConfig{
+		OpenAI: config.OpenAIConfig{APIKey: "configured-but-forbidden-fallback"},
+		Codex: config.CodexConfig{
+			Enabled: true,
+			Home:    t.TempDir(),
+			Model:   "gpt-test",
+		},
+	}
+	var statusOutput strings.Builder
+
+	router, err := buildTerminalAIRouterWithDependencies(
+		t.Context(),
+		cfg,
+		"codex",
+		&statusOutput,
+		terminalProviderDependencies{
+			findExecutable: func(string) (string, error) { return "/test/codex", nil },
+			newCodexLogin: func(context.Context, string, string) managedCodexLogin {
+				return login
+			},
+			pollInterval: time.Millisecond,
+		},
+	)
+	if err != nil {
+		t.Fatalf("buildTerminalAIRouterWithDependencies() error = %v", err)
+	}
+	if got := router.ProviderOrder(); !reflect.DeepEqual(got, []string{"codex"}) {
+		t.Fatalf("ProviderOrder() = %v, want Codex only", got)
+	}
+	response, err := router.Complete(t.Context(), ai.CompletionRequest{
+		Messages: []ai.Message{{Role: "user", Content: "hello"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	if response.Content != "Codex reply" || login.completionCalls != 1 {
+		t.Fatalf("Complete() = %#v, calls = %d", response, login.completionCalls)
+	}
+	if login.lastRequest.Model != "gpt-test" {
+		t.Fatalf("Codex request model = %q, want gpt-test", login.lastRequest.Model)
+	}
+	if !strings.Contains(statusOutput.String(), "Codex provider ready.") {
+		t.Fatalf("status output = %q, want ready confirmation", statusOutput.String())
+	}
+}
+
+func TestEnsureManagedCodexLoginPrintsDeviceInstructionsAndWaits(t *testing.T) {
+	login := &fakeManagedCodexLogin{
+		available:  true,
+		refreshErr: errors.New("not connected"),
+		statuses: []codexauth.Status{
+			{
+				State:           codexauth.StateAwaiting,
+				VerificationURL: "https://auth.openai.com/codex/device",
+				UserCode:        "ABCD-EFGH",
+			},
+			{State: codexauth.StateConnected},
+		},
+	}
+	var output strings.Builder
+
+	if err := ensureManagedCodexLogin(t.Context(), login, &output, time.Millisecond); err != nil {
+		t.Fatalf("ensureManagedCodexLogin() error = %v", err)
+	}
+	if login.startCalls != 1 {
+		t.Fatalf("Start() calls = %d, want 1", login.startCalls)
+	}
+	rendered := output.String()
+	for _, want := range []string{
+		"https://auth.openai.com/codex/device",
+		"ABCD-EFGH",
+		"Waiting for authorization",
+		"Codex connected.",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("output = %q, want %q", rendered, want)
+		}
+	}
+}
+
+func TestBuildTerminalAIRouterRejectsMissingCodexCLIWithoutFallback(t *testing.T) {
+	cfg := config.AIConfig{
+		OpenAI: config.OpenAIConfig{APIKey: "configured-but-forbidden-fallback"},
+		Codex: config.CodexConfig{
+			Enabled: true,
+			Home:    t.TempDir(),
+		},
+	}
+
+	_, err := buildTerminalAIRouterWithDependencies(
+		t.Context(),
+		cfg,
+		"codex",
+		&strings.Builder{},
+		terminalProviderDependencies{
+			findExecutable: func(string) (string, error) {
+				return "", errors.New("not found")
+			},
+		},
+	)
+	if err == nil || !strings.Contains(err.Error(), "codex CLI") {
+		t.Fatalf("error = %v, want actionable missing CLI error", err)
+	}
+}
+
+func TestEnsureManagedCodexLoginReturnsSafeFailureMessage(t *testing.T) {
+	login := &fakeManagedCodexLogin{
+		available:  true,
+		refreshErr: errors.New("not connected"),
+		startErr:   errors.New("unsafe lower-level detail"),
+		statuses: []codexauth.Status{{
+			State:   codexauth.StateFailed,
+			Message: "Codex CLI is not installed on the server.",
+		}},
+	}
+
+	err := ensureManagedCodexLogin(t.Context(), login, &strings.Builder{}, time.Millisecond)
+	if err == nil || err.Error() != "Codex CLI is not installed on the server." {
+		t.Fatalf("error = %v, want safe status message", err)
+	}
+}
+
+func TestEnsureManagedCodexLoginReturnsGenericFailureWithoutStatusMessage(t *testing.T) {
+	login := &fakeManagedCodexLogin{
+		available:  true,
+		refreshErr: errors.New("not connected"),
+		statuses: []codexauth.Status{{
+			State: codexauth.StateFailed,
+		}},
+	}
+
+	err := ensureManagedCodexLogin(t.Context(), login, &strings.Builder{}, time.Millisecond)
+	if err == nil || err.Error() != "codex device login failed" {
+		t.Fatalf("error = %v, want generic safe failure", err)
+	}
+}

--- a/cmd/terminal-chat/session.go
+++ b/cmd/terminal-chat/session.go
@@ -1,0 +1,152 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/p-n-ai/pai-bot/internal/agent"
+	"github.com/p-n-ai/pai-bot/internal/chat"
+	"github.com/p-n-ai/pai-bot/internal/terminalchat"
+)
+
+type terminalProcessorFactory func(terminalchat.Candidate) (terminalchat.Processor, error)
+
+type interactiveTerminalSession struct {
+	mu        sync.RWMutex
+	source    terminalchat.CandidateSource
+	factory   terminalProcessorFactory
+	processor terminalchat.Processor
+	candidate terminalchat.Candidate
+	character terminalchat.Character
+	provider  string
+}
+
+func newInteractiveTerminalSession(
+	source terminalchat.CandidateSource,
+	provider string,
+	factory terminalProcessorFactory,
+) (*interactiveTerminalSession, error) {
+	if factory == nil {
+		return nil, errors.New("processor factory is required")
+	}
+	candidate, err := source.Load()
+	if err != nil {
+		return nil, err
+	}
+	processor, err := factory(candidate)
+	if err != nil {
+		return nil, err
+	}
+	return &interactiveTerminalSession{
+		source:    source,
+		factory:   factory,
+		processor: processor,
+		candidate: candidate,
+		character: candidate.DefaultCharacter(),
+		provider:  strings.ToLower(strings.TrimSpace(provider)),
+	}, nil
+}
+
+func (s *interactiveTerminalSession) ProcessTurn(
+	ctx context.Context,
+	message chat.InboundMessage,
+) (agent.TurnResult, error) {
+	s.mu.RLock()
+	processor := s.processor
+	character := s.character
+	s.mu.RUnlock()
+	if processor == nil {
+		return agent.TurnResult{}, errors.New("interactive processor is not configured")
+	}
+	message.FirstName = character.FirstName
+	message.Username = character.Username
+	message.Language = character.Language
+	return processor.ProcessTurn(ctx, message)
+}
+
+func (s *interactiveTerminalSession) New(context.Context) (terminalchat.InteractiveStatus, error) {
+	s.mu.RLock()
+	candidate := s.candidate
+	character := s.character
+	s.mu.RUnlock()
+
+	processor, err := s.factory(candidate)
+	if err != nil {
+		return terminalchat.InteractiveStatus{}, err
+	}
+	s.mu.Lock()
+	s.processor = processor
+	s.character = character
+	status := s.statusLocked()
+	s.mu.Unlock()
+	return status, nil
+}
+
+func (s *interactiveTerminalSession) Reload(context.Context) (terminalchat.InteractiveStatus, error) {
+	candidate, err := s.source.Load()
+	if err != nil {
+		return terminalchat.InteractiveStatus{}, err
+	}
+	processor, err := s.factory(candidate)
+	if err != nil {
+		return terminalchat.InteractiveStatus{}, err
+	}
+	s.mu.Lock()
+	s.processor = processor
+	s.candidate = candidate
+	s.character = candidate.DefaultCharacter()
+	status := s.statusLocked()
+	s.mu.Unlock()
+	return status, nil
+}
+
+func (s *interactiveTerminalSession) SelectCharacter(
+	_ context.Context,
+	id string,
+) (terminalchat.InteractiveStatus, error) {
+	s.mu.RLock()
+	candidate := s.candidate
+	s.mu.RUnlock()
+	character, ok := candidate.Character(id)
+	if !ok {
+		return terminalchat.InteractiveStatus{}, fmt.Errorf("unknown character %q", strings.TrimSpace(id))
+	}
+	processor, err := s.factory(candidate)
+	if err != nil {
+		return terminalchat.InteractiveStatus{}, err
+	}
+	s.mu.Lock()
+	s.processor = processor
+	s.character = character
+	status := s.statusLocked()
+	s.mu.Unlock()
+	return status, nil
+}
+
+func (s *interactiveTerminalSession) Status() terminalchat.InteractiveStatus {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.statusLocked()
+}
+
+func (s *interactiveTerminalSession) CandidateChanged() (bool, error) {
+	s.mu.RLock()
+	activeHash := s.candidate.Hash
+	s.mu.RUnlock()
+	return s.source.Changed(activeHash)
+}
+
+func (s *interactiveTerminalSession) statusLocked() terminalchat.InteractiveStatus {
+	return terminalchat.InteractiveStatus{
+		Provider:      s.provider,
+		Memory:        true,
+		CharacterID:   s.character.ID,
+		CandidateHash: s.candidate.Hash,
+	}
+}

--- a/cmd/terminal-chat/session_test.go
+++ b/cmd/terminal-chat/session_test.go
@@ -1,0 +1,229 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/p-n-ai/pai-bot/internal/agent"
+	"github.com/p-n-ai/pai-bot/internal/chat"
+	"github.com/p-n-ai/pai-bot/internal/terminalchat"
+)
+
+type recordingTerminalProcessor struct {
+	mu       sync.Mutex
+	prompt   string
+	messages []chat.InboundMessage
+}
+
+func (p *recordingTerminalProcessor) ProcessTurn(
+	_ context.Context,
+	message chat.InboundMessage,
+) (agent.TurnResult, error) {
+	p.mu.Lock()
+	p.messages = append(p.messages, message)
+	p.mu.Unlock()
+	return agent.TurnResult{Text: p.prompt}, nil
+}
+
+func (p *recordingTerminalProcessor) snapshot() []chat.InboundMessage {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]chat.InboundMessage(nil), p.messages...)
+}
+
+func TestInteractiveTerminalSessionNewPreservesSelectedCharacter(t *testing.T) {
+	directory := t.TempDir()
+	writeTerminalSessionFile(t, directory, `prompt: candidate one
+default: aina
+characters:
+  - id: aina
+    first_name: Aina
+    language: en
+  - id: faris
+    first_name: Faris
+    username: faris_student
+    language: ms
+`)
+
+	var processors []*recordingTerminalProcessor
+	session, err := newInteractiveTerminalSession(
+		terminalchat.NewCandidateSource(directory),
+		"codex",
+		func(candidate terminalchat.Candidate) (terminalchat.Processor, error) {
+			processor := &recordingTerminalProcessor{prompt: candidate.Prompt}
+			processors = append(processors, processor)
+			return processor, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("newInteractiveTerminalSession() error = %v", err)
+	}
+	if _, err := session.SelectCharacter(t.Context(), "faris"); err != nil {
+		t.Fatalf("SelectCharacter() error = %v", err)
+	}
+	if _, err := session.ProcessTurn(t.Context(), chat.InboundMessage{Text: "first"}); err != nil {
+		t.Fatalf("first ProcessTurn() error = %v", err)
+	}
+	if _, err := session.New(t.Context()); err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if _, err := session.ProcessTurn(t.Context(), chat.InboundMessage{Text: "second"}); err != nil {
+		t.Fatalf("second ProcessTurn() error = %v", err)
+	}
+
+	if len(processors) != 3 {
+		t.Fatalf("processors built = %d, want initial, character, and new sessions", len(processors))
+	}
+	for index, processor := range processors[1:] {
+		messages := processor.snapshot()
+		if len(messages) != 1 {
+			t.Fatalf("processor %d messages = %#v, want one", index+2, messages)
+		}
+		message := messages[0]
+		if message.FirstName != "Faris" || message.Username != "faris_student" || message.Language != "ms" {
+			t.Fatalf("processor %d character = %#v, want Faris profile", index+2, message)
+		}
+	}
+	if status := session.Status(); status.CharacterID != "faris" || !status.Memory || status.Provider != "codex" {
+		t.Fatalf("Status() = %#v, want preserved Faris Codex memory session", status)
+	}
+}
+
+func TestInteractiveTerminalSessionReloadIsAtomicAndUsesCandidateDefault(t *testing.T) {
+	directory := t.TempDir()
+	writeTerminalSessionFile(t, directory, `prompt: old candidate
+default: aina
+characters:
+  - id: aina
+  - id: faris
+`)
+
+	var processors []*recordingTerminalProcessor
+	session, err := newInteractiveTerminalSession(
+		terminalchat.NewCandidateSource(directory),
+		"codex",
+		func(candidate terminalchat.Candidate) (terminalchat.Processor, error) {
+			processor := &recordingTerminalProcessor{prompt: candidate.Prompt}
+			processors = append(processors, processor)
+			return processor, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("newInteractiveTerminalSession() error = %v", err)
+	}
+	if _, err := session.SelectCharacter(t.Context(), "faris"); err != nil {
+		t.Fatalf("SelectCharacter() error = %v", err)
+	}
+	before := session.Status()
+
+	writeTerminalSessionFile(t, directory, `prompt: new candidate
+default: aina
+characters:
+  - id: aina
+    langauge: en
+`)
+	if _, err := session.Reload(t.Context()); err == nil || !strings.Contains(err.Error(), "langauge") {
+		t.Fatalf("Reload() error = %v, want invalid candidate failure", err)
+	}
+	if after := session.Status(); after != before {
+		t.Fatalf("status after failed reload = %#v, want unchanged %#v", after, before)
+	}
+	result, err := session.ProcessTurn(t.Context(), chat.InboundMessage{Text: "still old"})
+	if err != nil {
+		t.Fatalf("ProcessTurn() after failed reload error = %v", err)
+	}
+	if result.Text != "old candidate" {
+		t.Fatalf("reply after failed reload = %q, want old candidate", result.Text)
+	}
+
+	writeTerminalSessionFile(t, directory, `prompt: new candidate
+default: aina
+characters:
+  - id: aina
+    first_name: Aina
+    language: en
+  - id: faris
+`)
+	reloaded, err := session.Reload(t.Context())
+	if err != nil {
+		t.Fatalf("Reload(valid) error = %v", err)
+	}
+	if reloaded.CharacterID != "aina" {
+		t.Fatalf("reloaded character = %q, want candidate default aina", reloaded.CharacterID)
+	}
+	if reloaded.CandidateHash == before.CandidateHash {
+		t.Fatalf("candidate hash did not change: %q", reloaded.CandidateHash)
+	}
+	result, err = session.ProcessTurn(t.Context(), chat.InboundMessage{Text: "now new"})
+	if err != nil {
+		t.Fatalf("ProcessTurn() after reload error = %v", err)
+	}
+	if result.Text != "new candidate" {
+		t.Fatalf("reply after valid reload = %q, want new candidate", result.Text)
+	}
+}
+
+func TestInteractiveTerminalSessionCharacterFactoryFailureIsAtomic(t *testing.T) {
+	directory := t.TempDir()
+	writeTerminalSessionFile(t, directory, `prompt: candidate
+default: aina
+characters:
+  - id: aina
+    first_name: Aina
+  - id: faris
+    first_name: Faris
+`)
+
+	processor := &recordingTerminalProcessor{prompt: "active reply"}
+	factoryCalls := 0
+	session, err := newInteractiveTerminalSession(
+		terminalchat.NewCandidateSource(directory),
+		"codex",
+		func(terminalchat.Candidate) (terminalchat.Processor, error) {
+			factoryCalls++
+			if factoryCalls > 1 {
+				return nil, errors.New("processor unavailable")
+			}
+			return processor, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("newInteractiveTerminalSession() error = %v", err)
+	}
+	before := session.Status()
+
+	if _, err := session.SelectCharacter(t.Context(), "faris"); err == nil ||
+		!strings.Contains(err.Error(), "processor unavailable") {
+		t.Fatalf("SelectCharacter() error = %v, want processor failure", err)
+	}
+	if after := session.Status(); after != before {
+		t.Fatalf("status after failed selection = %#v, want unchanged %#v", after, before)
+	}
+	result, err := session.ProcessTurn(t.Context(), chat.InboundMessage{Text: "hello"})
+	if err != nil {
+		t.Fatalf("ProcessTurn() error = %v", err)
+	}
+	if result.Text != "active reply" {
+		t.Fatalf("ProcessTurn() reply = %q, want active processor reply", result.Text)
+	}
+	messages := processor.snapshot()
+	if len(messages) != 1 || messages[0].FirstName != "Aina" {
+		t.Fatalf("active processor messages = %#v, want original Aina character", messages)
+	}
+}
+
+func writeTerminalSessionFile(t *testing.T, directory, content string) {
+	t.Helper()
+	const filename = "candidate.yaml"
+	if err := os.WriteFile(filepath.Join(directory, filename), []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", filename, err)
+	}
+}

--- a/docs/operations/conversation-quality-harness.md
+++ b/docs/operations/conversation-quality-harness.md
@@ -1,0 +1,127 @@
+# Conversation quality harness
+
+`cmd/conversation-harness` runs scripted learner conversations through the real
+tutor engine. It separates deterministic conversation mechanics from
+model-variable response checks:
+
+- `wait` starts after earlier work finishes.
+- `queue` preserves unfinished work and runs the message in arrival order.
+- `interrupt` cancels the in-flight reply, suppresses queued stale replies, and
+  runs the replacement message.
+- `character` applies stable `first_name`, `username`, and `language` fields to
+  every inbound message in one conversation.
+- Conversation checks apply to every delivered reply or the full transcript.
+  Turn checks apply only to that reply, which is useful for terse follow-ups.
+
+The default fixture is
+`internal/agent/testdata/ai_quality_conversations.yaml`. Its `queue`,
+`interruptions`, and `short-replies` tags are the natural-conversation suite.
+
+## Run it
+
+Run the black-box pass/fail verifier:
+
+```bash
+just conversation-harness-verify
+```
+
+It builds the real CLI, checks queue, interruption, and terse-character cases,
+requires an overlong reply to fail its turn-scoped limit, and requires a
+misspelled fixture field to fail during loading. It does not need credentials or
+network access.
+
+Run the deterministic coordinator and command tests:
+
+```bash
+go test ./internal/conversationharness ./cmd/conversation-harness
+```
+
+Exercise one dynamic with a mock response:
+
+```bash
+go run ./cmd/conversation-harness \
+  --tag interruptions \
+  --mock-response "You can read 4x as four copies of x." \
+  --show-responses
+```
+
+Run the naturalness cases against the configured provider:
+
+```bash
+go run ./cmd/conversation-harness --tag naturalness --show-responses
+```
+
+Use `--jsonl` for automation and `--dump-requests <path> --request-only` to
+inspect model inputs without scoring. Request dumps are created with mode
+`0600` because prompts can contain learner context.
+
+JSON results include aggregate counts plus one safe structural outcome per turn:
+
+```json
+{
+  "id": "Q13",
+  "passed": true,
+  "turns": 2,
+  "delivered": 1,
+  "interrupted": 1,
+  "outcomes": [
+    {"turn": 1, "delivery": "wait", "status": "interrupted", "duration_ms": 0},
+    {"turn": 2, "delivery": "interrupt", "status": "delivered", "duration_ms": 0}
+  ]
+}
+```
+
+The JSON outcome intentionally omits learner text and model responses. Use
+`--show-responses` for human review or the mode-`0600` request dump when model
+input inspection is required.
+
+## Fixture shape
+
+```yaml
+version: 2
+provider: openai
+characters:
+  - id: aina
+    first_name: Aina
+    username: aina
+    language: en
+conversations:
+  - id: NAT01
+    title: Interruption replaces a stale answer
+    tags: [interruptions, naturalness]
+    character: aina
+    turns:
+      - user: "Explain every step."
+        expect_status: interrupted
+      - user: "Wait—just explain what 4x means."
+        delivery: interrupt
+        expect_status: delivered
+        checks:
+          max_response_chars: 320
+          forbid_section_labels_on_turn: [2]
+    checks:
+      require_non_empty_replies: true
+      forbid_fallback_message: true
+```
+
+`delivery` defaults to `wait`; `expect_status` defaults to `delivered`.
+Supported statuses are `delivered`, `interrupted`, and `failed`. An optional
+`after` value accepts a Go duration such as `25ms`, but zero-delay events are
+preferable for deterministic queue and interruption cases.
+
+Fixture decoding is strict. Unknown keys, unsupported delivery/status values,
+duplicate IDs, invalid turn references, and unsupported versions fail before
+the tutor engine or provider is constructed. Version 1 fixtures remain
+supported when they use fields understood by this command.
+
+The coordinator never exposes a canceled response, even if a provider returns
+fallback text after cancellation. It also waits for canceled processor work
+before returning, so harness runs do not leak background turns.
+
+## Boundary
+
+These delivery modes belong to the QA harness. They let a fixture state the
+interaction contract it wants to evaluate, but they do not change channel
+runtime behavior. Production ingress currently serializes and queues messages
+per destination; a passing interruption case does not prove that a live channel
+cancels an in-flight reply.

--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -77,6 +77,7 @@ type EngineConfig struct {
 	FocusedPages          *focusedpage.Service
 	FocusedPageEnabled    func(chat.InboundMessage) bool
 	TurnDeliverer         TurnDeliverer
+	TutorPromptExtension  string
 }
 
 // Engine is the core conversation processor.
@@ -110,6 +111,7 @@ type Engine struct {
 	focusedPageEnabled    func(chat.InboundMessage) bool
 	turnLocks             keyedTurnLocks
 	turnDeliverer         TurnDeliverer
+	tutorPromptExtension  string
 }
 
 // NewEngine creates a new agent engine.
@@ -199,6 +201,7 @@ func NewEngine(cfg EngineConfig) *Engine {
 		focusedPages:          cfg.FocusedPages,
 		focusedPageEnabled:    focusedPageEnabled,
 		turnDeliverer:         cfg.TurnDeliverer,
+		tutorPromptExtension:  strings.TrimSpace(cfg.TutorPromptExtension),
 	}
 }
 
@@ -1477,6 +1480,10 @@ EVIDENCE AND CITATIONS:
 If an image is attached, analyze it first, then answer. If image text is unclear, state what is unclear and ask for a clearer retake. If the student asks a follow-up about an earlier image but did not reply to that image or reattach it, ask them to reply directly to the image message.
 
 When writing maths, use plain-text only (example: 6x = 30, x = 5). Do not use LaTeX delimiters like \[ \], \( \), or $$. Do not format replies using Markdown headings, bold, italic, code blocks, or Markdown lists. Use plain chat text with simple line breaks only.`
+
+	if e.tutorPromptExtension != "" {
+		base += "\n\nLOCAL CONVERSATION TEST CANDIDATE:\n" + e.tutorPromptExtension
+	}
 
 	// Inject adaptive explanation depth based on mastery level.
 	if e.tracker != nil {

--- a/internal/agent/prompt_builder_test.go
+++ b/internal/agent/prompt_builder_test.go
@@ -9,7 +9,33 @@ import (
 	"testing"
 
 	"github.com/p-n-ai/pai-bot/internal/ai"
+	"github.com/p-n-ai/pai-bot/internal/chat"
 )
+
+func TestBuildSystemPromptIncludesLocalConversationCandidateOnlyWhenConfigured(t *testing.T) {
+	const candidate = "Match a terse learner with one short reply."
+	withCandidate := NewEngine(EngineConfig{TutorPromptExtension: candidate})
+	prompt := withCandidate.buildSystemPrompt(
+		chat.InboundMessage{UserID: "learner"},
+		&Conversation{UserID: "learner"},
+		nil,
+		"",
+	)
+	if !strings.Contains(prompt, "LOCAL CONVERSATION TEST CANDIDATE:\n"+candidate) {
+		t.Fatalf("system prompt missing candidate block")
+	}
+
+	withoutCandidate := NewEngine(EngineConfig{})
+	defaultPrompt := withoutCandidate.buildSystemPrompt(
+		chat.InboundMessage{UserID: "learner"},
+		&Conversation{UserID: "learner"},
+		nil,
+		"",
+	)
+	if strings.Contains(defaultPrompt, "LOCAL CONVERSATION TEST CANDIDATE:") {
+		t.Fatal("default system prompt unexpectedly contains a local candidate block")
+	}
+}
 
 func TestBuildPromptMessagesFromTurn_UsesQuotedSummaryAndExplicitCurrentUser(t *testing.T) {
 	engine := NewEngine(EngineConfig{})

--- a/internal/agent/testdata/ai_quality_conversations.yaml
+++ b/internal/agent/testdata/ai_quality_conversations.yaml
@@ -1,5 +1,14 @@
-version: 1
+version: 2
 provider: openai
+characters:
+  - id: aina-impatient
+    first_name: Aina
+    username: aina
+    language: en
+  - id: faris-terse
+    first_name: Faris
+    username: faris
+    language: ms
 conversations:
   - id: G01
     title: Teacher slide and OSS guidance are fused with citations
@@ -221,3 +230,70 @@ conversations:
       forbid_section_labels_on_turn: [1]
       max_response_lines: 5
       max_response_chars: 420
+
+  - id: Q12
+    title: Back-to-back learner messages stay ordered
+    tags: [queue, short-replies, naturalness]
+    character: aina-impatient
+    turns:
+      - user: "Can you help me understand 3x + 2 = 11?"
+        expect_status: delivered
+      - user: "Start with what 3x means."
+        delivery: queue
+        expect_status: delivered
+      - user: "Keep it short please."
+        delivery: queue
+        expect_status: delivered
+        checks:
+          forbid_section_labels_on_turn: [3]
+          max_response_lines: 5
+          max_response_chars: 320
+    checks:
+      require_non_empty_replies: true
+      forbid_fallback_message: true
+      forbid_markdown_and_latex: true
+      forbid_section_labels_on_turn: [2, 3]
+      expected_language: en_or_mixed
+
+  - id: Q13
+    title: Learner interruption suppresses the stale reply
+    tags: [interruptions, cancellation, naturalness]
+    character: aina-impatient
+    turns:
+      - user: "Give me a detailed explanation of every step in 4x + 8 = 20."
+        expect_status: interrupted
+      - user: "Actually wait—skip that. Just tell me what 4x means."
+        delivery: interrupt
+        expect_status: delivered
+        checks:
+          forbid_section_labels_on_turn: [2]
+          max_response_lines: 5
+          max_response_chars: 320
+    checks:
+      require_non_empty_replies: true
+      forbid_fallback_message: true
+      forbid_markdown_and_latex: true
+      expected_language: en_or_mixed
+
+  - id: Q14
+    title: Terse follow-ups retain context without over-answering
+    tags: [short-replies, continuity, bm, naturalness]
+    character: faris-terse
+    turns:
+      - user: "Saya tak faham kenapa 2x bermaksud dua kali x."
+      - user: "hah?"
+        checks:
+          forbid_section_labels_on_turn: [2]
+          max_response_lines: 4
+          max_response_chars: 260
+      - user: "kenapa?"
+        checks:
+          forbid_section_labels_on_turn: [3]
+          max_response_lines: 4
+          max_response_chars: 260
+    checks:
+      require_non_empty_replies: true
+      forbid_fallback_message: true
+      forbid_markdown_and_latex: true
+      forbid_section_labels_on_turn: [2, 3]
+      expected_language: bm_or_mixed

--- a/internal/conversationharness/runner.go
+++ b/internal/conversationharness/runner.go
@@ -270,14 +270,15 @@ func (c *coordinator) finishCurrent(result processResult) {
 }
 
 func (c *coordinator) stop() {
-	for _, index := range c.pending {
-		c.outcomes[index] = Outcome{Status: StatusFailed, Err: c.ctx.Err()}
-	}
 	c.pending = nil
-	if c.current == nil {
-		return
+	if c.current != nil {
+		c.current.cancel()
+		result := <-c.current.done
+		c.finishCurrent(result)
 	}
-	c.current.cancel()
-	result := <-c.current.done
-	c.finishCurrent(result)
+	for index, outcome := range c.outcomes {
+		if outcome.Status == "" {
+			c.outcomes[index] = Outcome{Status: StatusFailed, Err: c.ctx.Err()}
+		}
+	}
 }

--- a/internal/conversationharness/runner.go
+++ b/internal/conversationharness/runner.go
@@ -1,0 +1,283 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package conversationharness coordinates scripted conversation timing for
+// local quality evaluation.
+package conversationharness
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/p-n-ai/pai-bot/internal/chat"
+)
+
+// Delivery describes how a learner message relates to unfinished tutor work.
+type Delivery string
+
+const (
+	// DeliveryWait waits for all earlier messages before starting the turn.
+	DeliveryWait Delivery = "wait"
+	// DeliveryQueue preserves unfinished earlier messages and appends the turn.
+	DeliveryQueue Delivery = "queue"
+	// DeliveryInterrupt suppresses unfinished earlier replies and replaces them.
+	DeliveryInterrupt Delivery = "interrupt"
+)
+
+// Status describes the caller-visible result of one scripted turn.
+type Status string
+
+const (
+	// StatusDelivered means the processor completed and its response is visible.
+	StatusDelivered Status = "delivered"
+	// StatusInterrupted means a newer turn suppressed the response.
+	StatusInterrupted Status = "interrupted"
+	// StatusFailed means the processor or its turn context failed.
+	StatusFailed Status = "failed"
+)
+
+// Processor handles one learner message. It must stop when ctx is canceled.
+type Processor func(ctx context.Context, message chat.InboundMessage) (string, error)
+
+// Turn is one timed learner message in a scripted conversation.
+type Turn struct {
+	Message  chat.InboundMessage
+	Delivery Delivery
+	After    time.Duration
+	Timeout  time.Duration
+}
+
+// Outcome records the caller-visible result of one scripted turn.
+type Outcome struct {
+	Status   Status
+	Response string
+	Err      error
+	Duration time.Duration
+}
+
+type processResult struct {
+	response   string
+	err        error
+	contextErr error
+	duration   time.Duration
+}
+
+type runningTurn struct {
+	index       int
+	cancel      context.CancelFunc
+	done        <-chan processResult
+	interrupted bool
+}
+
+type coordinator struct {
+	ctx      context.Context
+	process  Processor
+	turns    []Turn
+	outcomes []Outcome
+	current  *runningTurn
+	pending  []int
+}
+
+// Run processes turns according to their wait, queue, and interrupt semantics.
+// It returns outcomes in fixture order and does not leave processor work running.
+func Run(ctx context.Context, process Processor, turns []Turn) ([]Outcome, error) {
+	if ctx == nil {
+		return nil, errors.New("context is required")
+	}
+	if process == nil {
+		return nil, errors.New("processor is required")
+	}
+	if err := validateTurns(turns); err != nil {
+		return nil, err
+	}
+
+	c := coordinator{
+		ctx:      ctx,
+		process:  process,
+		turns:    turns,
+		outcomes: make([]Outcome, len(turns)),
+	}
+	for index, turn := range turns {
+		if err := c.waitDelay(turn.After); err != nil {
+			c.stop()
+			return c.outcomes, err
+		}
+		switch normalizedDelivery(turn.Delivery) {
+		case DeliveryWait:
+			if err := c.drain(); err != nil {
+				c.stop()
+				return c.outcomes, err
+			}
+		case DeliveryInterrupt:
+			if err := c.interrupt(); err != nil {
+				c.stop()
+				return c.outcomes, err
+			}
+		case DeliveryQueue:
+		}
+		c.submit(index)
+	}
+	if err := c.drain(); err != nil {
+		c.stop()
+		return c.outcomes, err
+	}
+	return c.outcomes, nil
+}
+
+func validateTurns(turns []Turn) error {
+	for index, turn := range turns {
+		switch normalizedDelivery(turn.Delivery) {
+		case DeliveryWait, DeliveryQueue, DeliveryInterrupt:
+		default:
+			return fmt.Errorf("turn %d: unsupported delivery %q", index+1, turn.Delivery)
+		}
+		if turn.After < 0 {
+			return fmt.Errorf("turn %d: after must not be negative", index+1)
+		}
+		if turn.Timeout <= 0 {
+			return fmt.Errorf("turn %d: timeout must be positive", index+1)
+		}
+	}
+	return nil
+}
+
+func normalizedDelivery(delivery Delivery) Delivery {
+	if delivery == "" {
+		return DeliveryWait
+	}
+	return delivery
+}
+
+func (c *coordinator) submit(index int) {
+	if c.current != nil {
+		c.pending = append(c.pending, index)
+		return
+	}
+	c.start(index)
+}
+
+func (c *coordinator) start(index int) {
+	turn := c.turns[index]
+	turnCtx, cancel := context.WithTimeout(c.ctx, turn.Timeout)
+	done := make(chan processResult, 1)
+	startedAt := time.Now()
+	go func() {
+		response, err := c.process(turnCtx, turn.Message)
+		done <- processResult{
+			response:   response,
+			err:        err,
+			contextErr: turnCtx.Err(),
+			duration:   time.Since(startedAt),
+		}
+	}()
+	c.current = &runningTurn{
+		index:  index,
+		cancel: cancel,
+		done:   done,
+	}
+}
+
+func (c *coordinator) waitDelay(delay time.Duration) error {
+	if delay == 0 {
+		return nil
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	for {
+		if c.current == nil {
+			select {
+			case <-timer.C:
+				return nil
+			case <-c.ctx.Done():
+				return c.ctx.Err()
+			}
+		}
+		select {
+		case result := <-c.current.done:
+			c.finishCurrent(result)
+		case <-timer.C:
+			return nil
+		case <-c.ctx.Done():
+			return c.ctx.Err()
+		}
+	}
+}
+
+func (c *coordinator) drain() error {
+	for c.current != nil {
+		select {
+		case result := <-c.current.done:
+			c.finishCurrent(result)
+		case <-c.ctx.Done():
+			return c.ctx.Err()
+		}
+	}
+	return nil
+}
+
+func (c *coordinator) interrupt() error {
+	for _, index := range c.pending {
+		c.outcomes[index] = Outcome{Status: StatusInterrupted}
+	}
+	c.pending = nil
+	if c.current == nil {
+		return nil
+	}
+	c.current.interrupted = true
+	c.current.cancel()
+	select {
+	case result := <-c.current.done:
+		c.finishCurrent(result)
+		return nil
+	case <-c.ctx.Done():
+		return c.ctx.Err()
+	}
+}
+
+func (c *coordinator) finishCurrent(result processResult) {
+	current := c.current
+	current.cancel()
+	outcome := Outcome{
+		Response: result.response,
+		Err:      result.err,
+		Duration: result.duration,
+	}
+	switch {
+	case current.interrupted:
+		outcome.Status = StatusInterrupted
+		outcome.Response = ""
+		outcome.Err = nil
+	case result.contextErr != nil:
+		outcome.Status = StatusFailed
+		outcome.Response = ""
+		outcome.Err = result.contextErr
+	case result.err != nil:
+		outcome.Status = StatusFailed
+		outcome.Response = ""
+	default:
+		outcome.Status = StatusDelivered
+	}
+	c.outcomes[current.index] = outcome
+	c.current = nil
+	if len(c.pending) == 0 {
+		return
+	}
+	next := c.pending[0]
+	c.pending = c.pending[1:]
+	c.start(next)
+}
+
+func (c *coordinator) stop() {
+	for _, index := range c.pending {
+		c.outcomes[index] = Outcome{Status: StatusFailed, Err: c.ctx.Err()}
+	}
+	c.pending = nil
+	if c.current == nil {
+		return
+	}
+	c.current.cancel()
+	result := <-c.current.done
+	c.finishCurrent(result)
+}

--- a/internal/conversationharness/runner_test.go
+++ b/internal/conversationharness/runner_test.go
@@ -1,0 +1,245 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package conversationharness
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/p-n-ai/pai-bot/internal/chat"
+)
+
+func TestRunQueuesMessagesBehindInFlightTurn(t *testing.T) {
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	secondStarted := make(chan struct{})
+	var once sync.Once
+
+	done := make(chan struct{})
+	var outcomes []Outcome
+	var runErr error
+	go func() {
+		outcomes, runErr = Run(t.Context(), func(_ context.Context, message chat.InboundMessage) (string, error) {
+			switch message.Text {
+			case "first":
+				close(firstStarted)
+				<-releaseFirst
+			case "second":
+				once.Do(func() { close(secondStarted) })
+			}
+			return "reply:" + message.Text, nil
+		}, []Turn{
+			scriptedTurn("first", DeliveryWait),
+			scriptedTurn("second", DeliveryQueue),
+		})
+		close(done)
+	}()
+
+	select {
+	case <-firstStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first turn did not start")
+	}
+	select {
+	case <-secondStarted:
+		t.Fatal("queued turn started before the in-flight turn completed")
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(releaseFirst)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run() did not finish")
+	}
+	if runErr != nil {
+		t.Fatalf("Run() error = %v", runErr)
+	}
+	assertOutcome(t, outcomes[0], StatusDelivered, "reply:first")
+	assertOutcome(t, outcomes[1], StatusDelivered, "reply:second")
+}
+
+func TestRunInterruptsInFlightAndQueuedReplies(t *testing.T) {
+	processed := make(chan string, 3)
+	outcomes, err := Run(t.Context(), func(ctx context.Context, message chat.InboundMessage) (string, error) {
+		processed <- message.Text
+		if message.Text == "long request" {
+			<-ctx.Done()
+			return "", ctx.Err()
+		}
+		return "reply:" + message.Text, nil
+	}, []Turn{
+		scriptedTurn("long request", DeliveryWait),
+		scriptedTurn("stale follow-up", DeliveryQueue),
+		scriptedTurn("actually, this", DeliveryInterrupt),
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	assertOutcome(t, outcomes[0], StatusInterrupted, "")
+	assertOutcome(t, outcomes[1], StatusInterrupted, "")
+	assertOutcome(t, outcomes[2], StatusDelivered, "reply:actually, this")
+	close(processed)
+	var got []string
+	for text := range processed {
+		got = append(got, text)
+	}
+	if len(got) != 2 || got[0] != "long request" || got[1] != "actually, this" {
+		t.Fatalf("processed messages = %#v, want interrupted request then replacement", got)
+	}
+}
+
+func TestRunHonorsDelayBeforeStartingQueuedTurn(t *testing.T) {
+	const delay = 40 * time.Millisecond
+	startedAt := time.Now()
+	var secondStartedAfter time.Duration
+
+	outcomes, err := Run(t.Context(), func(_ context.Context, message chat.InboundMessage) (string, error) {
+		if message.Text == "second" {
+			secondStartedAfter = time.Since(startedAt)
+		}
+		return "reply:" + message.Text, nil
+	}, []Turn{
+		scriptedTurn("first", DeliveryWait),
+		{
+			Message:  chat.InboundMessage{Text: "second"},
+			Delivery: DeliveryQueue,
+			After:    delay,
+			Timeout:  time.Second,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if secondStartedAfter < delay {
+		t.Fatalf("queued turn started after %v, want at least %v", secondStartedAfter, delay)
+	}
+	assertOutcome(t, outcomes[0], StatusDelivered, "reply:first")
+	assertOutcome(t, outcomes[1], StatusDelivered, "reply:second")
+}
+
+func TestRunHonorsDelayBeforeInterruptingTurn(t *testing.T) {
+	const delay = 40 * time.Millisecond
+	startedAt := time.Now()
+	var replacementStartedAfter time.Duration
+
+	outcomes, err := Run(t.Context(), func(ctx context.Context, message chat.InboundMessage) (string, error) {
+		if message.Text == "first" {
+			<-ctx.Done()
+			return "", ctx.Err()
+		}
+		replacementStartedAfter = time.Since(startedAt)
+		return "reply:" + message.Text, nil
+	}, []Turn{
+		scriptedTurn("first", DeliveryWait),
+		{
+			Message:  chat.InboundMessage{Text: "replacement"},
+			Delivery: DeliveryInterrupt,
+			After:    delay,
+			Timeout:  time.Second,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if replacementStartedAfter < delay {
+		t.Fatalf("replacement started after %v, want at least %v", replacementStartedAfter, delay)
+	}
+	assertOutcome(t, outcomes[0], StatusInterrupted, "")
+	assertOutcome(t, outcomes[1], StatusDelivered, "reply:replacement")
+}
+
+func TestRunFailsTurnWhenProcessorExceedsTimeout(t *testing.T) {
+	outcomes, err := Run(t.Context(), func(ctx context.Context, _ chat.InboundMessage) (string, error) {
+		<-ctx.Done()
+		return "late fallback", nil
+	}, []Turn{{
+		Message:  chat.InboundMessage{Text: "slow"},
+		Delivery: DeliveryWait,
+		Timeout:  10 * time.Millisecond,
+	}})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if outcomes[0].Status != StatusFailed {
+		t.Fatalf("status = %q, want %q", outcomes[0].Status, StatusFailed)
+	}
+	if !errors.Is(outcomes[0].Err, context.DeadlineExceeded) {
+		t.Fatalf("error = %v, want deadline exceeded", outcomes[0].Err)
+	}
+	if outcomes[0].Response != "" {
+		t.Fatalf("timed out response was exposed: %q", outcomes[0].Response)
+	}
+}
+
+func TestRunWaitsForProcessorAfterParentCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	started := make(chan struct{})
+	stopped := make(chan struct{})
+	runDone := make(chan error, 1)
+	go func() {
+		_, err := Run(ctx, func(ctx context.Context, _ chat.InboundMessage) (string, error) {
+			close(started)
+			<-ctx.Done()
+			close(stopped)
+			return "", ctx.Err()
+		}, []Turn{scriptedTurn("cancel me", DeliveryWait)})
+		runDone <- err
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("processor did not start")
+	}
+	cancel()
+	select {
+	case err := <-runDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Run() error = %v, want context canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Run() did not stop after parent cancellation")
+	}
+	select {
+	case <-stopped:
+	default:
+		t.Fatal("Run() returned before the processor stopped")
+	}
+}
+
+func TestRunRejectsInvalidTurnsBeforeProcessing(t *testing.T) {
+	calls := 0
+	_, err := Run(t.Context(), func(context.Context, chat.InboundMessage) (string, error) {
+		calls++
+		return "", nil
+	}, []Turn{{
+		Delivery: "later",
+		Timeout:  time.Second,
+	}})
+	if err == nil {
+		t.Fatal("Run() should reject unsupported delivery")
+	}
+	if calls != 0 {
+		t.Fatalf("processor calls = %d, want 0", calls)
+	}
+}
+
+func scriptedTurn(text string, delivery Delivery) Turn {
+	return Turn{
+		Message:  chat.InboundMessage{Text: text},
+		Delivery: delivery,
+		Timeout:  time.Second,
+	}
+}
+
+func assertOutcome(t *testing.T, outcome Outcome, status Status, response string) {
+	t.Helper()
+	if outcome.Status != status || outcome.Response != response {
+		t.Fatalf("outcome = %#v, want status %q response %q", outcome, status, response)
+	}
+}

--- a/internal/conversationharness/runner_test.go
+++ b/internal/conversationharness/runner_test.go
@@ -6,6 +6,7 @@ package conversationharness
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -90,6 +91,143 @@ func TestRunInterruptsInFlightAndQueuedReplies(t *testing.T) {
 	}
 	if len(got) != 2 || got[0] != "long request" || got[1] != "actually, this" {
 		t.Fatalf("processed messages = %#v, want interrupted request then replacement", got)
+	}
+}
+
+func TestRunContinuesQueuedTurnsAfterProcessorFailure(t *testing.T) {
+	processErr := errors.New("processor failed")
+	var processed []string
+
+	outcomes, err := Run(t.Context(), func(_ context.Context, message chat.InboundMessage) (string, error) {
+		processed = append(processed, message.Text)
+		if message.Text == "first" {
+			return "unsafe partial response", processErr
+		}
+		return "reply:" + message.Text, nil
+	}, []Turn{
+		scriptedTurn("first", DeliveryWait),
+		scriptedTurn("second", DeliveryQueue),
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(processed) != 2 || processed[0] != "first" || processed[1] != "second" {
+		t.Fatalf("processed messages = %#v, want first then second", processed)
+	}
+	if outcomes[0].Status != StatusFailed || !errors.Is(outcomes[0].Err, processErr) {
+		t.Fatalf("first outcome = %#v, want failed processor error", outcomes[0])
+	}
+	if outcomes[0].Response != "" {
+		t.Fatalf("failed response was exposed: %q", outcomes[0].Response)
+	}
+	assertOutcome(t, outcomes[1], StatusDelivered, "reply:second")
+}
+
+func TestRunFailsQueuedTurnsWhenParentIsCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	started := make(chan struct{})
+	processed := make(chan string, 2)
+	runDone := make(chan struct {
+		outcomes []Outcome
+		err      error
+	}, 1)
+
+	go func() {
+		outcomes, err := Run(ctx, func(ctx context.Context, message chat.InboundMessage) (string, error) {
+			processed <- message.Text
+			if message.Text == "first" {
+				close(started)
+				<-ctx.Done()
+				return "", ctx.Err()
+			}
+			return "unexpected", nil
+		}, []Turn{
+			scriptedTurn("first", DeliveryWait),
+			scriptedTurn("second", DeliveryQueue),
+		})
+		runDone <- struct {
+			outcomes []Outcome
+			err      error
+		}{outcomes: outcomes, err: err}
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("first turn did not start")
+	}
+	cancel()
+
+	var result struct {
+		outcomes []Outcome
+		err      error
+	}
+	select {
+	case result = <-runDone:
+	case <-time.After(time.Second):
+		t.Fatal("Run() did not stop after parent cancellation")
+	}
+	if !errors.Is(result.err, context.Canceled) {
+		t.Fatalf("Run() error = %v, want context canceled", result.err)
+	}
+	if len(result.outcomes) != 2 {
+		t.Fatalf("outcomes = %d, want 2", len(result.outcomes))
+	}
+	for index, outcome := range result.outcomes {
+		if outcome.Status != StatusFailed || !errors.Is(outcome.Err, context.Canceled) {
+			t.Fatalf("outcome %d = %#v, want failed context cancellation", index+1, outcome)
+		}
+	}
+	close(processed)
+	var got []string
+	for message := range processed {
+		got = append(got, message)
+	}
+	if len(got) != 1 || got[0] != "first" {
+		t.Fatalf("processed messages = %#v, queued turn should not start", got)
+	}
+}
+
+func TestRunFailsTurnCanceledBeforeScheduledStart(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	calls := 0
+
+	outcomes, err := Run(ctx, func(context.Context, chat.InboundMessage) (string, error) {
+		calls++
+		return "unexpected", nil
+	}, []Turn{{
+		Message: chat.InboundMessage{Text: "later"},
+		After:   time.Hour,
+		Timeout: time.Second,
+	}})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run() error = %v, want context canceled", err)
+	}
+	if calls != 0 {
+		t.Fatalf("processor calls = %d, want 0", calls)
+	}
+	if len(outcomes) != 1 ||
+		outcomes[0].Status != StatusFailed ||
+		!errors.Is(outcomes[0].Err, context.Canceled) {
+		t.Fatalf("outcomes = %#v, want one failed canceled turn", outcomes)
+	}
+}
+
+func TestRunWithNoTurnsReturnsEmptyOutcomes(t *testing.T) {
+	calls := 0
+	outcomes, err := Run(t.Context(), func(context.Context, chat.InboundMessage) (string, error) {
+		calls++
+		return "unexpected", nil
+	}, nil)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(outcomes) != 0 {
+		t.Fatalf("outcomes = %#v, want empty", outcomes)
+	}
+	if calls != 0 {
+		t.Fatalf("processor calls = %d, want 0", calls)
 	}
 }
 
@@ -213,19 +351,43 @@ func TestRunWaitsForProcessorAfterParentCancellation(t *testing.T) {
 }
 
 func TestRunRejectsInvalidTurnsBeforeProcessing(t *testing.T) {
-	calls := 0
-	_, err := Run(t.Context(), func(context.Context, chat.InboundMessage) (string, error) {
-		calls++
-		return "", nil
-	}, []Turn{{
-		Delivery: "later",
-		Timeout:  time.Second,
-	}})
-	if err == nil {
-		t.Fatal("Run() should reject unsupported delivery")
-	}
-	if calls != 0 {
-		t.Fatalf("processor calls = %d, want 0", calls)
+	for _, test := range []struct {
+		name string
+		turn Turn
+		want string
+	}{
+		{
+			name: "unsupported delivery",
+			turn: Turn{Delivery: "later", Timeout: time.Second},
+			want: `unsupported delivery "later"`,
+		},
+		{
+			name: "negative delay",
+			turn: Turn{After: -time.Millisecond, Timeout: time.Second},
+			want: "after must not be negative",
+		},
+		{
+			name: "zero timeout",
+			turn: Turn{Timeout: 0},
+			want: "timeout must be positive",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			calls := 0
+			_, err := Run(t.Context(), func(context.Context, chat.InboundMessage) (string, error) {
+				calls++
+				return "", nil
+			}, []Turn{test.turn})
+			if err == nil {
+				t.Fatal("Run() should reject an invalid turn")
+			}
+			if !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Run() error = %q, want %q", err, test.want)
+			}
+			if calls != 0 {
+				t.Fatalf("processor calls = %d, want 0", calls)
+			}
+		})
 	}
 }
 

--- a/internal/platform/airouter/setup.go
+++ b/internal/platform/airouter/setup.go
@@ -85,6 +85,28 @@ func PrepareWithCodexAuth(cfg config.AIConfig, codexAuth ai.CodexAppServerClient
 	return Plan{registrations: regs}, preferredErr
 }
 
+// PrepareProviderWithCodexAuth constructs a plan containing only the selected
+// provider. It is intended for operator tools that must never fall back to a
+// different configured provider.
+func PrepareProviderWithCodexAuth(
+	name string,
+	cfg config.AIConfig,
+	codexAuth ai.CodexAppServerClient,
+) (Plan, error) {
+	name = strings.ToLower(strings.TrimSpace(name))
+	if !knownProvider(name) {
+		return Plan{}, fmt.Errorf("unsupported AI provider %q", name)
+	}
+	registration, configured, err := buildProviderChecked(name, cfg, codexAuth)
+	if err != nil {
+		return Plan{}, fmt.Errorf("provider %q is not available: %w", name, err)
+	}
+	if !configured {
+		return Plan{}, fmt.Errorf("provider %q is not configured", name)
+	}
+	return Plan{registrations: []ai.ProviderRegistration{registration}}, nil
+}
+
 // WouldRegister reports whether Apply would register provider name under cfg.
 func WouldRegister(name string, cfg config.AIConfig) bool {
 	_, ok := buildProvider(name, cfg)
@@ -215,4 +237,13 @@ func providerOrder(preferred string) []string {
 		order = append(order, candidate)
 	}
 	return order
+}
+
+func knownProvider(name string) bool {
+	for _, candidate := range ProviderNames() {
+		if name == candidate {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/platform/airouter/setup_test.go
+++ b/internal/platform/airouter/setup_test.go
@@ -268,3 +268,37 @@ func TestPrepareRejectsUnconfiguredPreferredProvider(t *testing.T) {
 		t.Fatalf("prepared fallback providers = %v, want [openrouter]", got)
 	}
 }
+
+func TestPrepareProviderRegistersOnlySelectedProvider(t *testing.T) {
+	cfg := config.AIConfig{
+		OpenAI: config.OpenAIConfig{APIKey: "fallback-key"},
+		Codex: config.CodexConfig{
+			Enabled: true,
+			Model:   "gpt-test",
+		},
+	}
+
+	plan, err := PrepareProviderWithCodexAuth(" CODEX ", cfg, stubCodexAuth{})
+	if err != nil {
+		t.Fatalf("PrepareProviderWithCodexAuth() error = %v", err)
+	}
+	router := ai.NewRouter()
+	plan.Apply(router)
+	if got := router.ProviderOrder(); !reflect.DeepEqual(got, []string{"codex"}) {
+		t.Fatalf("ProviderOrder() = %v, want [codex] without fallback", got)
+	}
+}
+
+func TestPrepareProviderRejectsUnavailableSelection(t *testing.T) {
+	cfg := config.AIConfig{
+		OpenAI: config.OpenAIConfig{APIKey: "fallback-key"},
+		Codex:  config.CodexConfig{Enabled: true},
+	}
+
+	if _, err := PrepareProviderWithCodexAuth("codex", cfg, nil); err == nil {
+		t.Fatal("PrepareProviderWithCodexAuth() error = nil, want unavailable Codex")
+	}
+	if _, err := PrepareProviderWithCodexAuth("unknown", cfg, nil); err == nil {
+		t.Fatal("PrepareProviderWithCodexAuth() error = nil, want unsupported provider")
+	}
+}

--- a/internal/terminalchat/candidate.go
+++ b/internal/terminalchat/candidate.go
@@ -1,0 +1,225 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalchat
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/p-n-ai/pai-bot/internal/i18n"
+)
+
+const (
+	candidateFilename         = "candidate.yaml"
+	candidateSnapshotAttempts = 3
+)
+
+// Character is one stable learner identity available to an interactive chat.
+type Character struct {
+	ID        string `yaml:"id"`
+	FirstName string `yaml:"first_name"`
+	Username  string `yaml:"username"`
+	Language  string `yaml:"language"`
+}
+
+// Candidate is one immutable prompt and learner-character snapshot.
+type Candidate struct {
+	Prompt             string
+	Hash               string
+	DefaultCharacterID string
+	Characters         []Character
+}
+
+// Character returns the named character from the snapshot.
+func (c Candidate) Character(id string) (Character, bool) {
+	id = strings.TrimSpace(id)
+	for _, character := range c.Characters {
+		if character.ID == id {
+			return character, true
+		}
+	}
+	return Character{}, false
+}
+
+// DefaultCharacter returns the snapshot's selected character.
+func (c Candidate) DefaultCharacter() Character {
+	character, ok := c.Character(c.DefaultCharacterID)
+	if ok {
+		return character
+	}
+	return Character{ID: "default"}
+}
+
+// CandidateSource loads candidate.yaml from one local directory.
+type CandidateSource struct {
+	directory string
+	readFile  func(string) ([]byte, error)
+}
+
+// NewCandidateSource creates a local candidate source. A missing or empty
+// directory uses the built-in prompt and default learner until files appear.
+func NewCandidateSource(directory string) CandidateSource {
+	return CandidateSource{
+		directory: strings.TrimSpace(directory),
+		readFile:  os.ReadFile,
+	}
+}
+
+// Load parses one complete candidate. Invalid changes never produce a partial
+// snapshot.
+func (s CandidateSource) Load() (Candidate, error) {
+	if s.directory == "" {
+		return builtInCandidate(), nil
+	}
+	readFile := s.readFile
+	if readFile == nil {
+		readFile = os.ReadFile
+	}
+	for range candidateSnapshotAttempts {
+		first, firstExists, err := readCandidateFile(readFile, filepath.Join(s.directory, candidateFilename))
+		if err != nil {
+			return Candidate{}, err
+		}
+		second, secondExists, err := readCandidateFile(readFile, filepath.Join(s.directory, candidateFilename))
+		if err != nil {
+			return Candidate{}, err
+		}
+		if firstExists == secondExists && bytes.Equal(first, second) {
+			return candidateFromFile(second, secondExists)
+		}
+	}
+	return Candidate{}, errors.New("candidate file changed while loading; try /reload again")
+}
+
+func candidateFromFile(data []byte, exists bool) (Candidate, error) {
+	if !exists {
+		return builtInCandidate(), nil
+	}
+	document, err := parseCandidate(data)
+	if err != nil {
+		return Candidate{}, fmt.Errorf("parse %s: %w", candidateFilename, err)
+	}
+	return Candidate{
+		Prompt:             strings.TrimSpace(document.Prompt),
+		Hash:               hashCandidate(data),
+		DefaultCharacterID: document.Default,
+		Characters:         document.Characters,
+	}, nil
+}
+
+// Changed reports whether the files now resolve to another valid snapshot.
+func (s CandidateSource) Changed(activeHash string) (bool, error) {
+	candidate, err := s.Load()
+	if err != nil {
+		return false, err
+	}
+	return candidate.Hash != activeHash, nil
+}
+
+type candidateFile struct {
+	Prompt     string      `yaml:"prompt"`
+	Default    string      `yaml:"default"`
+	Characters []Character `yaml:"characters"`
+}
+
+func parseCandidate(data []byte) (candidateFile, error) {
+	var document candidateFile
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&document); err != nil {
+		if errors.Is(err, io.EOF) {
+			document.Characters = []Character{{ID: "default"}}
+			document.Default = "default"
+			return document, nil
+		}
+		return candidateFile{}, err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return candidateFile{}, errors.New("multiple YAML documents are not supported")
+		}
+		return candidateFile{}, err
+	}
+
+	seen := make(map[string]struct{}, len(document.Characters))
+	characters := make([]Character, 0, len(document.Characters))
+	for index, character := range document.Characters {
+		character.ID = strings.TrimSpace(character.ID)
+		character.FirstName = strings.TrimSpace(character.FirstName)
+		character.Username = strings.TrimSpace(character.Username)
+		character.Language = strings.TrimSpace(character.Language)
+		if character.ID == "" {
+			return candidateFile{}, fmt.Errorf("character %d: id is required", index+1)
+		}
+		if _, exists := seen[character.ID]; exists {
+			return candidateFile{}, fmt.Errorf("duplicate character id %q", character.ID)
+		}
+		if character.Language != "" {
+			normalized := i18n.NormalizeLocale(character.Language)
+			if normalized == "" {
+				return candidateFile{}, fmt.Errorf("character %q: unsupported language %q", character.ID, character.Language)
+			}
+			character.Language = normalized
+		}
+		seen[character.ID] = struct{}{}
+		characters = append(characters, character)
+	}
+	if len(characters) == 0 {
+		characters = append(characters, Character{ID: "default"})
+	}
+
+	document.Default = strings.TrimSpace(document.Default)
+	if document.Default == "" {
+		document.Default = characters[0].ID
+	}
+	if _, exists := seen[document.Default]; !exists && document.Default != "default" {
+		return candidateFile{}, fmt.Errorf("default character %q is not defined", document.Default)
+	}
+	if document.Default == "default" && len(document.Characters) > 0 {
+		if _, exists := seen[document.Default]; !exists {
+			return candidateFile{}, fmt.Errorf("default character %q is not defined", document.Default)
+		}
+	}
+	document.Characters = characters
+	return document, nil
+}
+
+func readCandidateFile(readFile func(string) ([]byte, error), path string) ([]byte, bool, error) {
+	data, err := readFile(path)
+	if err == nil {
+		return data, true, nil
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, false, nil
+	}
+	return nil, false, fmt.Errorf("read %s: %w", filepath.Base(path), err)
+}
+
+func builtInCandidate() Candidate {
+	character := Character{ID: "default"}
+	return Candidate{
+		Hash:               hashCandidate(nil),
+		DefaultCharacterID: character.ID,
+		Characters:         []Character{character},
+	}
+}
+
+func hashCandidate(data []byte) string {
+	digest := sha256.New()
+	_, _ = digest.Write([]byte(candidateFilename))
+	_, _ = digest.Write([]byte{0})
+	_, _ = digest.Write(data)
+	return "sha256:" + hex.EncodeToString(digest.Sum(nil))
+}

--- a/internal/terminalchat/candidate_test.go
+++ b/internal/terminalchat/candidate_test.go
@@ -1,0 +1,185 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalchat
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCandidateSourceLoadsPromptAndCharacters(t *testing.T) {
+	directory := t.TempDir()
+	writeCandidateTestFile(t, directory, `prompt: Keep replies short.
+default: aina
+characters:
+  - id: aina
+    first_name: Aina
+    username: aina_student
+    language: EN
+  - id: faris
+    first_name: Faris
+    language: ms
+`)
+
+	candidate, err := NewCandidateSource(directory).Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if candidate.Prompt != "Keep replies short." {
+		t.Fatalf("Prompt = %q, want trimmed prompt", candidate.Prompt)
+	}
+	if !strings.HasPrefix(candidate.Hash, "sha256:") || len(candidate.Hash) != len("sha256:")+64 {
+		t.Fatalf("Hash = %q, want full SHA-256 identity", candidate.Hash)
+	}
+	if candidate.DefaultCharacterID != "aina" {
+		t.Fatalf("DefaultCharacterID = %q, want aina", candidate.DefaultCharacterID)
+	}
+	aina, ok := candidate.Character("aina")
+	if !ok {
+		t.Fatal("Character(aina) missing")
+	}
+	if aina.FirstName != "Aina" || aina.Username != "aina_student" || aina.Language != "en" {
+		t.Fatalf("Character(aina) = %#v, want normalized profile", aina)
+	}
+}
+
+func TestCandidateSourceRejectsUnknownCharacterField(t *testing.T) {
+	directory := t.TempDir()
+	writeCandidateTestFile(t, directory, `characters:
+  - id: aina
+    langauge: en
+`)
+
+	_, err := NewCandidateSource(directory).Load()
+	if err == nil || !strings.Contains(err.Error(), "field langauge not found") {
+		t.Fatalf("Load() error = %v, want strict unknown-field failure", err)
+	}
+}
+
+func TestCandidateSourceDetectsFileChanges(t *testing.T) {
+	directory := t.TempDir()
+	source := NewCandidateSource(directory)
+	initial, err := source.Load()
+	if err != nil {
+		t.Fatalf("initial Load() error = %v", err)
+	}
+	changed, err := source.Changed(initial.Hash)
+	if err != nil || changed {
+		t.Fatalf("Changed(initial) = %t, %v; want false, nil", changed, err)
+	}
+
+	writeCandidateTestFile(t, directory, "prompt: Try one question at a time.\n")
+	changed, err = source.Changed(initial.Hash)
+	if err != nil || !changed {
+		t.Fatalf("Changed(updated) = %t, %v; want true, nil", changed, err)
+	}
+}
+
+func TestCandidateSourceRetriesChangingFile(t *testing.T) {
+	reads := 0
+	source := CandidateSource{
+		directory: "/candidate",
+		readFile: func(path string) ([]byte, error) {
+			if filepath.Base(path) != candidateFilename {
+				return nil, os.ErrNotExist
+			}
+			reads++
+			if reads == 1 {
+				return []byte("prompt: old prompt\n"), nil
+			}
+			return []byte("prompt: new prompt\n"), nil
+		},
+	}
+
+	candidate, err := source.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if candidate.Prompt != "new prompt" {
+		t.Fatalf("Prompt = %q, want stable new generation", candidate.Prompt)
+	}
+	if reads != 4 {
+		t.Fatalf("reads = %d, want one rejected pair and one stable pair", reads)
+	}
+}
+
+func TestCandidateSourceRejectsContinuouslyChangingFiles(t *testing.T) {
+	reads := 0
+	source := CandidateSource{
+		directory: "/candidate",
+		readFile: func(path string) ([]byte, error) {
+			if filepath.Base(path) == candidateFilename {
+				reads++
+				return []byte(fmt.Sprintf("prompt: prompt-%d\n", reads)), nil
+			}
+			return nil, os.ErrNotExist
+		},
+	}
+
+	_, err := source.Load()
+	if err == nil || !strings.Contains(err.Error(), "changed while loading") {
+		t.Fatalf("Load() error = %v, want unstable snapshot failure", err)
+	}
+}
+
+func TestCandidateSourceRejectsInvalidCharacterContracts(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name: "duplicate id",
+			content: `characters:
+  - id: aina
+  - id: aina
+`,
+			want: `duplicate character id "aina"`,
+		},
+		{
+			name: "undefined default",
+			content: `default: missing
+characters:
+  - id: aina
+`,
+			want: `default character "missing" is not defined`,
+		},
+		{
+			name: "unsupported language",
+			content: `characters:
+  - id: aina
+    language: klingon
+`,
+			want: `unsupported language "klingon"`,
+		},
+		{
+			name: "multiple documents",
+			content: `prompt: first
+---
+prompt: second
+`,
+			want: "multiple YAML documents are not supported",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			directory := t.TempDir()
+			writeCandidateTestFile(t, directory, test.content)
+
+			_, err := NewCandidateSource(directory).Load()
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Load() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func writeCandidateTestFile(t *testing.T, directory, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(directory, candidateFilename), []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", candidateFilename, err)
+	}
+}

--- a/internal/terminalchat/interactive.go
+++ b/internal/terminalchat/interactive.go
@@ -1,0 +1,422 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalchat
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/p-n-ai/pai-bot/internal/agent"
+	"github.com/p-n-ai/pai-bot/internal/chat"
+)
+
+const candidatePollInterval = 500 * time.Millisecond
+
+// InteractiveStatus is the safe, operator-visible state of a live chat.
+type InteractiveStatus struct {
+	Provider      string
+	Memory        bool
+	CharacterID   string
+	CandidateHash string
+}
+
+// InteractiveSession owns the swappable engine and candidate snapshot used by
+// RunInteractive.
+type InteractiveSession interface {
+	Processor
+	New(context.Context) (InteractiveStatus, error)
+	Reload(context.Context) (InteractiveStatus, error)
+	SelectCharacter(context.Context, string) (InteractiveStatus, error)
+	Status() InteractiveStatus
+	CandidateChanged() (bool, error)
+}
+
+// InteractiveConfig controls a queue-aware local terminal session.
+type InteractiveConfig struct {
+	UserID  string
+	Channel string
+}
+
+type interactiveInput struct {
+	text string
+	err  error
+	eof  bool
+}
+
+type interactiveResult struct {
+	result agent.TurnResult
+	err    error
+}
+
+type interactiveTurn struct {
+	cancel      context.CancelFunc
+	done        <-chan interactiveResult
+	interrupted bool
+}
+
+type interactiveControl struct {
+	name string
+	arg  string
+}
+
+// RunInteractive accepts input while a model turn is running. It serializes
+// turns, owns queue order, and drains canceled work before changing sessions.
+func RunInteractive(
+	ctx context.Context,
+	in io.Reader,
+	out io.Writer,
+	session InteractiveSession,
+	cfg InteractiveConfig,
+) error {
+	if ctx == nil {
+		return errors.New("context is required")
+	}
+	if in == nil {
+		return errors.New("input is required")
+	}
+	if out == nil {
+		return errors.New("output is required")
+	}
+	if session == nil {
+		return errors.New("interactive session is required")
+	}
+
+	userID := strings.TrimSpace(cfg.UserID)
+	if userID == "" {
+		userID = "terminal-user"
+	}
+	channel := strings.TrimSpace(cfg.Channel)
+	if channel == "" {
+		channel = "terminal"
+	}
+
+	scanCtx, stopScanner := context.WithCancel(ctx)
+	defer stopScanner()
+	inputs := make(chan interactiveInput, 1)
+	go scanInteractiveInput(scanCtx, in, inputs)
+
+	ticker := time.NewTicker(candidatePollInterval)
+	defer ticker.Stop()
+	if closer, ok := in.(io.Closer); ok {
+		defer func() { _ = closer.Close() }()
+	}
+
+	if _, err := fmt.Fprintln(out, "Interactive chat ready. Commands: /status, /new, /reload, /character <id>, /interrupt <message>, /exit."); err != nil {
+		return err
+	}
+	if err := writeInteractiveStatus(out, session.Status(), false, 0); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprint(out, "You> "); err != nil {
+		return err
+	}
+
+	var current *interactiveTurn
+	var pending []string
+	var control *interactiveControl
+	var inputClosed bool
+	var exiting bool
+	var candidateNotified bool
+	var candidateError string
+	ctxDone := ctx.Done()
+
+	startTurn := func(text string) {
+		turnCtx, cancel := context.WithCancel(ctx)
+		done := make(chan interactiveResult, 1)
+		go func() {
+			result, err := session.ProcessTurn(turnCtx, chat.InboundMessage{
+				Channel: channel,
+				UserID:  userID,
+				Text:    text,
+			})
+			done <- interactiveResult{result: result, err: err}
+		}()
+		current = &interactiveTurn{cancel: cancel, done: done}
+	}
+
+	runControl := func(command interactiveControl) error {
+		var (
+			status InteractiveStatus
+			err    error
+		)
+		switch command.name {
+		case "new":
+			status, err = session.New(ctx)
+			if err == nil {
+				_, err = fmt.Fprintln(out, "Session reset.")
+			}
+		case "reload":
+			status, err = session.Reload(ctx)
+			if err == nil {
+				candidateNotified = false
+				candidateError = ""
+				_, err = fmt.Fprintln(out, "Candidate reloaded into a fresh session.")
+			}
+		case "character":
+			status, err = session.SelectCharacter(ctx, command.arg)
+			if err == nil {
+				_, err = fmt.Fprintf(out, "Character selected: %s\n", status.CharacterID)
+			}
+		default:
+			return fmt.Errorf("unsupported control %q", command.name)
+		}
+		if err != nil {
+			return err
+		}
+		return writeInteractiveStatus(out, status, false, 0)
+	}
+
+	startNext := func() error {
+		if control != nil {
+			nextControl := *control
+			control = nil
+			if err := runControl(nextControl); err != nil {
+				if _, writeErr := fmt.Fprintf(out, "Error: %v\n", err); writeErr != nil {
+					return writeErr
+				}
+			}
+		}
+		if len(pending) > 0 {
+			next := pending[0]
+			pending = pending[1:]
+			startTurn(next)
+			return nil
+		}
+		if exiting || inputClosed {
+			_, err := fmt.Fprintln(out, "Session ended.")
+			return err
+		}
+		_, err := fmt.Fprint(out, "You> ")
+		return err
+	}
+
+	for {
+		var turnDone <-chan interactiveResult
+		if current != nil {
+			turnDone = current.done
+		}
+		select {
+		case <-ctxDone:
+			ctxDone = nil
+			exiting = true
+			pending = nil
+			control = nil
+			if current == nil {
+				_, _ = fmt.Fprintln(out, "\nSession ended.")
+				return nil
+			}
+			current.interrupted = true
+			current.cancel()
+
+		case input := <-inputs:
+			if input.err != nil {
+				if current != nil {
+					current.cancel()
+				}
+				return input.err
+			}
+			if input.eof {
+				inputClosed = true
+				if current == nil && len(pending) == 0 && control == nil {
+					_, _ = fmt.Fprintln(out, "\nSession ended.")
+					return nil
+				}
+				continue
+			}
+
+			text := strings.TrimSpace(input.text)
+			if text == "" {
+				continue
+			}
+			command, isCommand, commandErr := parseInteractiveCommand(text)
+			if commandErr != nil {
+				if _, err := fmt.Fprintf(out, "Error: %v\n", commandErr); err != nil {
+					return err
+				}
+				if current == nil {
+					if _, err := fmt.Fprint(out, "You> "); err != nil {
+						return err
+					}
+				}
+				continue
+			}
+			if isCommand {
+				switch command.name {
+				case "exit":
+					exiting = true
+					pending = nil
+					control = nil
+					if current == nil {
+						_, _ = fmt.Fprintln(out, "Session ended.")
+						return nil
+					}
+					current.interrupted = true
+					current.cancel()
+				case "status":
+					if err := writeInteractiveStatus(out, session.Status(), current != nil, len(pending)); err != nil {
+						return err
+					}
+					if current == nil {
+						if _, err := fmt.Fprint(out, "You> "); err != nil {
+							return err
+						}
+					}
+				case "interrupt":
+					pending = []string{command.arg}
+					control = nil
+					if current == nil {
+						startTurn(command.arg)
+						pending = nil
+					} else {
+						current.interrupted = true
+						current.cancel()
+					}
+				case "new", "reload", "character":
+					pending = nil
+					control = &command
+					if current == nil {
+						if err := startNext(); err != nil {
+							return err
+						}
+					} else {
+						current.interrupted = true
+						current.cancel()
+					}
+				}
+				continue
+			}
+
+			if current == nil {
+				startTurn(text)
+				continue
+			}
+			pending = append(pending, text)
+			if _, err := fmt.Fprintf(out, "[queued #%d]\n", len(pending)); err != nil {
+				return err
+			}
+
+		case result := <-turnDone:
+			finished := current
+			current = nil
+			finished.cancel()
+			if finished.interrupted {
+				if !exiting {
+					if _, err := fmt.Fprintln(out, "[interrupted]"); err != nil {
+						return err
+					}
+				}
+			} else if result.err != nil {
+				if _, err := fmt.Fprintf(out, "Error: %v\n", result.err); err != nil {
+					return err
+				}
+			} else if err := writeTurn(out, "", result.result); err != nil {
+				return err
+			}
+			if exiting {
+				_, _ = fmt.Fprintln(out, "Session ended.")
+				return nil
+			}
+			if err := startNext(); err != nil {
+				return err
+			}
+			if current == nil && inputClosed {
+				return nil
+			}
+
+		case <-ticker.C:
+			changed, err := session.CandidateChanged()
+			if err != nil {
+				if message := err.Error(); message != candidateError {
+					candidateError = message
+					if _, writeErr := fmt.Fprintf(out, "Candidate invalid: %v\n", err); writeErr != nil {
+						return writeErr
+					}
+				}
+				continue
+			}
+			candidateError = ""
+			if changed && !candidateNotified {
+				candidateNotified = true
+				if _, err := fmt.Fprintln(out, "Candidate changed; type /reload to apply."); err != nil {
+					return err
+				}
+			}
+			if !changed {
+				candidateNotified = false
+			}
+		}
+	}
+}
+
+func scanInteractiveInput(ctx context.Context, in io.Reader, inputs chan<- interactiveInput) {
+	scanner := bufio.NewScanner(in)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		select {
+		case inputs <- interactiveInput{text: scanner.Text()}:
+		case <-ctx.Done():
+			return
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		select {
+		case inputs <- interactiveInput{err: err}:
+		case <-ctx.Done():
+		}
+		return
+	}
+	select {
+	case inputs <- interactiveInput{eof: true}:
+	case <-ctx.Done():
+	}
+}
+
+func parseInteractiveCommand(text string) (interactiveControl, bool, error) {
+	if !strings.HasPrefix(text, "/") {
+		return interactiveControl{}, false, nil
+	}
+	name, arg, _ := strings.Cut(strings.TrimPrefix(text, "/"), " ")
+	name = strings.ToLower(strings.TrimSpace(name))
+	arg = strings.TrimSpace(arg)
+	switch name {
+	case "exit", "quit":
+		return interactiveControl{name: "exit"}, true, nil
+	case "status", "new", "reload":
+		if arg != "" {
+			return interactiveControl{}, true, fmt.Errorf("/%s does not accept arguments", name)
+		}
+		return interactiveControl{name: name}, true, nil
+	case "character":
+		if arg == "" {
+			return interactiveControl{}, true, errors.New("usage: /character <id>")
+		}
+		return interactiveControl{name: name, arg: arg}, true, nil
+	case "interrupt":
+		if arg == "" {
+			return interactiveControl{}, true, errors.New("usage: /interrupt <message>")
+		}
+		return interactiveControl{name: name, arg: arg}, true, nil
+	default:
+		return interactiveControl{}, false, nil
+	}
+}
+
+func writeInteractiveStatus(out io.Writer, status InteractiveStatus, active bool, queued int) error {
+	_, err := fmt.Fprintf(
+		out,
+		"Status: provider=%s memory=%t character=%s prompt=%s active=%t queued=%d\n",
+		status.Provider,
+		status.Memory,
+		status.CharacterID,
+		status.CandidateHash,
+		active,
+		queued,
+	)
+	return err
+}

--- a/internal/terminalchat/interactive_test.go
+++ b/internal/terminalchat/interactive_test.go
@@ -1,0 +1,322 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalchat
+
+import (
+	"context"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/p-n-ai/pai-bot/internal/agent"
+	"github.com/p-n-ai/pai-bot/internal/chat"
+)
+
+type stubInteractiveSession struct {
+	mu      sync.Mutex
+	process func(context.Context, chat.InboundMessage) (agent.TurnResult, error)
+	reload  func(context.Context) (InteractiveStatus, error)
+	status  InteractiveStatus
+}
+
+func (s *stubInteractiveSession) ProcessTurn(ctx context.Context, msg chat.InboundMessage) (agent.TurnResult, error) {
+	return s.process(ctx, msg)
+}
+
+func (s *stubInteractiveSession) New(context.Context) (InteractiveStatus, error) {
+	return s.Status(), nil
+}
+
+func (s *stubInteractiveSession) Reload(ctx context.Context) (InteractiveStatus, error) {
+	if s.reload != nil {
+		return s.reload(ctx)
+	}
+	return s.Status(), nil
+}
+
+func (s *stubInteractiveSession) SelectCharacter(_ context.Context, id string) (InteractiveStatus, error) {
+	s.mu.Lock()
+	s.status.CharacterID = id
+	status := s.status
+	s.mu.Unlock()
+	return status, nil
+}
+
+func (s *stubInteractiveSession) Status() InteractiveStatus {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.status
+}
+
+func (*stubInteractiveSession) CandidateChanged() (bool, error) {
+	return false, nil
+}
+
+func TestRunInteractiveQueuesMessagesFIFO(t *testing.T) {
+	reader, writer := io.Pipe()
+	defer func() { _ = reader.Close() }()
+	started := make(chan string, 3)
+	releaseFirst := make(chan struct{})
+	session := &stubInteractiveSession{
+		status: InteractiveStatus{
+			Provider:      "codex",
+			Memory:        true,
+			CharacterID:   "default",
+			CandidateHash: "sha256:test",
+		},
+		process: func(_ context.Context, msg chat.InboundMessage) (agent.TurnResult, error) {
+			started <- msg.Text
+			if msg.Text == "first" {
+				<-releaseFirst
+			}
+			return agent.TurnResult{Text: "reply:" + msg.Text}, nil
+		},
+	}
+	var output strings.Builder
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- RunInteractive(t.Context(), reader, &output, session, InteractiveConfig{})
+	}()
+
+	writeInteractiveTestLine(t, writer, "first")
+	requireInteractiveTestValue(t, started, "first")
+	writeInteractiveTestLine(t, writer, "second")
+	writeInteractiveTestLine(t, writer, "third")
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close input: %v", err)
+	}
+
+	select {
+	case got := <-started:
+		t.Fatalf("queued turn %q started before first completed", got)
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(releaseFirst)
+	requireInteractiveTestValue(t, started, "second")
+	requireInteractiveTestValue(t, started, "third")
+	requireInteractiveTestDone(t, runDone)
+
+	rendered := output.String()
+	for _, want := range []string{
+		"[queued #1]",
+		"[queued #2]",
+		"P&AI> reply:first",
+		"P&AI> reply:second",
+		"P&AI> reply:third",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("output = %q, want %q", rendered, want)
+		}
+	}
+	if strings.Index(rendered, "reply:first") > strings.Index(rendered, "reply:second") ||
+		strings.Index(rendered, "reply:second") > strings.Index(rendered, "reply:third") {
+		t.Fatalf("output replies are not FIFO: %q", rendered)
+	}
+}
+
+func TestRunInteractiveInterruptSuppressesStaleReply(t *testing.T) {
+	reader, writer := io.Pipe()
+	defer func() { _ = reader.Close() }()
+	firstStarted := make(chan struct{})
+	firstCanceled := make(chan struct{})
+	session := &stubInteractiveSession{
+		status: InteractiveStatus{
+			Provider:      "codex",
+			Memory:        true,
+			CharacterID:   "default",
+			CandidateHash: "sha256:test",
+		},
+		process: func(ctx context.Context, msg chat.InboundMessage) (agent.TurnResult, error) {
+			if msg.Text == "long answer" {
+				close(firstStarted)
+				<-ctx.Done()
+				close(firstCanceled)
+				return agent.TurnResult{Text: "stale reply"}, nil
+			}
+			return agent.TurnResult{Text: "fresh reply"}, nil
+		},
+	}
+	var output strings.Builder
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- RunInteractive(t.Context(), reader, &output, session, InteractiveConfig{})
+	}()
+
+	writeInteractiveTestLine(t, writer, "long answer")
+	requireInteractiveTestSignal(t, firstStarted, "first turn did not start")
+	writeInteractiveTestLine(t, writer, "/interrupt actually, be brief")
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close input: %v", err)
+	}
+	requireInteractiveTestSignal(t, firstCanceled, "first turn was not canceled")
+	requireInteractiveTestDone(t, runDone)
+
+	rendered := output.String()
+	if strings.Contains(rendered, "stale reply") {
+		t.Fatalf("interrupted response leaked: %q", rendered)
+	}
+	if !strings.Contains(rendered, "[interrupted]") || !strings.Contains(rendered, "P&AI> fresh reply") {
+		t.Fatalf("output = %q, want interruption marker and fresh replacement", rendered)
+	}
+}
+
+func TestRunInteractiveReloadDrainsActiveTurnAndDropsQueue(t *testing.T) {
+	reader, writer := io.Pipe()
+	defer func() { _ = reader.Close() }()
+	firstStarted := make(chan struct{})
+	firstCanceled := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	reloadCalled := make(chan struct{})
+	processed := make(chan string, 3)
+	session := &stubInteractiveSession{
+		status: InteractiveStatus{
+			Provider:      "codex",
+			Memory:        true,
+			CharacterID:   "default",
+			CandidateHash: "sha256:old",
+		},
+		process: func(ctx context.Context, msg chat.InboundMessage) (agent.TurnResult, error) {
+			processed <- msg.Text
+			if msg.Text == "long answer" {
+				close(firstStarted)
+				<-ctx.Done()
+				close(firstCanceled)
+				<-releaseFirst
+				return agent.TurnResult{Text: "stale reply"}, nil
+			}
+			return agent.TurnResult{Text: "unexpected reply"}, nil
+		},
+		reload: func(context.Context) (InteractiveStatus, error) {
+			close(reloadCalled)
+			return InteractiveStatus{
+				Provider:      "codex",
+				Memory:        true,
+				CharacterID:   "default",
+				CandidateHash: "sha256:new",
+			}, nil
+		},
+	}
+	var output strings.Builder
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- RunInteractive(t.Context(), reader, &output, session, InteractiveConfig{})
+	}()
+
+	writeInteractiveTestLine(t, writer, "long answer")
+	requireInteractiveTestSignal(t, firstStarted, "first turn did not start")
+	writeInteractiveTestLine(t, writer, "queued stale follow-up")
+	writeInteractiveTestLine(t, writer, "/reload")
+	requireInteractiveTestSignal(t, firstCanceled, "reload did not cancel the active turn")
+	select {
+	case <-reloadCalled:
+		t.Fatal("reload ran before the canceled processor drained")
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(releaseFirst)
+	requireInteractiveTestSignal(t, reloadCalled, "reload did not run after the processor drained")
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close input: %v", err)
+	}
+	requireInteractiveTestDone(t, runDone)
+
+	close(processed)
+	var messages []string
+	for message := range processed {
+		messages = append(messages, message)
+	}
+	if len(messages) != 1 || messages[0] != "long answer" {
+		t.Fatalf("processed messages = %#v, want only the canceled active turn", messages)
+	}
+	rendered := output.String()
+	for _, want := range []string{
+		"[queued #1]",
+		"[interrupted]",
+		"Candidate reloaded into a fresh session.",
+		"prompt=sha256:new",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("output = %q, want %q", rendered, want)
+		}
+	}
+	if strings.Contains(rendered, "stale reply") {
+		t.Fatalf("reloaded session exposed stale reply: %q", rendered)
+	}
+}
+
+func TestRunInteractivePassesUnknownSlashCommandToProcessor(t *testing.T) {
+	processed := make(chan chat.InboundMessage, 1)
+	session := &stubInteractiveSession{
+		status: InteractiveStatus{
+			Provider:      "codex",
+			Memory:        true,
+			CharacterID:   "default",
+			CandidateHash: "sha256:test",
+		},
+		process: func(_ context.Context, msg chat.InboundMessage) (agent.TurnResult, error) {
+			processed <- msg
+			return agent.TurnResult{Text: "challenge accepted"}, nil
+		},
+	}
+	var output strings.Builder
+
+	err := RunInteractive(
+		t.Context(),
+		strings.NewReader("/challenge friend\n"),
+		&output,
+		session,
+		InteractiveConfig{},
+	)
+	if err != nil {
+		t.Fatalf("RunInteractive() error = %v", err)
+	}
+	message := <-processed
+	if message.Text != "/challenge friend" || message.UserID != "terminal-user" || message.Channel != "terminal" {
+		t.Fatalf("processed message = %#v, want unchanged slash command with defaults", message)
+	}
+	if !strings.Contains(output.String(), "P&AI> challenge accepted") {
+		t.Fatalf("output = %q, want processor reply", output.String())
+	}
+}
+
+func writeInteractiveTestLine(t *testing.T, writer io.Writer, text string) {
+	t.Helper()
+	if _, err := io.WriteString(writer, text+"\n"); err != nil {
+		t.Fatalf("write %q: %v", text, err)
+	}
+}
+
+func requireInteractiveTestValue(t *testing.T, values <-chan string, want string) {
+	t.Helper()
+	select {
+	case got := <-values:
+		if got != want {
+			t.Fatalf("started = %q, want %q", got, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for %q", want)
+	}
+}
+
+func requireInteractiveTestSignal(t *testing.T, signal <-chan struct{}, message string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(time.Second):
+		t.Fatal(message)
+	}
+}
+
+func requireInteractiveTestDone(t *testing.T, done <-chan error) {
+	t.Helper()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("RunInteractive() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("RunInteractive() did not finish")
+	}
+}

--- a/justfile
+++ b/justfile
@@ -309,6 +309,9 @@ emulate-vercel:
 chat-terminal:
   docker compose run --rm --entrypoint /pai-terminal-chat app
 
+chat-codex:
+  LEARN_DEV_MODE=true LEARN_AI_CODEX_ENABLED=true LEARN_AI_DEFAULT_PROVIDER=codex go run ./cmd/terminal-chat --memory --provider codex --interactive --candidate .codex/chat-codex-candidate
+
 conversation-harness:
   go run ./cmd/conversation-harness
 

--- a/justfile
+++ b/justfile
@@ -312,6 +312,9 @@ chat-terminal:
 conversation-harness:
   go run ./cmd/conversation-harness
 
+conversation-harness-verify:
+  ./scripts/verify-conversation-harness.sh
+
 nudge-terminal:
   docker compose run --rm --entrypoint /pai-terminal-nudge app --user-id "${USER_ID:-}"
 

--- a/plugins/pai-conversation-tester/.claude-plugin/plugin.json
+++ b/plugins/pai-conversation-tester/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "pai-conversation-tester",
+  "version": "0.1.0",
+  "description": "Run and evaluate live, multi-turn PaiBot conversations through the local Codex-backed chat CLI.",
+  "author": {
+    "name": "P&AI"
+  },
+  "repository": "https://github.com/p-n-ai/pai-bot",
+  "license": "Apache-2.0",
+  "keywords": [
+    "paibot",
+    "conversation-testing",
+    "tutor-evaluation"
+  ]
+}

--- a/plugins/pai-conversation-tester/.codex-plugin/plugin.json
+++ b/plugins/pai-conversation-tester/.codex-plugin/plugin.json
@@ -1,0 +1,33 @@
+{
+  "name": "pai-conversation-tester",
+  "version": "0.1.0+codex.20260730075027",
+  "description": "Run and evaluate live, multi-turn PaiBot conversations through the local Codex-backed chat CLI.",
+  "author": {
+    "name": "P&AI",
+    "url": "https://github.com/p-n-ai"
+  },
+  "homepage": "https://github.com/p-n-ai/pai-bot",
+  "repository": "https://github.com/p-n-ai/pai-bot",
+  "license": "Apache-2.0",
+  "keywords": [
+    "paibot",
+    "conversation-testing",
+    "tutor-evaluation"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "PaiBot Conversation Tester",
+    "shortDescription": "Test live PaiBot tutor conversations.",
+    "longDescription": "Runs bounded, adaptive, multi-turn learner conversations through PaiBot's memory-only Codex-backed CLI and reports qualitative tutor behavior.",
+    "developerName": "P&AI",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Live conversation testing",
+      "Multi-turn tutor evaluation",
+      "Qualitative failure classification"
+    ],
+    "defaultPrompt": [
+      "Test a live PaiBot tutor conversation."
+    ]
+  }
+}

--- a/plugins/pai-conversation-tester/README.md
+++ b/plugins/pai-conversation-tester/README.md
@@ -1,0 +1,55 @@
+# PaiBot Conversation Tester
+
+Dual-host plugin for running the shared `pai-chat-codex` skill against PaiBot's local, memory-only conversation harness.
+
+The skill launches `just chat-codex`, which pins PaiBot to the managed Codex provider with no fallback. The CLI accepts messages while a reply is running, exposes FIFO queue and interruption controls, and watches `.codex/chat-codex-candidate/` for prompt or character changes.
+
+The candidate file is optional and should be saved atomically:
+
+```text
+.codex/chat-codex-candidate/
+└── candidate.yaml
+```
+
+`prompt` is appended as a local conversation-test instruction. The same snapshot defines selectable learner identities:
+
+```yaml
+prompt: |
+  Keep replies short and conversational.
+default: aina
+characters:
+  - id: aina
+    first_name: Aina
+    username: aina
+    language: en
+```
+
+The CLI reports only the candidate's SHA-256 identity. Apply a detected change with `/reload`; use `/new` to reset while retaining the selected character.
+
+## Claude Code
+
+From the PaiBot repository root:
+
+```bash
+claude --plugin-dir ./plugins/pai-conversation-tester
+```
+
+After editing the plugin, run `/reload-plugins` in the active Claude Code session.
+
+## Codex
+
+Codex installs local plugins through a marketplace, not `--plugin-dir`. Point a configured local marketplace entry named `pai-conversation-tester` at this directory, then install it with:
+
+```bash
+codex plugin add pai-conversation-tester@<local-marketplace-name>
+```
+
+For subsequent edits, update the manifest cachebuster and reinstall through the same marketplace:
+
+```bash
+python3 ~/.codex/skills/.system/plugin-creator/scripts/update_plugin_cachebuster.py \
+  ./plugins/pai-conversation-tester
+codex plugin add pai-conversation-tester@<local-marketplace-name>
+```
+
+Start a new Codex task after reinstalling. Existing tasks do not pick up updated plugin skills.

--- a/plugins/pai-conversation-tester/skills/pai-chat-codex/SKILL.md
+++ b/plugins/pai-conversation-tester/skills/pai-chat-codex/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: pai-chat-codex
+description: Run and evaluate live, multi-turn PaiBot conversations through the local `just chat-codex` CLI and PaiBot's managed Codex application provider. Use when the user asks Codex to talk to PaiBot, smoke-test tutor tone or prompt flow, probe short replies and context continuity, collect a real terminal transcript, or reproduce a conversational issue without PostgreSQL.
+---
+
+# PaiBot Conversation Tester
+
+Converse with PaiBot as a learner through its real tutor engine. Treat the transcript as qualitative evidence, not deterministic proof.
+
+## Establish the boundary
+
+1. Resolve the PaiBot checkout with `git rev-parse --show-toplevel`; read its nearest `AGENTS.md`.
+2. Confirm `just --dry-run chat-codex` contains `--memory`, `--provider codex`, and `--interactive`. Stop if it can open PostgreSQL or allow provider fallback.
+3. Treat an explicit request to use this skill as authorization for one bounded live evaluation of up to eight learner messages. Ask before exceeding that scope.
+4. Never print environment variables, credentials, the isolated Codex home contents, or device codes in the final report.
+5. Do not use browser automation. If the CLI requests device authorization, show the user the safe verification URL and ask them to complete it; continue after the CLI reports connection.
+6. Test only unless the user also asks for a fix. Do not edit, commit, push, or open a PR from a test request.
+
+## Plan the conversation
+
+Choose a plausible learner and a concrete learning goal. Adapt each message to PaiBot's previous reply instead of replaying a fixed script.
+
+Within four to eight messages, cover the relevant subset:
+
+- A natural opener with enough context to teach.
+- A terse or ambiguous follow-up such as `why?`, `2`, or `wait`.
+- A reference to earlier context without repeating it.
+- A correction or change of mind.
+- A request to shorten, reframe, or switch language.
+- One repair attempt after a weak answer to distinguish recoverable dialogue from a persistent failure.
+
+Do not tell PaiBot it is under evaluation unless the requested scenario requires that behavior.
+
+## Run the live PTY
+
+Launch from the repository root:
+
+```text
+exec_command(
+  cmd="just chat-codex",
+  tty=true,
+  yield_time_ms=1000
+)
+```
+
+Keep the returned session ID. Then:
+
+1. Wait for `Codex provider ready.`, `Codex connected.`, or the device-login instructions.
+2. Wait for `Interactive chat ready.` and `You> `.
+3. Send `/status\n`. Require `provider=codex` and `memory=true`; retain the displayed character and prompt hash for the report.
+4. Send exactly one learner message with `write_stdin(chars="<message>\n")`.
+5. Wait for `P&AI> ` and the next `You> `. Poll with empty input when needed; do not send duplicate messages.
+6. Read the response, update the learner's next message, and continue.
+7. Send `/exit\n` when the evaluation is complete.
+8. If shutdown hangs, send Ctrl-C once and verify the process exits.
+
+When the requested evaluation covers delivery mechanics, send an additional learner message while a reply is in flight and require `[queued #N]`, or send `/interrupt <replacement>` and require `[interrupted]` before the replacement reply. Do not use these controls during an ordinary tone evaluation.
+
+## Reload a candidate
+
+`just chat-codex` watches `.codex/chat-codex-candidate/candidate.yaml`. Keep prompt and characters in that single file so one save is one coherent candidate. A change prints `Candidate changed; type /reload to apply.`
+
+- `/reload` validates the entire candidate and starts a fresh memory session.
+- `/new` starts a fresh memory session while preserving the selected character.
+- `/character <id>` selects a configured character and starts fresh.
+- `/status` reports only safe structural state, including `sha256:<hash>`.
+
+Edit `candidate.yaml` only when the user asks to tune or compare a prompt or character. Never place credentials, private learner data, or raw production prompts there.
+
+Keep user-facing status updates under one minute apart while a turn is still running.
+
+## Judge the conversation
+
+Evaluate observable behavior:
+
+- **Continuity:** understands pronouns, terse replies, and earlier facts.
+- **Brevity fit:** response length matches the learner's request and message size.
+- **Teaching:** guides rather than dumping an answer or worksheet.
+- **Repair:** responds naturally to correction or confusion.
+- **Voice:** conversational, age-appropriate, and free of canned headings.
+- **Language:** follows the learner's language and requested changes.
+- **Flow:** no duplicate replies, unexplained fallback, hang, or lost turn.
+
+Classify a finding by its likely owner:
+
+- `prompt/content`: tone, verbosity, teaching decision, context interpretation.
+- `flow/runtime`: ordering, cancellation, duplication, state loss, error handling.
+- `uncertain`: one model-variable result without a reproducible pattern.
+
+Do not convert a subjective dislike into a defect without quoting the triggering learner message and summarizing the observed consequence.
+
+## Report
+
+Lead with the result. Include:
+
+- Provider path used and whether the session stayed memory-only.
+- Active prompt hash and character ID.
+- Number and shape of turns tested.
+- What felt natural.
+- Failures with the learner message, PaiBot behavior, and likely owner.
+- Whether a second attempt reproduced or repaired the problem.
+- The smallest next test or fix.
+
+Keep device authorization details, credentials, and raw model-facing prompts out of the report. Provide a full transcript only when the user explicitly asks for it.

--- a/scripts/verify-conversation-harness.sh
+++ b/scripts/verify-conversation-harness.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(dirname -- "$script_dir")
+temp_root=$(mktemp -d "${TMPDIR:-/tmp}/pai-conversation-harness.XXXXXX")
+binary="$temp_root/conversation-harness"
+harness_cache="${TMPDIR:-/tmp}/pai-bot-conversation-harness-go-cache"
+
+cleanup() {
+  case "$temp_root" in
+    */pai-conversation-harness.*) rm -R -- "$temp_root" ;;
+  esac
+}
+trap cleanup EXIT HUP INT TERM
+
+require_text() {
+  result_file=$1
+  expected_text=$2
+  if ! grep -F -- "$expected_text" "$result_file" >/dev/null; then
+    echo "missing expected verifier output: $expected_text" >&2
+    echo "result file: $result_file" >&2
+    exit 1
+  fi
+}
+
+cd "$repo_root"
+GOCACHE="$harness_cache" go build -o "$binary" ./cmd/conversation-harness
+
+queue_result="$temp_root/queue.jsonl"
+"$binary" \
+  --case Q12 \
+  --mock-response "You can read 3x as three copies of x." \
+  --jsonl >"$queue_result"
+require_text "$queue_result" '"passed":true'
+require_text "$queue_result" '"delivered":3'
+queue_normalized="$temp_root/queue-normalized.jsonl"
+sed -E 's/"duration_ms":[0-9]+/"duration_ms":0/g' "$queue_result" >"$queue_normalized"
+require_text "$queue_normalized" '"outcomes":[{"turn":1,"delivery":"wait","status":"delivered","duration_ms":0},{"turn":2,"delivery":"queue","status":"delivered","duration_ms":0},{"turn":3,"delivery":"queue","status":"delivered","duration_ms":0}]'
+
+interrupt_result="$temp_root/interrupt.jsonl"
+"$binary" \
+  --case Q13 \
+  --mock-response "You can read 4x as four copies of x." \
+  --jsonl >"$interrupt_result"
+require_text "$interrupt_result" '"passed":true'
+require_text "$interrupt_result" '"interrupted":1'
+require_text "$interrupt_result" '"turn":1,"delivery":"wait","status":"interrupted"'
+require_text "$interrupt_result" '"turn":2,"delivery":"interrupt","status":"delivered"'
+
+terse_result="$temp_root/terse.jsonl"
+"$binary" \
+  --case Q14 \
+  --mock-response "Kita baca 2x sebagai dua kali x." \
+  --jsonl >"$terse_result"
+require_text "$terse_result" '"passed":true'
+require_text "$terse_result" '"delivered":3'
+
+long_reply="Kita baca 2x sebagai dua kali x. Setiap x mewakili satu nilai yang sama, jadi dua salinan x ditambah bersama. Bayangkan dua kotak yang beratnya sama, dengan setiap kotak bernilai x. Apabila kedua-duanya digabungkan, jumlahnya ialah 2x. Penerangan ini sengaja terlalu panjang untuk semakan had balasan ringkas."
+negative_result="$temp_root/negative.jsonl"
+if "$binary" \
+  --case Q14 \
+  --mock-response "$long_reply" \
+  --jsonl >"$negative_result" 2>"$temp_root/negative.stderr"; then
+  echo "negative verifier probe unexpectedly passed" >&2
+  exit 1
+fi
+require_text "$negative_result" '"passed":false'
+require_text "$negative_result" 'turn 2: response has'
+require_text "$negative_result" 'max 260'
+
+invalid_fixture="$temp_root/invalid-fixture.yaml"
+printf '%s\n' \
+  'version: 2' \
+  'provider: mock' \
+  'conversations:' \
+  '  - id: INVALID01' \
+  '    title: Unknown field must fail' \
+  '    turns:' \
+  '      - user: hello' \
+  '        delivry: queue' >"$invalid_fixture"
+if "$binary" \
+  --fixture "$invalid_fixture" \
+  --mock-response "unused" \
+  --jsonl >"$temp_root/invalid.stdout" 2>"$temp_root/invalid.stderr"; then
+  echo "invalid fixture unexpectedly passed" >&2
+  exit 1
+fi
+require_text "$temp_root/invalid.stderr" 'field delivry not found'
+
+echo "conversation harness verifier: PASS"


### PR DESCRIPTION
## Summary
- add deterministic wait, queue, and interruption scheduling with cancellation ownership
- add character-aware, turn-scoped conversation fixtures and structural JSON outcomes
- add strict fixture validation, black-box pass/fail verification, and an operator guide

## Testing
- `just conversation-harness-verify`
- `go test -race ./internal/conversationharness ./cmd/conversation-harness -count=3`
- `go vet ./internal/conversationharness ./cmd/conversation-harness`
- `go test ./... -count=1`
- `sh -n scripts/verify-conversation-harness.sh`
- `git diff --check origin/main...HEAD`