### PR TITLE
feat(curriculum): add validated OSS curriculum engine

### DIFF
--- a/internal/agent/adaptive_depth_integration_test.go
+++ b/internal/agent/adaptive_depth_integration_test.go
@@ -5,8 +5,6 @@ package agent_test
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -202,28 +200,5 @@ func TestAdaptiveDepth_NoTrackerIsUnknown(t *testing.T) {
 
 func createAdaptiveTestLoader(t *testing.T) *curriculum.Loader {
 	t.Helper()
-	dir := t.TempDir()
-
-	topicYAML := `id: F1-06
-name: "Persamaan Linear (Linear Equations)"
-subject_id: algebra
-syllabus_id: default
-keywords:
-  - persamaan linear
-  - linear equation
-`
-	if err := os.WriteFile(filepath.Join(dir, "F1-06.yaml"), []byte(topicYAML), 0o644); err != nil {
-		t.Fatalf("write topic: %v", err)
-	}
-
-	teachingMD := "# Persamaan Linear\nTeaching notes for linear equations."
-	if err := os.WriteFile(filepath.Join(dir, "F1-06.teaching.md"), []byte(teachingMD), 0o644); err != nil {
-		t.Fatalf("write teaching notes: %v", err)
-	}
-
-	loader, err := curriculum.NewLoader(dir)
-	if err != nil {
-		t.Fatalf("NewLoader: %v", err)
-	}
-	return loader
+	return createLearnTestLoader(t)
 }

--- a/internal/agent/challenge_ai_fallback_internal_test.go
+++ b/internal/agent/challenge_ai_fallback_internal_test.go
@@ -302,17 +302,25 @@ func createChallengeFallbackCurriculumLoader(t *testing.T) *curriculum.Loader {
 	if err := os.MkdirAll(topicsDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll() error = %v", err)
 	}
+	writeChallengeCurriculumMetadata(t, dir)
 
 	yamlPath := filepath.Join(topicsDir, "01-linear-equations.yaml")
 	yamlData := `id: F1-02
 name: Linear Equations
+subject_grade_id: math-f1
 subject_id: math
 syllabus_id: kssm-f1
 difficulty: beginner
+content_standards:
+  - id: "1.1"
+    text: Linear equations
 learning_objectives:
   - id: LO1
+    content_standard_id: "1.1"
     text: Solve linear equations in one variable
     bloom: apply
+quality_level: 2
+provenance: human
 `
 	if err := os.WriteFile(yamlPath, []byte(yamlData), 0o644); err != nil {
 		t.Fatalf("WriteFile(yaml) error = %v", err)

--- a/internal/agent/challenge_runtime_test.go
+++ b/internal/agent/challenge_runtime_test.go
@@ -24,17 +24,25 @@ func createChallengeRuntimeCurriculumLoader(t *testing.T) *curriculum.Loader {
 	if err := os.MkdirAll(topicsDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll() error = %v", err)
 	}
+	writeChallengeCurriculumMetadata(t, dir)
 
 	yamlPath := filepath.Join(topicsDir, "01-linear-equations.yaml")
 	yamlData := `id: F1-02
 name: Linear Equations
+subject_grade_id: math-f1
 subject_id: math
 syllabus_id: kssm-f1
 difficulty: beginner
+content_standards:
+  - id: "1.1"
+    text: Linear equations
 learning_objectives:
   - id: LO1
+    content_standard_id: "1.1"
     text: Solve linear equations in one variable
     bloom: apply
+quality_level: 2
+provenance: human
 `
 	if err := os.WriteFile(yamlPath, []byte(yamlData), 0o644); err != nil {
 		t.Fatalf("WriteFile(yaml) error = %v", err)
@@ -73,6 +81,36 @@ questions:
 		t.Fatalf("NewLoader() error = %v", err)
 	}
 	return loader
+}
+
+func writeChallengeCurriculumMetadata(t *testing.T, root string) {
+	t.Helper()
+	curriculumDir := filepath.Join(root, "curricula", "malaysia", "kssm")
+	files := map[string]string{
+		"syllabus.yaml": `id: kssm-f1
+name: KSSM Form 1
+subjects:
+  - math
+`,
+		"subject.yaml": `id: math
+name: Mathematics
+syllabus_id: kssm-f1
+`,
+		"subject-grade.yaml": `id: math-f1
+name: Mathematics Form 1
+subject_id: math
+syllabus_id: kssm-f1
+grade_id: form-1
+topics:
+  - F1-02
+`,
+	}
+	for name, content := range files {
+		path := filepath.Join(curriculumDir, name)
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s) error = %v", path, err)
+		}
+	}
 }
 
 func testChallengeEngine(t *testing.T) (*Engine, *MemoryStore, *MemoryChallengeStore, *progress.MemoryXPTracker) {

--- a/internal/agent/context_resolver_test.go
+++ b/internal/agent/context_resolver_test.go
@@ -4,12 +4,14 @@
 package agent_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/p-n-ai/pai-bot/internal/agent"
 	"github.com/p-n-ai/pai-bot/internal/curriculum"
+	"github.com/p-n-ai/pai-bot/internal/retrieval"
 )
 
 func TestCurriculumContextResolver_Resolve_MatchedTopicWithTeachingNotes(t *testing.T) {
@@ -44,19 +46,51 @@ func TestCurriculumContextResolver_Resolve_NoMatch(t *testing.T) {
 	}
 }
 
-func TestCurriculumContextResolver_Resolve_MatchWithoutTeachingNotes(t *testing.T) {
+func TestCurriculumContextResolver_Resolve_RejectsTopicBelowAITeachingQuality(t *testing.T) {
 	loader := createCurriculumLoaderForResolverTest(t, false)
 	resolver := agent.NewCurriculumContextResolver(loader)
 
 	topic, notes := resolver.Resolve("help me with linear equations")
-	if topic == nil {
-		t.Fatal("expected matched topic, got nil")
-	}
-	if topic.ID != "F1-02" {
-		t.Fatalf("topic.ID = %q, want F1-02", topic.ID)
+	if topic != nil {
+		t.Fatalf("topic = %#v, want lower-quality topic excluded", topic)
 	}
 	if notes != "" {
-		t.Fatalf("expected empty notes when teaching notes are missing, got: %s", notes)
+		t.Fatalf("notes = %q, want no lower-quality tutor evidence", notes)
+	}
+}
+
+func TestCurriculumContextResolver_Resolve_RejectsLowerQualitySharedServiceDocument(t *testing.T) {
+	loader := createCurriculumLoaderForResolverTest(t, false)
+	service := retrieval.NewService()
+	if _, err := service.UpsertCollection(retrieval.UpsertCollectionInput{
+		ID:   "curriculum:math",
+		Name: "Mathematics",
+	}); err != nil {
+		t.Fatalf("UpsertCollection() error = %v", err)
+	}
+	if _, err := service.UpsertDocument(retrieval.UpsertDocumentInput{
+		ID:           "topic:F1-02",
+		CollectionID: "curriculum:math",
+		Kind:         "topic_card",
+		Title:        "Linear Equations",
+		Body:         "Solve linear equations in one variable.",
+		Metadata: map[string]string{
+			"topic_id":    "F1-02",
+			"subject_id":  "malaysia-kssm-matematik",
+			"syllabus_id": "malaysia-kssm",
+			"kind":        "topic_card",
+		},
+	}); err != nil {
+		t.Fatalf("UpsertDocument() error = %v", err)
+	}
+	resolver := agent.NewCurriculumContextResolver(
+		loader,
+		agent.WithResolverRetrievalService(service),
+	)
+
+	topic, notes := resolver.Resolve("teach linear equations")
+	if topic != nil || notes != "" {
+		t.Fatalf("Resolve() = %#v, %q; want lower-quality service evidence rejected", topic, notes)
 	}
 }
 
@@ -154,34 +188,73 @@ name: "Kurikulum Standard Sekolah Menengah"
 country: malaysia
 board: kssm
 level: secondary
+subjects:
+  - malaysia-kssm-matematik
 `)
 
-	write(filepath.Join(filepath.Join(curriculumDir, "form-1"), "subject.yaml"), `id: malaysia-kssm-matematik-tingkatan-1
+	write(filepath.Join(curriculumDir, "subject.yaml"), `id: malaysia-kssm-matematik
+name: Matematik
+name_en: Mathematics
+syllabus_id: malaysia-kssm
+`)
+	write(filepath.Join(filepath.Join(curriculumDir, "form-1"), "subject-grade.yaml"), `id: malaysia-kssm-matematik-tingkatan-1
 name: "Matematik Tingkatan 1"
 name_en: "Mathematics Form 1"
+subject_id: malaysia-kssm-matematik
 syllabus_id: malaysia-kssm
 grade_id: tingkatan-1
 topics:
   - F1-02
 `)
 
-	write(filepath.Join(f1TopicsDir, "01-linear-equations.yaml"), `id: F1-02
+	qualityLevel := 2
+	if withNotes {
+		qualityLevel = 3
+	}
+	write(filepath.Join(f1TopicsDir, "01-linear-equations.yaml"), fmt.Sprintf(`id: F1-02
 official_ref: "Bab 6"
 name: "Persamaan Linear (Linear Equations)"
-subject_id: malaysia-kssm-matematik-tingkatan-1
+subject_grade_id: malaysia-kssm-matematik-tingkatan-1
+subject_id: malaysia-kssm-matematik
 syllabus_id: malaysia-kssm
 difficulty: beginner
+content_standards:
+  - id: "1.1"
+    text: Linear equations
 learning_objectives:
   - id: LO1
+    content_standard_id: "1.1"
     text: Solve linear equations in one variable
     bloom: apply
-`)
+quality_level: %d
+provenance: human
+`, qualityLevel))
 
 	if withNotes {
 		write(filepath.Join(f1TopicsDir, "01-linear-equations.teaching.md"), `# Linear Equations Teaching Notes
 
 ## Balance Method
 Use balance method and subtract 5 on both sides.`)
+		write(filepath.Join(f1TopicsDir, "01-linear-equations.examples.yaml"), `topic_id: F1-02
+worked_examples:
+  - id: WE-01
+    topic: Solving linear equations
+    difficulty: easy
+    learning_objective: LO1
+    misconception_alert: Moving a term changes nothing.
+    scenario: Solve x plus 5 equals 8.
+    working: Subtract 5 from both sides.
+`)
+		write(filepath.Join(f1TopicsDir, "01-linear-equations.assessments.yaml"), `topic_id: F1-02
+questions:
+  - id: Q1
+    text: Solve x plus 5 equals 8.
+    difficulty: easy
+    learning_objective: LO1
+    answer:
+      type: exact
+      value: "3"
+`)
 	}
 
 	loader, err := curriculum.NewLoader(dir)
@@ -217,47 +290,74 @@ name: "Kurikulum Standard Sekolah Menengah"
 country: malaysia
 board: kssm
 level: secondary
+subjects:
+  - malaysia-kssm-matematik
 `)
 
-	write(filepath.Join(filepath.Join(curriculumDir, "form-1"), "subject.yaml"), `id: malaysia-kssm-matematik-tingkatan-1
+	write(filepath.Join(curriculumDir, "subject.yaml"), `id: malaysia-kssm-matematik
+name: Matematik
+name_en: Mathematics
+syllabus_id: malaysia-kssm
+`)
+	write(filepath.Join(filepath.Join(curriculumDir, "form-1"), "subject-grade.yaml"), `id: malaysia-kssm-matematik-tingkatan-1
 name: "Matematik Tingkatan 1"
 name_en: "Mathematics Form 1"
+subject_id: malaysia-kssm-matematik
 syllabus_id: malaysia-kssm
 grade_id: tingkatan-1
 topics:
   - F1-02
 `)
-	write(filepath.Join(filepath.Join(curriculumDir, "form-2"), "subject.yaml"), `id: malaysia-kssm-matematik-tingkatan-2
+	write(filepath.Join(filepath.Join(curriculumDir, "form-2"), "subject-grade.yaml"), `id: malaysia-kssm-matematik-tingkatan-2
 name: "Matematik Tingkatan 2"
 name_en: "Mathematics Form 2"
+subject_id: malaysia-kssm-matematik
 syllabus_id: malaysia-kssm
 grade_id: tingkatan-2
 topics:
   - F2-02
 `)
 
-	write(filepath.Join(f1TopicsDir, "01-linear-equations.yaml"), `id: F1-02
+	qualityLevel := 2
+	if withNotes {
+		qualityLevel = 3
+	}
+	write(filepath.Join(f1TopicsDir, "01-linear-equations.yaml"), fmt.Sprintf(`id: F1-02
 official_ref: "Bab 6"
 name: "Persamaan Linear (Linear Equations)"
-subject_id: malaysia-kssm-matematik-tingkatan-1
+subject_grade_id: malaysia-kssm-matematik-tingkatan-1
+subject_id: malaysia-kssm-matematik
 syllabus_id: malaysia-kssm
 difficulty: beginner
+content_standards:
+  - id: "1.1"
+    text: Linear equations
 learning_objectives:
   - id: LO1
+    content_standard_id: "1.1"
     text: Solve linear equations in one variable
     bloom: apply
-`)
-	write(filepath.Join(f2TopicsDir, "02-linear-equations.yaml"), `id: F2-02
+quality_level: %d
+provenance: human
+`, qualityLevel))
+	write(filepath.Join(f2TopicsDir, "02-linear-equations.yaml"), fmt.Sprintf(`id: F2-02
 official_ref: "Bab 3"
 name: "Persamaan Linear (Linear Equations)"
-subject_id: malaysia-kssm-matematik-tingkatan-2
+subject_grade_id: malaysia-kssm-matematik-tingkatan-2
+subject_id: malaysia-kssm-matematik
 syllabus_id: malaysia-kssm
 difficulty: intermediate
+content_standards:
+  - id: "2.1"
+    text: Simultaneous linear equations
 learning_objectives:
   - id: LO1
+    content_standard_id: "2.1"
     text: Solve simultaneous linear equations using elimination
     bloom: apply
-`)
+quality_level: %d
+provenance: human
+`, qualityLevel))
 
 	if withNotes {
 		write(filepath.Join(f1TopicsDir, "01-linear-equations.teaching.md"), `# Linear Equations Teaching Notes
@@ -268,6 +368,39 @@ Use balance method and subtract 5 on both sides.`)
 
 ## Common Misconceptions
 Students often get confused by double negatives during elimination.`)
+		for _, fixture := range []struct {
+			dir, base, topicID, objectiveID, scenario, answer string
+		}{
+			{
+				dir: f1TopicsDir, base: "01-linear-equations", topicID: "F1-02",
+				objectiveID: "LO1", scenario: "Solve x plus 5 equals 8.", answer: "3",
+			},
+			{
+				dir: f2TopicsDir, base: "02-linear-equations", topicID: "F2-02",
+				objectiveID: "LO1", scenario: "Solve x plus y equals 4.", answer: "2",
+			},
+		} {
+			write(filepath.Join(fixture.dir, fixture.base+".examples.yaml"), fmt.Sprintf(`topic_id: %s
+worked_examples:
+  - id: WE-01
+    topic: Linear equations
+    difficulty: easy
+    learning_objective: %s
+    misconception_alert: Moving a term changes nothing.
+    scenario: %s
+    working: Apply the same inverse operation to both sides.
+`, fixture.topicID, fixture.objectiveID, fixture.scenario))
+			write(filepath.Join(fixture.dir, fixture.base+".assessments.yaml"), fmt.Sprintf(`topic_id: %s
+questions:
+  - id: Q1
+    text: %s
+    difficulty: easy
+    learning_objective: %s
+    answer:
+      type: exact
+      value: %q
+`, fixture.topicID, fixture.scenario, fixture.objectiveID, fixture.answer))
+		}
 	}
 
 	loader, err := curriculum.NewLoader(dir)

--- a/internal/agent/curriculum_retriever.go
+++ b/internal/agent/curriculum_retriever.go
@@ -131,6 +131,9 @@ func newCurriculumRetriever(loader *curriculum.Loader, cfg curriculumRetrieverCo
 		r.buildIndex()
 	}
 	for _, topic := range loader.AllTopics() {
+		if !topic.IsAITeachingReady() {
+			continue
+		}
 		r.topics[topic.ID] = topic
 	}
 	return r
@@ -377,6 +380,9 @@ func (r *curriculumRetriever) scoredDocsFromSearchResults(results []retrieval.Se
 	followUp := looksLikeFollowUp(query.Text)
 	for _, result := range results {
 		doc := docFromDocument(result.Document)
+		if _, ready := r.topics[doc.TopicID]; !ready {
+			continue
+		}
 		score := result.Score
 		if usedFallback && targetForm != "" && doc.Form != "" && doc.Form != targetForm {
 			score -= formMismatchPenalty
@@ -432,15 +438,19 @@ func docFromDocument(document retrieval.Document) retrievalDoc {
 func (r *curriculumRetriever) buildIndex() {
 	fieldTotals := make(map[string]int)
 	for _, topic := range r.loader.AllTopics() {
+		if !topic.IsAITeachingReady() {
+			continue
+		}
 		r.topics[topic.ID] = topic
 		subject, _ := r.loader.GetSubject(topic.SubjectID)
+		subjectGrade, _ := r.loader.GetSubjectGrade(topic.SubjectGradeID)
 		syllabus, _ := r.loader.GetSyllabus(topic.SyllabusID)
-		form := inferTopicForm(topic, subject)
+		form := inferTopicForm(topic, subject, subjectGrade)
 
 		r.addDoc(newRetrievalDoc("topic:"+topic.ID, topic.ID, topic.SubjectID, topic.SyllabusID, form, "topic", map[string]string{
 			"title":      topic.Name,
 			"aliases":    strings.Join(topicAliases(topic), " "),
-			"subject":    joinNonEmpty(subject.Name, subject.NameEN, subject.GradeID),
+			"subject":    joinNonEmpty(subject.Name, subject.NameEN, subjectGrade.Name, subjectGrade.NameEN, subjectGrade.GradeID),
 			"syllabus":   syllabus.Name,
 			"objectives": strings.Join(topicObjectives(topic), " "),
 			"body":       joinNonEmpty(topic.OfficialRef, topic.Difficulty, topic.Tier, topic.Provenance),
@@ -451,7 +461,7 @@ func (r *curriculumRetriever) buildIndex() {
 				r.addDoc(newRetrievalDoc("note:"+topic.ID+":"+strconv.Itoa(i), topic.ID, topic.SubjectID, topic.SyllabusID, form, "teaching_note", map[string]string{
 					"title":      topic.Name,
 					"aliases":    strings.Join(topicAliases(topic), " "),
-					"subject":    joinNonEmpty(subject.Name, subject.NameEN, subject.GradeID),
+					"subject":    joinNonEmpty(subject.Name, subject.NameEN, subjectGrade.Name, subjectGrade.NameEN, subjectGrade.GradeID),
 					"syllabus":   syllabus.Name,
 					"heading":    section.Title,
 					"objectives": strings.Join(topicObjectives(topic), " "),
@@ -465,7 +475,7 @@ func (r *curriculumRetriever) buildIndex() {
 				r.addDoc(newRetrievalDoc("assessment:"+topic.ID+":"+strconv.Itoa(i), topic.ID, topic.SubjectID, topic.SyllabusID, form, "assessment", map[string]string{
 					"title":      topic.Name,
 					"aliases":    strings.Join(topicAliases(topic), " "),
-					"subject":    joinNonEmpty(subject.Name, subject.NameEN, subject.GradeID),
+					"subject":    joinNonEmpty(subject.Name, subject.NameEN, subjectGrade.Name, subjectGrade.NameEN, subjectGrade.GradeID),
 					"syllabus":   syllabus.Name,
 					"heading":    question.Text,
 					"objectives": strings.Join(topicObjectives(topic), " "),
@@ -869,7 +879,17 @@ func topicObjectives(topic curriculum.Topic) []string {
 	return objectives
 }
 
-func inferTopicForm(topic curriculum.Topic, subject curriculum.Subject) string {
+func inferTopicForm(topic curriculum.Topic, subject curriculum.Subject, subjectGrade curriculum.SubjectGrade) string {
+	for _, text := range []string{
+		subjectGrade.GradeID,
+		subjectGrade.Name,
+		subjectGrade.NameEN,
+		subjectGrade.ID,
+	} {
+		if form := detectFormInText(text); form != "" {
+			return form
+		}
+	}
 	if form := detectFormInText(subject.GradeID); form != "" {
 		return form
 	}

--- a/internal/agent/curriculum_tool.go
+++ b/internal/agent/curriculum_tool.go
@@ -35,7 +35,7 @@ func (curriculumLookupTool) Definition() llm.Tool {
 func (t curriculumLookupTool) Execute(_ context.Context, call llm.ToolCall) (llm.ToolResultMessage, error) {
 	topicID, _ := call.Arguments["topic_id"].(string)
 	topic, ok := t.loader.GetTopic(topicID)
-	if !ok {
+	if !ok || !topic.IsAITeachingReady() {
 		return llm.ToolResultMessage{
 			Content:   []llm.UserContent{llm.TextContent{Text: "curriculum topic not found"}},
 			IsError:   true,

--- a/internal/agent/curriculum_tool_test.go
+++ b/internal/agent/curriculum_tool_test.go
@@ -1,0 +1,25 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/p-n-ai/pai-bot/internal/llm"
+)
+
+func TestCurriculumLookupToolRejectsTopicBelowAITeachingQuality(t *testing.T) {
+	tool := curriculumLookupTool{loader: newUnlockCurriculumLoader(t)}
+
+	result, err := tool.Execute(context.Background(), llm.ToolCall{
+		Arguments: map[string]any{"topic_id": "F1-02"},
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("Execute() = %#v, want lower-quality topic rejected", result)
+	}
+}

--- a/internal/agent/engine_test.go
+++ b/internal/agent/engine_test.go
@@ -2744,7 +2744,7 @@ learning_objectives:
     content_standard_id: "1.1"
     text: Solve linear equations in one variable
     bloom: apply
-quality_level: 2
+quality_level: 3
 provenance: human
 `
 	if err := os.WriteFile(yamlPath, []byte(yamlData), 0o644); err != nil {
@@ -2809,6 +2809,21 @@ questions:
 `
 	if err := os.WriteFile(assessmentPath, []byte(assessment), 0o644); err != nil {
 		t.Fatalf("WriteFile(assessment) error = %v", err)
+	}
+	examplesPath := filepath.Join(topicsDir, "01-linear-equations.examples.yaml")
+	examples := `topic_id: F1-02
+provenance: human
+worked_examples:
+  - id: WE1
+    topic: Solving a linear equation
+    difficulty: easy
+    learning_objective: LO1
+    scenario: Solve x + 3 = 7.
+    working: Subtract 3 from both sides to get x = 4.
+    misconception_alert: Changing only one side breaks the equality.
+`
+	if err := os.WriteFile(examplesPath, []byte(examples), 0o644); err != nil {
+		t.Fatalf("WriteFile(examples) error = %v", err)
 	}
 
 	loader, err := curriculum.NewLoader(dir)

--- a/internal/agent/engine_test.go
+++ b/internal/agent/engine_test.go
@@ -2703,17 +2703,49 @@ func createTestCurriculumLoader(t *testing.T) *curriculum.Loader {
 	if err := os.MkdirAll(topicsDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll() error = %v", err)
 	}
+	curriculumDir := filepath.Join(dir, "curricula", "malaysia", "kssm")
+	for name, content := range map[string]string{
+		"syllabus.yaml": `id: kssm-f1
+name: KSSM Form 1
+subjects:
+  - math
+`,
+		"subject.yaml": `id: math
+name: Mathematics
+syllabus_id: kssm-f1
+`,
+		"subject-grade.yaml": `id: math-f1
+name: Mathematics Form 1
+subject_id: math
+syllabus_id: kssm-f1
+grade_id: form-1
+topics:
+  - F1-02
+`,
+	} {
+		path := filepath.Join(curriculumDir, name)
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s) error = %v", path, err)
+		}
+	}
 
 	yamlPath := filepath.Join(topicsDir, "01-linear-equations.yaml")
 	yamlData := `id: F1-02
 name: Linear Equations
+subject_grade_id: math-f1
 subject_id: math
 syllabus_id: kssm-f1
 difficulty: beginner
+content_standards:
+  - id: "1.1"
+    text: Linear equations
 learning_objectives:
   - id: LO1
+    content_standard_id: "1.1"
     text: Solve linear equations in one variable
     bloom: apply
+quality_level: 2
+provenance: human
 `
 	if err := os.WriteFile(yamlPath, []byte(yamlData), 0o644); err != nil {
 		t.Fatalf("WriteFile(yaml) error = %v", err)

--- a/internal/agent/learn.go
+++ b/internal/agent/learn.go
@@ -23,9 +23,15 @@ func (e *Engine) handleLearnCommand(ctx context.Context, msg chat.InboundMessage
 		usage := i18n.S(locale, i18n.MsgLearnUsage)
 		if e.curriculumLoader != nil {
 			topics := e.curriculumLoader.AllTopics()
-			if len(topics) > 0 {
+			readyTopics := topics[:0]
+			for _, topic := range topics {
+				if topic.IsAITeachingReady() {
+					readyTopics = append(readyTopics, topic)
+				}
+			}
+			if len(readyTopics) > 0 {
 				usage += "\n\nTopik tersedia:"
-				for _, t := range topics {
+				for _, t := range readyTopics {
 					usage += "\n- " + t.Name + " (" + t.ID + ")"
 				}
 			}
@@ -37,6 +43,9 @@ func (e *Engine) handleLearnCommand(ctx context.Context, msg chat.InboundMessage
 
 	// Resolve topic from text via lexical retrieval.
 	topic, _ := e.resolveCurriculumContext(msg.UserID, "", raw)
+	if topic != nil && !topic.IsAITeachingReady() {
+		topic = nil
+	}
 
 	// Fallback: if lexical retrieval missed (e.g. typos), ask AI to fuzzy-match.
 	if topic == nil && e.curriculumLoader != nil && e.aiRouter != nil {
@@ -107,6 +116,13 @@ func (e *Engine) handleLearnCommand(ctx context.Context, msg chat.InboundMessage
 // typos) against the list of available topic IDs and names.
 func (e *Engine) aiMatchTopic(ctx context.Context, userInput string) *curriculum.Topic {
 	topics := e.curriculumLoader.AllTopics()
+	readyTopics := topics[:0]
+	for _, topic := range topics {
+		if topic.IsAITeachingReady() {
+			readyTopics = append(readyTopics, topic)
+		}
+	}
+	topics = readyTopics
 	if len(topics) == 0 {
 		return nil
 	}
@@ -161,7 +177,7 @@ Return JSON: {"topic_id": "<ID>"}`, userInput, topicList.String())
 	}
 
 	matched, ok := e.curriculumLoader.GetTopic(result.TopicID)
-	if !ok {
+	if !ok || !matched.IsAITeachingReady() {
 		slog.Warn("AI returned unknown topic ID", "topic_id", result.TopicID, "input", userInput)
 		return nil
 	}

--- a/internal/agent/learn_test.go
+++ b/internal/agent/learn_test.go
@@ -5,6 +5,7 @@ package agent_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -89,6 +90,33 @@ func TestLearnCommand_TopicNotFound(t *testing.T) {
 	}
 }
 
+func TestLearnCommand_RejectsTopicBelowAITeachingQuality(t *testing.T) {
+	loader := createLearnTestLoaderAtQuality(t, 2)
+	store := agent.NewMemoryStore()
+	engine := agent.NewEngine(agent.EngineConfig{
+		AIRouter:             ai.NewRouter(),
+		Store:                store,
+		CurriculumLoader:     loader,
+		DisableMultiLanguage: true,
+	})
+
+	resp, err := engine.ProcessMessage(context.Background(), chat.InboundMessage{
+		Channel: "terminal",
+		UserID:  "user1",
+		Text:    "/learn persamaan linear",
+	})
+	if err != nil {
+		t.Fatalf("ProcessMessage: %v", err)
+	}
+	identity, err := agent.NewLearnerIdentity("terminal", "user1")
+	if err != nil {
+		t.Fatalf("NewLearnerIdentity: %v", err)
+	}
+	if conversation, found := store.GetActiveConversationFor(identity); found && conversation.TopicID != "" {
+		t.Fatalf("conversation.TopicID = %q after response %q, want unset", conversation.TopicID, resp)
+	}
+}
+
 func TestLearnCommand_SetsConversationTopicID(t *testing.T) {
 	provider := &echoProvider{}
 	router := ai.NewRouter()
@@ -142,24 +170,92 @@ func (p *echoProvider) Models() []ai.ModelInfo            { return nil }
 func (p *echoProvider) HealthCheck(context.Context) error { return nil }
 
 func createLearnTestLoader(t *testing.T) *curriculum.Loader {
+	return createLearnTestLoaderAtQuality(t, 3)
+}
+
+func createLearnTestLoaderAtQuality(t *testing.T, qualityLevel int) *curriculum.Loader {
 	t.Helper()
 	dir := t.TempDir()
-
-	topicYAML := `id: F1-06
-name: "Persamaan Linear (Linear Equations)"
+	curriculumDir := filepath.Join(dir, "curricula", "default")
+	topicsDir := filepath.Join(curriculumDir, "topics")
+	if err := os.MkdirAll(topicsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	for name, content := range map[string]string{
+		"syllabus.yaml": `id: default
+name: Default
+subjects:
+  - algebra
+`,
+		"subject.yaml": `id: algebra
+name: Algebra
+syllabus_id: default
+`,
+		"subject-grade.yaml": `id: algebra-f1
+name: Algebra Form 1
 subject_id: algebra
 syllabus_id: default
-keywords:
-  - persamaan linear
-  - linear equation
-`
-	if err := os.WriteFile(filepath.Join(dir, "F1-06.yaml"), []byte(topicYAML), 0o644); err != nil {
+grade_id: form-1
+topics:
+  - F1-06
+`,
+	} {
+		path := filepath.Join(curriculumDir, name)
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("write metadata %s: %v", name, err)
+		}
+	}
+
+	topicYAML := fmt.Sprintf(`id: F1-06
+name: "Persamaan Linear (Linear Equations)"
+subject_grade_id: algebra-f1
+subject_id: algebra
+syllabus_id: default
+difficulty: beginner
+content_standards:
+  - id: "1.1"
+    text: Linear equations
+learning_objectives:
+  - id: LO1
+    content_standard_id: "1.1"
+    text: Solve linear equations.
+    bloom: apply
+quality_level: %d
+provenance: human
+`, qualityLevel)
+	if err := os.WriteFile(filepath.Join(topicsDir, "F1-06.yaml"), []byte(topicYAML), 0o644); err != nil {
 		t.Fatalf("write topic: %v", err)
 	}
 
 	teachingMD := "# Persamaan Linear\nTeaching notes for linear equations."
-	if err := os.WriteFile(filepath.Join(dir, "F1-06.teaching.md"), []byte(teachingMD), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(topicsDir, "F1-06.teaching.md"), []byte(teachingMD), 0o644); err != nil {
 		t.Fatalf("write teaching notes: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(topicsDir, "F1-06.examples.yaml"), []byte(`
+topic_id: F1-06
+worked_examples:
+  - id: WE-01
+    topic: Solving linear equations
+    difficulty: easy
+    learning_objective: LO1
+    misconception_alert: Moving a term changes nothing.
+    scenario: Solve x plus 1 equals 2.
+    working: Subtract 1 from both sides.
+`), 0o644); err != nil {
+		t.Fatalf("write examples: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(topicsDir, "F1-06.assessments.yaml"), []byte(`
+topic_id: F1-06
+questions:
+  - id: Q1
+    text: Solve x plus 1 equals 2.
+    difficulty: easy
+    learning_objective: LO1
+    answer:
+      type: exact
+      value: "1"
+`), 0o644); err != nil {
+		t.Fatalf("write assessment: %v", err)
 	}
 
 	loader, err := curriculum.NewLoader(dir)

--- a/internal/agent/topic_unlock.go
+++ b/internal/agent/topic_unlock.go
@@ -61,6 +61,13 @@ func (e *Engine) checkTopicUnlocks(identity LearnerIdentity, syllabusID string, 
 	}
 
 	unlocked := e.prereqGraph.UnlockableTopics(topic.ID, scores)
+	ready := unlocked[:0]
+	for _, candidate := range unlocked {
+		if candidate.IsAITeachingReady() {
+			ready = append(ready, candidate)
+		}
+	}
+	unlocked = ready
 	if len(unlocked) == 0 {
 		return
 	}
@@ -144,7 +151,29 @@ func buildPrereqGraph(loader *curriculum.Loader) *curriculum.PrereqGraph {
 	if loader == nil {
 		return nil
 	}
-	topics := loader.AllTopics()
+	allTopics := loader.AllTopics()
+	readyIDs := make(map[string]struct{}, len(allTopics))
+	for _, topic := range allTopics {
+		if topic.IsAITeachingReady() {
+			readyIDs[topic.ID] = struct{}{}
+		}
+	}
+	topics := make([]curriculum.Topic, 0, len(readyIDs))
+	for _, topic := range allTopics {
+		if _, ready := readyIDs[topic.ID]; !ready {
+			continue
+		}
+		allPrerequisitesReady := true
+		for _, prerequisiteID := range topic.Prerequisites.RequiredTopicIDs() {
+			if _, ready := readyIDs[prerequisiteID]; !ready {
+				allPrerequisitesReady = false
+				break
+			}
+		}
+		if allPrerequisitesReady {
+			topics = append(topics, topic)
+		}
+	}
 	if len(topics) == 0 {
 		return nil
 	}
@@ -156,7 +185,7 @@ func buildPrereqGraph(loader *curriculum.Loader) *curriculum.PrereqGraph {
 		if len(t.Prerequisites.Required) > 0 {
 			slog.Debug("topic prerequisites",
 				"topic_id", t.ID,
-				"requires", fmt.Sprintf("%v", t.Prerequisites.Required),
+				"requires", fmt.Sprintf("%v", t.Prerequisites.RequiredTopicIDs()),
 			)
 		}
 	}

--- a/internal/agent/topic_unlock_test.go
+++ b/internal/agent/topic_unlock_test.go
@@ -4,6 +4,8 @@
 package agent
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -69,6 +71,19 @@ func TestPendingUnlocks_IsolatesSameExternalIDAcrossChannels(t *testing.T) {
 	}
 }
 
+func TestBuildPrereqGraphExcludesLowerQualityUnlockDestinations(t *testing.T) {
+	loader := newUnlockCurriculumLoader(t)
+	graph := buildPrereqGraph(loader)
+	if graph == nil {
+		t.Fatal("buildPrereqGraph() = nil, want graph for ready source topic")
+	}
+
+	unlocked := graph.UnlockableTopics("F1-01", map[string]float64{"F1-01": 1})
+	if len(unlocked) != 0 {
+		t.Fatalf("UnlockableTopics() = %#v, want lower-quality destination excluded", unlocked)
+	}
+}
+
 func TestFormatUnlockNotification(t *testing.T) {
 	topics := []curriculum.Topic{
 		{ID: "F1-06", Name: "Persamaan Linear"},
@@ -113,4 +128,102 @@ func TestFormatUnlockNotification_Chinese(t *testing.T) {
 	if !strings.Contains(msg, "线性方程") {
 		t.Errorf("expected Chinese topic name, got: %s", msg)
 	}
+}
+
+func newUnlockCurriculumLoader(t *testing.T) *curriculum.Loader {
+	t.Helper()
+	root := t.TempDir()
+	curriculumDir := filepath.Join(root, "curricula", "test")
+	topicsDir := filepath.Join(curriculumDir, "grade", "topics")
+	if err := os.MkdirAll(topicsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(topics) error = %v", err)
+	}
+	write := func(path, content string) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s) error = %v", path, err)
+		}
+	}
+	write(filepath.Join(curriculumDir, "syllabus.yaml"), `
+id: test-syllabus
+name: Test Syllabus
+subjects:
+  - test-math
+`)
+	write(filepath.Join(curriculumDir, "subject.yaml"), `
+id: test-math
+name: Test Mathematics
+syllabus_id: test-syllabus
+`)
+	write(filepath.Join(curriculumDir, "grade", "subject-grade.yaml"), `
+id: test-math-form-1
+name: Test Mathematics Form 1
+subject_id: test-math
+syllabus_id: test-syllabus
+topics:
+  - F1-01
+  - F1-02
+`)
+	write(filepath.Join(topicsDir, "F1-01.yaml"), `
+id: F1-01
+name: Ready Numbers
+subject_grade_id: test-math-form-1
+subject_id: test-math
+syllabus_id: test-syllabus
+content_standards:
+  - id: CS1
+    text: Numbers
+learning_objectives:
+  - id: LO1
+    content_standard_id: CS1
+    text: Compare numbers.
+quality_level: 3
+`)
+	write(filepath.Join(topicsDir, "F1-01.teaching.md"), "# Ready numbers\n")
+	write(filepath.Join(topicsDir, "F1-01.examples.yaml"), `
+topic_id: F1-01
+worked_examples:
+  - id: WE-01
+    topic: Comparing numbers
+    difficulty: easy
+    learning_objective: LO1
+    misconception_alert: The smaller number is larger.
+    scenario: Compare 2 and 1.
+    working: Locate both on a number line.
+`)
+	write(filepath.Join(topicsDir, "F1-01.assessments.yaml"), `
+topic_id: F1-01
+questions:
+  - id: Q1
+    text: Which is larger, 2 or 1?
+    difficulty: easy
+    learning_objective: LO1
+    answer:
+      type: exact
+      value: "2"
+`)
+	write(filepath.Join(topicsDir, "F1-02.yaml"), `
+id: F1-02
+name: Draft Algebra
+subject_grade_id: test-math-form-1
+subject_id: test-math
+syllabus_id: test-syllabus
+content_standards:
+  - id: CS2
+    text: Algebra
+learning_objectives:
+  - id: LO2
+    content_standard_id: CS2
+    text: Solve equations.
+prerequisites:
+  required:
+    - F1-01
+quality_level: 2
+`)
+
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	return loader
 }

--- a/internal/curriculum/clone.go
+++ b/internal/curriculum/clone.go
@@ -1,0 +1,62 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package curriculum
+
+import (
+	"maps"
+	"slices"
+)
+
+func cloneTopic(topic Topic) Topic {
+	topic.ContentStandards = slices.Clone(topic.ContentStandards)
+	topic.LearningObjectives = slices.Clone(topic.LearningObjectives)
+	topic.PerformanceStandards = slices.Clone(topic.PerformanceStandards)
+	topic.Prerequisites.Required = slices.Clone(topic.Prerequisites.Required)
+	topic.Prerequisites.Recommended = slices.Clone(topic.Prerequisites.Recommended)
+	topic.BackgroundKnowledge = slices.Clone(topic.BackgroundKnowledge)
+	topic.CrossCurriculum = slices.Clone(topic.CrossCurriculum)
+	topic.Teaching.Sequence = slices.Clone(topic.Teaching.Sequence)
+	topic.Teaching.CommonMisconceptions = slices.Clone(topic.Teaching.CommonMisconceptions)
+	topic.Teaching.EngagementHooks = slices.Clone(topic.Teaching.EngagementHooks)
+	return topic
+}
+
+func cloneConcept(concept Concept) Concept {
+	concept.Curricula = slices.Clone(concept.Curricula)
+	return concept
+}
+
+func cloneExampleSet(examples ExampleSet) ExampleSet {
+	examples.WorkedExamples = slices.Clone(examples.WorkedExamples)
+	return examples
+}
+
+func cloneAssessment(assessment Assessment) Assessment {
+	assessment.Questions = slices.Clone(assessment.Questions)
+	for index := range assessment.Questions {
+		question := &assessment.Questions[index]
+		question.Rubric = slices.Clone(question.Rubric)
+		question.Hints = slices.Clone(question.Hints)
+		question.Distractors = slices.Clone(question.Distractors)
+		question.Answer.Options = maps.Clone(question.Answer.Options)
+		question.Answer.Pairs = slices.Clone(question.Answer.Pairs)
+		question.Answer.Distractors = slices.Clone(question.Answer.Distractors)
+	}
+	return assessment
+}
+
+func cloneSyllabus(syllabus Syllabus) Syllabus {
+	syllabus.Subjects = slices.Clone(syllabus.Subjects)
+	return syllabus
+}
+
+func cloneSubject(subject Subject) Subject {
+	subject.Topics = slices.Clone(subject.Topics)
+	return subject
+}
+
+func cloneSubjectGrade(subjectGrade SubjectGrade) SubjectGrade {
+	subjectGrade.Topics = slices.Clone(subjectGrade.Topics)
+	return subjectGrade
+}

--- a/internal/curriculum/engine.go
+++ b/internal/curriculum/engine.go
@@ -1,0 +1,1081 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package curriculum
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/p-n-ai/pai-bot/internal/progress"
+)
+
+// TeachingAction is a deterministic pedagogical decision, not learner-facing copy.
+type TeachingAction string
+
+const (
+	// TeachingActionTeachAndCheck teaches the selected objective and offers a
+	// source-backed deterministic check when one is available.
+	TeachingActionTeachAndCheck TeachingAction = "teach_and_check"
+	// TeachingActionRepairPrerequisite redirects the turn to a required topic
+	// whose demonstrated mastery is below its OSS-authored threshold.
+	TeachingActionRepairPrerequisite TeachingAction = "repair_prerequisite"
+	// TeachingActionDiagnosePrerequisite checks a required topic before teaching
+	// when the learner has no recorded evidence for it.
+	TeachingActionDiagnosePrerequisite TeachingAction = "diagnose_prerequisite"
+)
+
+// ProgressStore is the curriculum engine's single mastery read/write boundary.
+type ProgressStore interface {
+	GetMasterySnapshot(context.Context, progress.LearnerID) ([]progress.MasterySnapshotItem, error)
+	RecordMasteryEvidence(context.Context, progress.MasteryEvidence) (progress.MasteryEvidenceResult, error)
+}
+
+// EngineConfig contains the curriculum engine's authoritative dependencies.
+type EngineConfig struct {
+	Loader   *Loader
+	Progress ProgressStore
+}
+
+// Engine plans teaching turns from OSS and records gradeable learner evidence.
+type Engine struct {
+	loader   *Loader
+	progress ProgressStore
+}
+
+// ErrAssessmentNotGradeable means OSS does not provide a deterministic answer
+// contract for the requested question.
+var ErrAssessmentNotGradeable = errors.New("assessment question is not deterministically gradeable")
+
+// ErrTopicNotAITeachingReady means OSS does not explicitly claim that a topic
+// meets the minimum quality contract for AI teaching.
+var ErrTopicNotAITeachingReady = errors.New("topic is not ready for AI teaching")
+
+// NewEngine constructs a curriculum engine over one validated OSS snapshot.
+func NewEngine(config EngineConfig) (*Engine, error) {
+	if config.Loader == nil {
+		return nil, fmt.Errorf("curriculum loader is required")
+	}
+	if config.Progress == nil {
+		return nil, fmt.Errorf("curriculum progress store is required")
+	}
+	return &Engine{
+		loader:   config.Loader,
+		progress: config.Progress,
+	}, nil
+}
+
+// PlanTurnInput identifies the learner and curriculum target for one read-only
+// planning decision. Topic resolution from free-form chat belongs to the harness.
+type PlanTurnInput struct {
+	LearnerID   progress.LearnerID
+	TopicID     string
+	ObjectiveID string
+	Locale      string
+}
+
+// TeachingTarget is the exact topic and objective selected for this turn.
+type TeachingTarget struct {
+	TopicID          string
+	TopicName        string
+	SyllabusID       string
+	ObjectiveID      string
+	Objective        string
+	MasteryScore     float64
+	MasteryKnown     bool
+	EvidenceCount    int
+	EvidenceRequired int
+}
+
+// EvidenceRef traces one planning fact to an OSS artifact.
+type EvidenceRef struct {
+	SourcePath  string
+	SourceKind  string
+	Revision    string
+	TopicID     string
+	ObjectiveID string
+	QuestionID  string
+	Provenance  string
+}
+
+// CurriculumNodeKind identifies one validated curriculum artifact or a
+// topic-scoped teaching identity.
+type CurriculumNodeKind string
+
+const (
+	CurriculumNodeKindSyllabus      CurriculumNodeKind = "syllabus"
+	CurriculumNodeKindSubject       CurriculumNodeKind = "subject"
+	CurriculumNodeKindSubjectGrade  CurriculumNodeKind = "subject_grade"
+	CurriculumNodeKindTopic         CurriculumNodeKind = "topic"
+	CurriculumNodeKindObjective     CurriculumNodeKind = "objective"
+	CurriculumNodeKindQuestion      CurriculumNodeKind = "question"
+	CurriculumNodeKindConcept       CurriculumNodeKind = "concept"
+	CurriculumNodeKindTeachingNote  CurriculumNodeKind = "teaching_note"
+	CurriculumNodeKindWorkedExample CurriculumNodeKind = "worked_example"
+)
+
+// CurriculumRelationType identifies a source-backed edge projected from the
+// validated curriculum snapshot.
+type CurriculumRelationType string
+
+const (
+	CurriculumRelationContains          CurriculumRelationType = "contains"
+	CurriculumRelationContainsObjective CurriculumRelationType = "contains_objective"
+	CurriculumRelationRequires          CurriculumRelationType = "requires"
+	CurriculumRelationAssessedBy        CurriculumRelationType = "assessed_by"
+	CurriculumRelationLocalizedBy       CurriculumRelationType = "localized_by"
+	CurriculumRelationSharesConcept     CurriculumRelationType = "shares_concept"
+	CurriculumRelationGuidedBy          CurriculumRelationType = "guided_by"
+	CurriculumRelationIllustratedBy     CurriculumRelationType = "illustrated_by"
+)
+
+// CurriculumNodeRef identifies one endpoint of a plan relation. TopicID scopes
+// objective and question IDs, which are only unique within a topic.
+type CurriculumNodeRef struct {
+	Kind    CurriculumNodeKind
+	ID      string
+	TopicID string
+	Locale  string
+}
+
+// CurriculumRelation is a deterministic, cited projection of the validated
+// OSS snapshot. It is evidence for a plan, not a mutable graph store.
+type CurriculumRelation struct {
+	Type     CurriculumRelationType
+	From     CurriculumNodeRef
+	Via      CurriculumNodeRef
+	To       CurriculumNodeRef
+	Evidence EvidenceRef
+}
+
+// PlannedCheck is a source-backed question that RecordAttempt may grade.
+type PlannedCheck struct {
+	TopicID     string
+	ObjectiveID string
+	QuestionID  string
+	Question    string
+	Options     []CheckOption
+	AnswerType  string
+	Difficulty  string
+	SourcePath  string
+}
+
+// CheckOption is one ordered learner-visible multiple-choice option.
+type CheckOption struct {
+	ID   string
+	Text string
+}
+
+// SourcedTeachingGuidance carries source-authored guidance that is useful to a
+// tutor but is not trusted policy.
+type SourcedTeachingGuidance struct {
+	BackgroundKnowledge  []string
+	CommonMisconceptions []CommonMisconception
+	EngagementHooks      []string
+	Evidence             EvidenceRef
+}
+
+// TeachingNoteMaterial is one source-cited Markdown note.
+type TeachingNoteMaterial struct {
+	Content  string
+	Evidence EvidenceRef
+}
+
+// WorkedExampleMaterial is one typed example cited to its backing artifact.
+type WorkedExampleMaterial struct {
+	Example  WorkedExample
+	Evidence EvidenceRef
+}
+
+// TeachingMaterials contains source prose available to the tutor.
+type TeachingMaterials struct {
+	TeachingNote   *TeachingNoteMaterial
+	WorkedExamples []WorkedExampleMaterial
+}
+
+// TeachingPlan is structured policy and evidence for a tutor. It deliberately
+// contains no final learner-facing response.
+type TeachingPlan struct {
+	Action           TeachingAction
+	Target           TeachingTarget
+	TeachingSequence []string
+	Guidance         SourcedTeachingGuidance
+	Materials        TeachingMaterials
+	Check            *PlannedCheck
+	Evidence         []EvidenceRef
+	Relations        []CurriculumRelation
+	Constraints      []string
+	Rationale        []string
+}
+
+// AttemptInput contains learner-authored evidence for one exact OSS question.
+// It intentionally has no tutor-response field.
+type AttemptInput struct {
+	AttemptID  string
+	LearnerID  progress.LearnerID
+	TopicID    string
+	QuestionID string
+	Answer     string
+	Locale     string
+}
+
+// AttemptResult is the deterministic grade and resulting mastery transition.
+type AttemptResult struct {
+	Applied       bool
+	Correct       bool
+	Score         float64
+	MasteryBefore float64
+	MasteryAfter  float64
+	Evidence      EvidenceRef
+}
+
+// PlanTurn returns a deterministic, read-only teaching plan.
+func (e *Engine) PlanTurn(ctx context.Context, input PlanTurnInput) (TeachingPlan, error) {
+	if err := ctx.Err(); err != nil {
+		return TeachingPlan{}, err
+	}
+	topicID := strings.TrimSpace(input.TopicID)
+	if input.LearnerID.String() == "" {
+		return TeachingPlan{}, fmt.Errorf("learner ID is required")
+	}
+	if topicID == "" {
+		return TeachingPlan{}, fmt.Errorf("topic ID is required")
+	}
+	topic, found := e.loader.GetTopic(topicID)
+	if !found {
+		return TeachingPlan{}, fmt.Errorf("topic %q not found", topicID)
+	}
+	if err := requireAITeachingReady(topic); err != nil {
+		return TeachingPlan{}, err
+	}
+	mastery, err := e.masteryObservations(ctx, input.LearnerID)
+	if err != nil {
+		return TeachingPlan{}, fmt.Errorf("read learner mastery: %w", err)
+	}
+
+	block, err := e.firstPrerequisiteBlock(topic, mastery)
+	if err != nil {
+		return TeachingPlan{}, err
+	}
+	if block != nil {
+		plan, err := e.planForTopic(block.topic, "", input.Locale, block.observation)
+		if err != nil {
+			return TeachingPlan{}, err
+		}
+		plan.Action = block.action
+		plan.Relations = append(e.prerequisitePathRelations(block.path), plan.Relations...)
+		plan.Rationale = append(plan.Rationale, block.rationale)
+		return plan, nil
+	}
+
+	observation := mastery[masteryKey(topic.SyllabusID, topic.ID)]
+	return e.planForTopic(topic, input.ObjectiveID, input.Locale, observation)
+}
+
+type prerequisiteBlock struct {
+	topic       Topic
+	observation masteryObservation
+	action      TeachingAction
+	rationale   string
+	path        []prerequisiteStep
+}
+
+type prerequisiteStep struct {
+	dependent    Topic
+	prerequisite Topic
+}
+
+func (e *Engine) firstPrerequisiteBlock(
+	topic Topic,
+	mastery map[string]masteryObservation,
+) (*prerequisiteBlock, error) {
+	for _, prerequisiteRef := range topic.Prerequisites.Required {
+		prerequisiteID := prerequisiteRef.TopicID
+		prerequisite, found := e.loader.GetTopic(prerequisiteID)
+		if !found {
+			return nil, fmt.Errorf("topic %q requires missing prerequisite %q", topic.ID, prerequisiteID)
+		}
+		nested, err := e.firstPrerequisiteBlock(prerequisite, mastery)
+		if err != nil {
+			return nil, err
+		}
+		step := prerequisiteStep{dependent: topic, prerequisite: prerequisite}
+		if nested != nil {
+			nested.path = append([]prerequisiteStep{step}, nested.path...)
+			return nested, nil
+		}
+
+		observation := mastery[masteryKey(prerequisite.SyllabusID, prerequisite.ID)]
+		switch {
+		case !observation.known:
+			return &prerequisiteBlock{
+				topic:       prerequisite,
+				observation: observation,
+				action:      TeachingActionDiagnosePrerequisite,
+				rationale:   fmt.Sprintf("required prerequisite %s has no recorded learner evidence", prerequisite.ID),
+				path:        []prerequisiteStep{step},
+			}, nil
+		case observation.score < masteryThreshold(prerequisite):
+			return &prerequisiteBlock{
+				topic:       prerequisite,
+				observation: observation,
+				action:      TeachingActionRepairPrerequisite,
+				rationale:   fmt.Sprintf("required prerequisite %s is below its mastery threshold", prerequisite.ID),
+				path:        []prerequisiteStep{step},
+			}, nil
+		case observation.evidenceCount < minimumAssessmentCount(prerequisite):
+			return &prerequisiteBlock{
+				topic:       prerequisite,
+				observation: observation,
+				action:      TeachingActionDiagnosePrerequisite,
+				rationale: fmt.Sprintf(
+					"required prerequisite %s has %d of %d required assessment sessions",
+					prerequisite.ID,
+					observation.evidenceCount,
+					minimumAssessmentCount(prerequisite),
+				),
+				path: []prerequisiteStep{step},
+			}, nil
+		}
+	}
+	return nil, nil
+}
+
+// RecordAttempt grades one source-backed deterministic question and records the
+// resulting learner evidence. Ordinary conversation cannot enter this path.
+func (e *Engine) RecordAttempt(ctx context.Context, input AttemptInput) (AttemptResult, error) {
+	if err := ctx.Err(); err != nil {
+		return AttemptResult{}, err
+	}
+	attemptID := strings.TrimSpace(input.AttemptID)
+	topicID := strings.TrimSpace(input.TopicID)
+	questionID := strings.TrimSpace(input.QuestionID)
+	if input.LearnerID.String() == "" {
+		return AttemptResult{}, fmt.Errorf("learner ID is required")
+	}
+	if attemptID == "" || topicID == "" || questionID == "" {
+		return AttemptResult{}, fmt.Errorf("attempt ID, topic ID, and question ID are required")
+	}
+	topic, found := e.loader.GetTopic(topicID)
+	if !found {
+		return AttemptResult{}, fmt.Errorf("topic %q not found", topicID)
+	}
+	if err := requireAITeachingReady(topic); err != nil {
+		return AttemptResult{}, err
+	}
+	assessment, found := e.loader.GetAssessment(topicID)
+	if !found {
+		return AttemptResult{}, fmt.Errorf("assessment for topic %q not found", topicID)
+	}
+	question, found := assessmentQuestion(assessment, questionID)
+	if !found {
+		return AttemptResult{}, fmt.Errorf("assessment question %q not found for topic %q", questionID, topicID)
+	}
+	if !isDeterministicallyGradeable(question.Answer.Type) {
+		return AttemptResult{}, fmt.Errorf("%w: %s/%s uses %q", ErrAssessmentNotGradeable, topicID, questionID, question.Answer.Type)
+	}
+
+	presentationQuestion, _, _ := localizedAssessmentQuestion(e.loader, topic.ID, input.Locale, question)
+	correct := gradeDeterministicAnswer(question, presentationQuestion, input.Answer)
+	score := 0.0
+	if correct {
+		score = 1
+	}
+	transition, err := e.progress.RecordMasteryEvidence(ctx, progress.MasteryEvidence{
+		AttemptID:      attemptID,
+		LearnerID:      input.LearnerID,
+		SyllabusID:     topic.SyllabusID,
+		TopicID:        topic.ID,
+		SourceKind:     assessment.Source.Kind,
+		SourceID:       question.ID,
+		SourceRevision: assessment.Source.Revision,
+		Score:          score,
+		PayloadHash:    attemptPayloadHash(topic, question, input.Answer),
+	})
+	if err != nil {
+		return AttemptResult{}, fmt.Errorf("record mastery evidence: %w", err)
+	}
+
+	return AttemptResult{
+		Applied:       transition.Applied,
+		Correct:       correct,
+		Score:         score,
+		MasteryBefore: transition.MasteryBefore,
+		MasteryAfter:  transition.MasteryAfter,
+		Evidence: EvidenceRef{
+			SourcePath:  assessment.Source.Path,
+			SourceKind:  assessment.Source.Kind,
+			Revision:    assessment.Source.Revision,
+			TopicID:     topic.ID,
+			ObjectiveID: question.LearningObjective,
+			QuestionID:  question.ID,
+			Provenance:  assessment.Provenance,
+		},
+	}, nil
+}
+
+func attemptPayloadHash(topic Topic, question AssessmentQuestion, answer string) [32]byte {
+	payload := strings.Join([]string{
+		"curriculum-attempt/v1",
+		topic.SyllabusID,
+		topic.ID,
+		question.ID,
+		question.Answer.Type,
+		normalizeDeterministicAnswer(answer),
+	}, "\x00")
+	return sha256.Sum256([]byte(payload))
+}
+
+type masteryObservation struct {
+	score         float64
+	known         bool
+	evidenceCount int
+}
+
+func (e *Engine) masteryObservations(ctx context.Context, learnerID progress.LearnerID) (map[string]masteryObservation, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	snapshot, err := e.progress.GetMasterySnapshot(ctx, learnerID)
+	if err != nil {
+		return nil, err
+	}
+	observations := make(map[string]masteryObservation, len(snapshot))
+	for _, item := range snapshot {
+		observations[masteryKey(item.SyllabusID, item.TopicID)] = masteryObservation{
+			score:         item.MasteryScore,
+			known:         item.MasteryKnown,
+			evidenceCount: item.EvidenceCount,
+		}
+	}
+	return observations, nil
+}
+
+func masteryKey(syllabusID, topicID string) string {
+	return syllabusID + "\x00" + topicID
+}
+
+func (e *Engine) planForTopic(topic Topic, objectiveID, locale string, mastery masteryObservation) (TeachingPlan, error) {
+	if err := requireAITeachingReady(topic); err != nil {
+		return TeachingPlan{}, err
+	}
+	selected := localizedTopic(e.loader, topic, locale)
+	objective, err := selectObjective(selected, objectiveID)
+	if err != nil {
+		return TeachingPlan{}, err
+	}
+
+	plan := TeachingPlan{
+		Action: TeachingActionTeachAndCheck,
+		Target: TeachingTarget{
+			TopicID:          selected.ID,
+			TopicName:        localizedTopicName(selected),
+			SyllabusID:       selected.SyllabusID,
+			ObjectiveID:      objective.ID,
+			Objective:        localizedObjectiveText(selected.Language, objective),
+			MasteryScore:     mastery.score,
+			MasteryKnown:     mastery.known,
+			EvidenceCount:    mastery.evidenceCount,
+			EvidenceRequired: minimumAssessmentCount(topic),
+		},
+		TeachingSequence: append([]string(nil), selected.Teaching.Sequence...),
+		Guidance: SourcedTeachingGuidance{
+			BackgroundKnowledge:  append([]string(nil), topic.BackgroundKnowledge...),
+			CommonMisconceptions: append([]CommonMisconception(nil), topic.Teaching.CommonMisconceptions...),
+			EngagementHooks:      append([]string(nil), topic.Teaching.EngagementHooks...),
+			Evidence:             sourceEvidence(topic.Source, topic.ID, "", "", topic.Provenance),
+		},
+		Evidence: []EvidenceRef{{
+			SourcePath:  topic.Source.Path,
+			SourceKind:  topic.Source.Kind,
+			Revision:    topic.Source.Revision,
+			TopicID:     topic.ID,
+			ObjectiveID: objective.ID,
+			Provenance:  topic.Provenance,
+		}},
+		Constraints: []string{
+			"do not update mastery from tutor prose or ordinary conversation",
+			"update mastery only through RecordAttempt with a source-backed deterministic question",
+		},
+		Rationale: []string{
+			"target selected from the validated OSS topic and objective graph",
+		},
+	}
+	plan.Relations, err = e.topicRelations(topic, selected, objective)
+	if err != nil {
+		return TeachingPlan{}, err
+	}
+	if selected.Source.Path != topic.Source.Path {
+		plan.Evidence = append(plan.Evidence, EvidenceRef{
+			SourcePath:  selected.Source.Path,
+			SourceKind:  selected.Source.Kind,
+			Revision:    selected.Source.Revision,
+			TopicID:     selected.ID,
+			ObjectiveID: objective.ID,
+			Provenance:  selected.Provenance,
+		})
+	}
+	e.addTeachingMaterials(&plan, topic, locale)
+
+	assessment, found := e.loader.GetAssessment(topic.ID)
+	if !found {
+		plan.Constraints = append(plan.Constraints, "no source assessment is available for this topic")
+		return plan, nil
+	}
+	question, found := selectGradeableQuestion(assessment, objective.ID)
+	if !found {
+		plan.Constraints = append(plan.Constraints, "no deterministic source assessment is available for this objective")
+		return plan, nil
+	}
+	presentationQuestion, presentationSource, localized := localizedAssessmentQuestion(
+		e.loader,
+		topic.ID,
+		locale,
+		question,
+	)
+	plan.Check = &PlannedCheck{
+		TopicID:     topic.ID,
+		ObjectiveID: question.LearningObjective,
+		QuestionID:  question.ID,
+		Question:    presentationQuestion.Text,
+		Options:     orderedCheckOptions(presentationQuestion.Answer.Options),
+		AnswerType:  question.Answer.Type,
+		Difficulty:  question.Difficulty,
+		SourcePath:  presentationSource.Path,
+	}
+	plan.Evidence = append(plan.Evidence, EvidenceRef{
+		SourcePath:  assessment.Source.Path,
+		SourceKind:  assessment.Source.Kind,
+		Revision:    assessment.Source.Revision,
+		TopicID:     topic.ID,
+		ObjectiveID: question.LearningObjective,
+		QuestionID:  question.ID,
+		Provenance:  assessment.Provenance,
+	})
+	plan.Relations = append(plan.Relations, newCurriculumRelation(
+		CurriculumRelationAssessedBy,
+		objectiveNode(topic.ID, question.LearningObjective, ""),
+		questionNode(topic.ID, question.ID, ""),
+		sourceEvidence(
+			assessment.Source,
+			topic.ID,
+			question.LearningObjective,
+			question.ID,
+			assessment.Provenance,
+		),
+	))
+	if localized {
+		variant, _ := e.loader.GetAssessmentVariant(topic.ID, strings.TrimSpace(locale))
+		plan.Evidence = append(plan.Evidence, EvidenceRef{
+			SourcePath:  presentationSource.Path,
+			SourceKind:  presentationSource.Kind,
+			Revision:    presentationSource.Revision,
+			TopicID:     topic.ID,
+			ObjectiveID: presentationQuestion.LearningObjective,
+			QuestionID:  presentationQuestion.ID,
+			Provenance:  variant.Provenance,
+		})
+		plan.Relations = append(plan.Relations, newCurriculumRelation(
+			CurriculumRelationLocalizedBy,
+			questionNode(topic.ID, question.ID, ""),
+			questionNode(topic.ID, presentationQuestion.ID, strings.TrimSpace(locale)),
+			sourceEvidence(
+				presentationSource,
+				topic.ID,
+				presentationQuestion.LearningObjective,
+				presentationQuestion.ID,
+				variant.Provenance,
+			),
+		))
+	}
+	return plan, nil
+}
+
+func (e *Engine) addTeachingMaterials(plan *TeachingPlan, topic Topic, locale string) {
+	note, found := e.loader.GetTeachingNote(topic.ID)
+	locale = strings.TrimSpace(locale)
+	if locale != "" {
+		if variant, variantFound := e.loader.GetTeachingNoteVariant(topic.ID, locale); variantFound {
+			note = variant
+			found = true
+		}
+	}
+	if found {
+		evidence := sourceEvidence(note.Source, topic.ID, "", "", "")
+		plan.Materials.TeachingNote = &TeachingNoteMaterial{
+			Content:  note.Content,
+			Evidence: evidence,
+		}
+		plan.Evidence = append(plan.Evidence, evidence)
+		plan.Relations = append(plan.Relations, newCurriculumRelation(
+			CurriculumRelationGuidedBy,
+			curriculumNode(CurriculumNodeKindTopic, topic.ID),
+			teachingNoteNode(topic.ID, note.Source.Locale),
+			evidence,
+		))
+	}
+
+	examples, found := e.loader.GetExamples(topic.ID)
+	if locale != "" {
+		if variant, variantFound := e.loader.GetExamplesVariant(topic.ID, locale); variantFound {
+			examples = variant
+			found = true
+		}
+	}
+	if !found {
+		return
+	}
+	artifactEvidence := sourceEvidence(
+		examples.Source,
+		topic.ID,
+		"",
+		"",
+		examples.Provenance,
+	)
+	plan.Evidence = append(plan.Evidence, artifactEvidence)
+	for _, example := range examples.WorkedExamples {
+		evidence := sourceEvidence(
+			examples.Source,
+			topic.ID,
+			example.LearningObjective,
+			"",
+			examples.Provenance,
+		)
+		plan.Materials.WorkedExamples = append(
+			plan.Materials.WorkedExamples,
+			WorkedExampleMaterial{Example: example, Evidence: evidence},
+		)
+		from := curriculumNode(CurriculumNodeKindTopic, topic.ID)
+		if example.LearningObjective != "" {
+			from = objectiveNode(topic.ID, example.LearningObjective, "")
+		}
+		plan.Relations = append(plan.Relations, newCurriculumRelation(
+			CurriculumRelationIllustratedBy,
+			from,
+			workedExampleNode(topic.ID, example.ID, examples.Source.Locale),
+			evidence,
+		))
+	}
+}
+
+func requireAITeachingReady(topic Topic) error {
+	if topic.IsAITeachingReady() {
+		return nil
+	}
+	return fmt.Errorf(
+		"%w: topic %q has no explicit source quality level of 3 or higher",
+		ErrTopicNotAITeachingReady,
+		topic.ID,
+	)
+}
+
+func (e *Engine) topicRelations(
+	topic Topic,
+	selected Topic,
+	objective LearningObjective,
+) ([]CurriculumRelation, error) {
+	subjectGrade, found := e.loader.GetSubjectGrade(topic.SubjectGradeID)
+	if !found {
+		return nil, fmt.Errorf("topic %q references missing subject grade %q", topic.ID, topic.SubjectGradeID)
+	}
+	subject, found := e.loader.GetSubject(topic.SubjectID)
+	if !found {
+		return nil, fmt.Errorf("topic %q references missing subject %q", topic.ID, topic.SubjectID)
+	}
+	syllabus, found := e.loader.GetSyllabus(topic.SyllabusID)
+	if !found {
+		return nil, fmt.Errorf("topic %q references missing syllabus %q", topic.ID, topic.SyllabusID)
+	}
+
+	relations := []CurriculumRelation{
+		newCurriculumRelation(
+			CurriculumRelationContains,
+			curriculumNode(CurriculumNodeKindSyllabus, syllabus.ID),
+			curriculumNode(CurriculumNodeKindSubject, subject.ID),
+			sourceEvidence(syllabus.Source, "", "", "", ""),
+		),
+		newCurriculumRelation(
+			CurriculumRelationContains,
+			curriculumNode(CurriculumNodeKindSubject, subject.ID),
+			curriculumNode(CurriculumNodeKindSubjectGrade, subjectGrade.ID),
+			sourceEvidence(subjectGrade.Source, "", "", "", subjectGrade.Provenance),
+		),
+		newCurriculumRelation(
+			CurriculumRelationContains,
+			curriculumNode(CurriculumNodeKindSubjectGrade, subjectGrade.ID),
+			curriculumNode(CurriculumNodeKindTopic, topic.ID),
+			sourceEvidence(subjectGrade.Source, topic.ID, "", "", subjectGrade.Provenance),
+		),
+		newCurriculumRelation(
+			CurriculumRelationContainsObjective,
+			curriculumNode(CurriculumNodeKindTopic, topic.ID),
+			objectiveNode(topic.ID, objective.ID, ""),
+			sourceEvidence(topic.Source, topic.ID, objective.ID, "", topic.Provenance),
+		),
+	}
+	for _, prerequisite := range topic.Prerequisites.Required {
+		relations = append(relations, newCurriculumRelation(
+			CurriculumRelationRequires,
+			curriculumNode(CurriculumNodeKindTopic, topic.ID),
+			curriculumNode(CurriculumNodeKindTopic, prerequisite.TopicID),
+			sourceEvidence(topic.Source, topic.ID, "", "", topic.Provenance),
+		))
+	}
+	for _, concept := range e.loader.ConceptsForTopic(topic.SyllabusID, topic.ID) {
+		for _, occurrence := range concept.Curricula {
+			if occurrence.SyllabusID == topic.SyllabusID && occurrence.TopicID == topic.ID {
+				continue
+			}
+			relations = append(relations, CurriculumRelation{
+				Type: CurriculumRelationSharesConcept,
+				From: curriculumNode(CurriculumNodeKindTopic, topic.ID),
+				Via:  curriculumNode(CurriculumNodeKindConcept, concept.ID),
+				To:   curriculumNode(CurriculumNodeKindTopic, occurrence.TopicID),
+				Evidence: sourceEvidence(
+					concept.Source,
+					topic.ID,
+					"",
+					"",
+					"",
+				),
+			})
+		}
+	}
+	if selected.Source.Path != topic.Source.Path {
+		locale := selected.Source.Locale
+		relations = append(
+			relations,
+			newCurriculumRelation(
+				CurriculumRelationLocalizedBy,
+				curriculumNode(CurriculumNodeKindTopic, topic.ID),
+				curriculumNodeWithLocale(CurriculumNodeKindTopic, topic.ID, locale),
+				sourceEvidence(selected.Source, topic.ID, "", "", selected.Provenance),
+			),
+			newCurriculumRelation(
+				CurriculumRelationLocalizedBy,
+				objectiveNode(topic.ID, objective.ID, ""),
+				objectiveNode(topic.ID, objective.ID, locale),
+				sourceEvidence(selected.Source, topic.ID, objective.ID, "", selected.Provenance),
+			),
+		)
+	}
+	return relations, nil
+}
+
+func (e *Engine) prerequisitePathRelations(path []prerequisiteStep) []CurriculumRelation {
+	relations := make([]CurriculumRelation, 0, len(path))
+	for _, step := range path {
+		relations = append(relations, newCurriculumRelation(
+			CurriculumRelationRequires,
+			curriculumNode(CurriculumNodeKindTopic, step.dependent.ID),
+			curriculumNode(CurriculumNodeKindTopic, step.prerequisite.ID),
+			sourceEvidence(
+				step.dependent.Source,
+				step.dependent.ID,
+				"",
+				"",
+				step.dependent.Provenance,
+			),
+		))
+	}
+	return relations
+}
+
+func newCurriculumRelation(
+	relationType CurriculumRelationType,
+	from CurriculumNodeRef,
+	to CurriculumNodeRef,
+	evidence EvidenceRef,
+) CurriculumRelation {
+	return CurriculumRelation{
+		Type:     relationType,
+		From:     from,
+		To:       to,
+		Evidence: evidence,
+	}
+}
+
+func sourceEvidence(
+	source SourceRef,
+	topicID, objectiveID, questionID, provenance string,
+) EvidenceRef {
+	return EvidenceRef{
+		SourcePath:  source.Path,
+		SourceKind:  source.Kind,
+		Revision:    source.Revision,
+		TopicID:     topicID,
+		ObjectiveID: objectiveID,
+		QuestionID:  questionID,
+		Provenance:  provenance,
+	}
+}
+
+func curriculumNode(kind CurriculumNodeKind, id string) CurriculumNodeRef {
+	return CurriculumNodeRef{Kind: kind, ID: id}
+}
+
+func curriculumNodeWithLocale(kind CurriculumNodeKind, id, locale string) CurriculumNodeRef {
+	return CurriculumNodeRef{Kind: kind, ID: id, Locale: locale}
+}
+
+func objectiveNode(topicID, objectiveID, locale string) CurriculumNodeRef {
+	return CurriculumNodeRef{
+		Kind:    CurriculumNodeKindObjective,
+		ID:      objectiveID,
+		TopicID: topicID,
+		Locale:  locale,
+	}
+}
+
+func questionNode(topicID, questionID, locale string) CurriculumNodeRef {
+	return CurriculumNodeRef{
+		Kind:    CurriculumNodeKindQuestion,
+		ID:      questionID,
+		TopicID: topicID,
+		Locale:  locale,
+	}
+}
+
+func teachingNoteNode(topicID, locale string) CurriculumNodeRef {
+	return CurriculumNodeRef{
+		Kind:    CurriculumNodeKindTeachingNote,
+		ID:      topicID,
+		TopicID: topicID,
+		Locale:  locale,
+	}
+}
+
+func workedExampleNode(topicID, exampleID, locale string) CurriculumNodeRef {
+	return CurriculumNodeRef{
+		Kind:    CurriculumNodeKindWorkedExample,
+		ID:      exampleID,
+		TopicID: topicID,
+		Locale:  locale,
+	}
+}
+
+func localizedAssessmentQuestion(
+	loader *Loader,
+	topicID, locale string,
+	canonical AssessmentQuestion,
+) (AssessmentQuestion, SourceRef, bool) {
+	assessment, _ := loader.GetAssessment(topicID)
+	source := assessment.Source
+	locale = strings.TrimSpace(locale)
+	if locale == "" {
+		return canonical, source, false
+	}
+	variant, found := loader.GetAssessmentVariant(topicID, locale)
+	if !found {
+		return canonical, source, false
+	}
+	question, found := assessmentQuestion(variant, canonical.ID)
+	if !found {
+		return canonical, source, false
+	}
+	return question, variant.Source, true
+}
+
+func orderedCheckOptions(options AssessmentOptions) []CheckOption {
+	if len(options) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(options))
+	for id := range options {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	result := make([]CheckOption, 0, len(ids))
+	for _, id := range ids {
+		result = append(result, CheckOption{ID: id, Text: options[id]})
+	}
+	return result
+}
+
+func masteryThreshold(topic Topic) float64 {
+	if topic.Mastery.minimumScoreSet || topic.Mastery.MinimumScore != 0 {
+		return topic.Mastery.MinimumScore
+	}
+	return progress.MasteryThreshold
+}
+
+func minimumAssessmentCount(topic Topic) int {
+	if topic.Mastery.assessmentSet || topic.Mastery.AssessmentCount != 0 {
+		return topic.Mastery.AssessmentCount
+	}
+	return 1
+}
+
+func localizedTopic(loader *Loader, canonical Topic, locale string) Topic {
+	locale = strings.TrimSpace(locale)
+	if locale == "" || locale == canonical.Language {
+		return canonical
+	}
+	variant, found := loader.GetTopicVariant(canonical.ID, locale)
+	if !found {
+		return canonical
+	}
+
+	localized := canonical
+	localized.Language = variant.Language
+	localized.Source = variant.Source
+	localized.Provenance = variant.Provenance
+	if variant.Name != "" {
+		localized.Name = variant.Name
+	}
+	if variant.NameEN != "" {
+		localized.NameEN = variant.NameEN
+	}
+	localizedObjectives := append([]LearningObjective(nil), canonical.LearningObjectives...)
+	variantObjectives := make(map[string]LearningObjective, len(variant.LearningObjectives))
+	for _, objective := range variant.LearningObjectives {
+		variantObjectives[objective.ID] = objective
+	}
+	for index, objective := range localizedObjectives {
+		variantObjective, found := variantObjectives[objective.ID]
+		if !found {
+			continue
+		}
+		if variantObjective.Text != "" {
+			objective.Text = variantObjective.Text
+		}
+		if variantObjective.TextEN != "" {
+			objective.TextEN = variantObjective.TextEN
+		}
+		localizedObjectives[index] = objective
+	}
+	localized.LearningObjectives = localizedObjectives
+	return localized
+}
+
+func localizedTopicName(topic Topic) string {
+	if topic.Language == "en" && strings.TrimSpace(topic.NameEN) != "" {
+		return topic.NameEN
+	}
+	if strings.TrimSpace(topic.Name) != "" {
+		return topic.Name
+	}
+	return topic.NameEN
+}
+
+func localizedObjectiveText(language string, objective LearningObjective) string {
+	if language == "en" && strings.TrimSpace(objective.TextEN) != "" {
+		return objective.TextEN
+	}
+	if strings.TrimSpace(objective.Text) != "" {
+		return objective.Text
+	}
+	return objective.TextEN
+}
+
+func selectObjective(topic Topic, objectiveID string) (LearningObjective, error) {
+	if len(topic.LearningObjectives) == 0 {
+		return LearningObjective{}, fmt.Errorf("topic %q has no learning objectives", topic.ID)
+	}
+	objectiveID = strings.TrimSpace(objectiveID)
+	if objectiveID == "" {
+		return topic.LearningObjectives[0], nil
+	}
+	for _, objective := range topic.LearningObjectives {
+		if objective.ID == objectiveID {
+			return objective, nil
+		}
+	}
+	return LearningObjective{}, fmt.Errorf("topic %q has no objective %q", topic.ID, objectiveID)
+}
+
+func selectGradeableQuestion(assessment Assessment, objectiveID string) (AssessmentQuestion, bool) {
+	for _, question := range assessment.Questions {
+		if question.LearningObjective == objectiveID && isDeterministicallyGradeable(question.Answer.Type) {
+			return question, true
+		}
+	}
+	return AssessmentQuestion{}, false
+}
+
+func assessmentQuestion(assessment Assessment, questionID string) (AssessmentQuestion, bool) {
+	for _, question := range assessment.Questions {
+		if question.ID == questionID {
+			return question, true
+		}
+	}
+	return AssessmentQuestion{}, false
+}
+
+func isDeterministicallyGradeable(answerType string) bool {
+	switch answerType {
+	case "exact", "multiple_choice":
+		return true
+	default:
+		return false
+	}
+}
+
+func gradeDeterministicAnswer(canonical, presentation AssessmentQuestion, answer string) bool {
+	actual := normalizeDeterministicAnswer(answer)
+	if actual == "" {
+		return false
+	}
+	expected := normalizeDeterministicAnswer(canonical.Answer.Value)
+	if expected != "" && actual == expected {
+		return true
+	}
+	localizedExpected := normalizeDeterministicAnswer(presentation.Answer.Value)
+	if localizedExpected != "" && actual == localizedExpected {
+		return true
+	}
+	if canonical.Answer.Type != "multiple_choice" {
+		return false
+	}
+	for _, question := range []AssessmentQuestion{canonical, presentation} {
+		optionID := correctOptionID(question)
+		if optionID != "" && actual == normalizeDeterministicAnswer(optionID) {
+			return true
+		}
+	}
+	return false
+}
+
+func correctOptionID(question AssessmentQuestion) string {
+	expected := normalizeDeterministicAnswer(question.Answer.Value)
+	var matchedKey string
+	for id := range question.Answer.Options {
+		if normalizeDeterministicAnswer(id) != expected {
+			continue
+		}
+		if matchedKey != "" {
+			return ""
+		}
+		matchedKey = id
+	}
+	if matchedKey != "" {
+		return matchedKey
+	}
+
+	var matchedValue string
+	for id, value := range question.Answer.Options {
+		if normalizeDeterministicAnswer(value) != expected {
+			continue
+		}
+		if matchedValue != "" {
+			return ""
+		}
+		matchedValue = id
+	}
+	return matchedValue
+}
+
+func normalizeDeterministicAnswer(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	return strings.NewReplacer(
+		" ", "",
+		"\n", "",
+		"\t", "",
+		"−", "-",
+		"–", "-",
+	).Replace(value)
+}

--- a/internal/curriculum/engine.go
+++ b/internal/curriculum/engine.go
@@ -431,9 +431,10 @@ func attemptPayloadHash(topic Topic, question AssessmentQuestion, answer string)
 }
 
 type masteryObservation struct {
-	score         float64
-	known         bool
-	evidenceCount int
+	score          float64
+	known          bool
+	evidenceCount  int
+	latestEvidence *progress.MasteryEvidenceSummary
 }
 
 func (e *Engine) masteryObservations(ctx context.Context, learnerID progress.LearnerID) (map[string]masteryObservation, error) {
@@ -447,9 +448,10 @@ func (e *Engine) masteryObservations(ctx context.Context, learnerID progress.Lea
 	observations := make(map[string]masteryObservation, len(snapshot))
 	for _, item := range snapshot {
 		observations[masteryKey(item.SyllabusID, item.TopicID)] = masteryObservation{
-			score:         item.MasteryScore,
-			known:         item.MasteryKnown,
-			evidenceCount: item.EvidenceCount,
+			score:          item.MasteryScore,
+			known:          item.MasteryKnown,
+			evidenceCount:  item.EvidenceCount,
+			latestEvidence: item.LatestEvidence,
 		}
 	}
 	return observations, nil
@@ -464,7 +466,14 @@ func (e *Engine) planForTopic(topic Topic, objectiveID, locale string, mastery m
 		return TeachingPlan{}, err
 	}
 	selected := localizedTopic(e.loader, topic, locale)
-	objective, err := selectObjective(selected, objectiveID)
+	assessment, hasAssessment := e.loader.GetAssessment(topic.ID)
+	objective, question, hasQuestion, err := selectPlanTarget(
+		selected,
+		assessment,
+		hasAssessment,
+		objectiveID,
+		mastery.latestEvidence,
+	)
 	if err != nil {
 		return TeachingPlan{}, err
 	}
@@ -521,13 +530,11 @@ func (e *Engine) planForTopic(topic Topic, objectiveID, locale string, mastery m
 	}
 	e.addTeachingMaterials(&plan, topic, locale)
 
-	assessment, found := e.loader.GetAssessment(topic.ID)
-	if !found {
+	if !hasAssessment {
 		plan.Constraints = append(plan.Constraints, "no source assessment is available for this topic")
 		return plan, nil
 	}
-	question, found := selectGradeableQuestion(assessment, objective.ID)
-	if !found {
+	if !hasQuestion {
 		plan.Constraints = append(plan.Constraints, "no deterministic source assessment is available for this objective")
 		return plan, nil
 	}
@@ -988,13 +995,69 @@ func selectObjective(topic Topic, objectiveID string) (LearningObjective, error)
 	return LearningObjective{}, fmt.Errorf("topic %q has no objective %q", topic.ID, objectiveID)
 }
 
-func selectGradeableQuestion(assessment Assessment, objectiveID string) (AssessmentQuestion, bool) {
-	for _, question := range assessment.Questions {
-		if question.LearningObjective == objectiveID && isDeterministicallyGradeable(question.Answer.Type) {
-			return question, true
+func selectPlanTarget(
+	topic Topic,
+	assessment Assessment,
+	hasAssessment bool,
+	requestedObjectiveID string,
+	latest *progress.MasteryEvidenceSummary,
+) (LearningObjective, AssessmentQuestion, bool, error) {
+	requestedObjectiveID = strings.TrimSpace(requestedObjectiveID)
+	if requestedObjectiveID != "" {
+		objective, err := selectObjective(topic, requestedObjectiveID)
+		if err != nil {
+			return LearningObjective{}, AssessmentQuestion{}, false, err
+		}
+		if !hasAssessment {
+			return objective, AssessmentQuestion{}, false, nil
+		}
+		question, found := selectProgressedQuestion(assessment, objective.ID, latest)
+		return objective, question, found, nil
+	}
+
+	if hasAssessment {
+		question, found := selectProgressedQuestion(assessment, "", latest)
+		if found {
+			objective, err := selectObjective(topic, question.LearningObjective)
+			if err != nil {
+				return LearningObjective{}, AssessmentQuestion{}, false, err
+			}
+			return objective, question, true, nil
 		}
 	}
-	return AssessmentQuestion{}, false
+
+	objective, err := selectObjective(topic, "")
+	return objective, AssessmentQuestion{}, false, err
+}
+
+func selectProgressedQuestion(
+	assessment Assessment,
+	objectiveID string,
+	latest *progress.MasteryEvidenceSummary,
+) (AssessmentQuestion, bool) {
+	questions := make([]AssessmentQuestion, 0, len(assessment.Questions))
+	for _, question := range assessment.Questions {
+		if (objectiveID == "" || question.LearningObjective == objectiveID) &&
+			isDeterministicallyGradeable(question.Answer.Type) {
+			questions = append(questions, question)
+		}
+	}
+	if len(questions) == 0 {
+		return AssessmentQuestion{}, false
+	}
+	if latest == nil || latest.SourceKind != assessment.Source.Kind {
+		return questions[0], true
+	}
+	for index, question := range questions {
+		if question.ID != latest.SourceID {
+			continue
+		}
+		if latest.Score < 1 || index == len(questions)-1 {
+			return question, true
+		}
+		return questions[index+1], true
+	}
+	return questions[0], true
 }
 
 func assessmentQuestion(assessment Assessment, questionID string) (AssessmentQuestion, bool) {

--- a/internal/curriculum/engine.go
+++ b/internal/curriculum/engine.go
@@ -8,6 +8,8 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"math/big"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -1078,17 +1080,22 @@ func isDeterministicallyGradeable(answerType string) bool {
 	}
 }
 
+var plainNumberPattern = regexp.MustCompile(`^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$`)
+
 func gradeDeterministicAnswer(canonical, presentation AssessmentQuestion, answer string) bool {
 	actual := normalizeDeterministicAnswer(answer)
 	if actual == "" {
 		return false
 	}
-	expected := normalizeDeterministicAnswer(canonical.Answer.Value)
-	if expected != "" && actual == expected {
+	expectedValue := canonical.Answer.Value
+	expected := normalizeDeterministicAnswer(expectedValue)
+	if expected != "" && deterministicAnswersEqual(canonical.Answer.Type, answer, expectedValue) {
 		return true
 	}
-	localizedExpected := normalizeDeterministicAnswer(presentation.Answer.Value)
-	if localizedExpected != "" && actual == localizedExpected {
+	localizedExpectedValue := presentation.Answer.Value
+	localizedExpected := normalizeDeterministicAnswer(localizedExpectedValue)
+	if localizedExpected != "" &&
+		deterministicAnswersEqual(canonical.Answer.Type, answer, localizedExpectedValue) {
 		return true
 	}
 	if canonical.Answer.Type != "multiple_choice" {
@@ -1101,6 +1108,27 @@ func gradeDeterministicAnswer(canonical, presentation AssessmentQuestion, answer
 		}
 	}
 	return false
+}
+
+func deterministicAnswersEqual(answerType, actual, expected string) bool {
+	if normalizeDeterministicAnswer(actual) == normalizeDeterministicAnswer(expected) {
+		return true
+	}
+	if answerType != "exact" {
+		return false
+	}
+	actualNumber, actualOK := parsePlainNumber(actual)
+	expectedNumber, expectedOK := parsePlainNumber(expected)
+	return actualOK && expectedOK && actualNumber.Cmp(expectedNumber) == 0
+}
+
+func parsePlainNumber(value string) (*big.Rat, bool) {
+	value = strings.TrimSpace(value)
+	if !plainNumberPattern.MatchString(value) {
+		return nil, false
+	}
+	number, ok := new(big.Rat).SetString(value)
+	return number, ok
 }
 
 func correctOptionID(question AssessmentQuestion) string {

--- a/internal/curriculum/engine_test.go
+++ b/internal/curriculum/engine_test.go
@@ -1005,6 +1005,54 @@ func TestEngineRecordAttemptGradesSourceQuestionAndUpdatesMastery(t *testing.T) 
 	}
 }
 
+func TestEngineRecordAttemptComparesExactNumericAnswersByValue(t *testing.T) {
+	root := setupCurriculumEngineFixture(t)
+	assessmentPath := fixtureTopicPath(root, "MT1-05.assessments.yaml")
+	replaceFixtureText(t, assessmentPath, `value: "10"`, `value: "249.00"`)
+
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	tracker := progress.NewMemoryTracker()
+	learnerID, err := progress.NewLearnerID("numeric-answer-learner")
+	if err != nil {
+		t.Fatalf("NewLearnerID() error = %v", err)
+	}
+	engine, err := curriculum.NewEngine(curriculum.EngineConfig{Loader: loader, Progress: tracker})
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+
+	equivalent, err := engine.RecordAttempt(context.Background(), curriculum.AttemptInput{
+		AttemptID:  "numeric-equivalent",
+		LearnerID:  learnerID,
+		TopicID:    "MT1-05",
+		QuestionID: "Q4",
+		Answer:     "249",
+	})
+	if err != nil {
+		t.Fatalf("RecordAttempt(equivalent) error = %v", err)
+	}
+	if !equivalent.Correct {
+		t.Fatalf("RecordAttempt(249) = %#v, want equivalent to 249.00", equivalent)
+	}
+
+	different, err := engine.RecordAttempt(context.Background(), curriculum.AttemptInput{
+		AttemptID:  "numeric-different",
+		LearnerID:  learnerID,
+		TopicID:    "MT1-05",
+		QuestionID: "Q4",
+		Answer:     "249.01",
+	})
+	if err != nil {
+		t.Fatalf("RecordAttempt(different) error = %v", err)
+	}
+	if different.Correct {
+		t.Fatalf("RecordAttempt(249.01) = %#v, want different from 249.00", different)
+	}
+}
+
 func TestEngineRecordAttemptTreatsWrongAnswerAsNegativeEvidence(t *testing.T) {
 	root := setupCurriculumEngineFixture(t)
 	loader, err := curriculum.NewLoader(root)

--- a/internal/curriculum/engine_test.go
+++ b/internal/curriculum/engine_test.go
@@ -1,0 +1,1594 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package curriculum_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/p-n-ai/pai-bot/internal/curriculum"
+	"github.com/p-n-ai/pai-bot/internal/progress"
+)
+
+func TestEnginePlanTurnRepairsUnmetPrerequisiteWithoutMutatingProgress(t *testing.T) {
+	root := setupCurriculumEngineFixture(t)
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	tracker := progress.NewMemoryTracker()
+	learnerID, err := progress.NewLearnerID("learner-1")
+	if err != nil {
+		t.Fatalf("NewLearnerID() error = %v", err)
+	}
+	if err := tracker.UpdateMasteryForLearner(learnerID, "malaysia-kssm", "MT1-01", 0.2); err != nil {
+		t.Fatalf("seed prerequisite mastery: %v", err)
+	}
+	engine, err := curriculum.NewEngine(curriculum.EngineConfig{
+		Loader:   loader,
+		Progress: tracker,
+	})
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+
+	plan, err := engine.PlanTurn(context.Background(), curriculum.PlanTurnInput{
+		LearnerID:   learnerID,
+		TopicID:     "MT1-05",
+		ObjectiveID: "5.1.1",
+	})
+	if err != nil {
+		t.Fatalf("PlanTurn() error = %v", err)
+	}
+
+	if plan.Action != curriculum.TeachingActionRepairPrerequisite {
+		t.Fatalf("plan.Action = %q, want %q", plan.Action, curriculum.TeachingActionRepairPrerequisite)
+	}
+	if plan.Target.TopicID != "MT1-01" {
+		t.Fatalf("plan.Target.TopicID = %q, want MT1-01", plan.Target.TopicID)
+	}
+	if plan.Target.TopicName != "Rational Numbers" {
+		t.Fatalf("plan.Target.TopicName = %q, want English canonical name", plan.Target.TopicName)
+	}
+	if !plan.Target.MasteryKnown {
+		t.Fatal("plan.Target.MasteryKnown = false, want seeded mastery evidence")
+	}
+	if plan.Check == nil || plan.Check.QuestionID != "Q1" {
+		t.Fatalf("plan.Check = %#v, want source-backed MT1-01/Q1", plan.Check)
+	}
+	if len(plan.Evidence) == 0 || plan.Evidence[0].SourcePath == "" {
+		t.Fatalf("plan.Evidence = %#v, want source provenance", plan.Evidence)
+	}
+	requires := requirePlanRelation(
+		t,
+		plan,
+		curriculum.CurriculumRelationRequires,
+		curriculum.CurriculumNodeRef{Kind: curriculum.CurriculumNodeKindTopic, ID: "MT1-05"},
+		curriculum.CurriculumNodeRef{Kind: curriculum.CurriculumNodeKindTopic, ID: "MT1-01"},
+	)
+	requestedTopic, _ := loader.GetTopic("MT1-05")
+	if requires.Evidence.SourceKind != "topic" ||
+		requires.Evidence.Revision != requestedTopic.Source.Revision {
+		t.Fatalf("requires relation evidence = %#v, want cited prerequisite edge artifact", requires.Evidence)
+	}
+
+	mastery, err := tracker.GetMasteryForLearner(learnerID, "malaysia-kssm", "MT1-01")
+	if err != nil {
+		t.Fatalf("GetMasteryForLearner() error = %v", err)
+	}
+	if mastery != 0.2 {
+		t.Fatalf("mastery after PlanTurn = %v, want unchanged 0.2", mastery)
+	}
+}
+
+func TestEnginePlanTurnDiagnosesPrerequisiteWhenMasteryIsUnknown(t *testing.T) {
+	root := setupCurriculumEngineFixture(t)
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	tracker := progress.NewMemoryTracker()
+	learnerID, err := progress.NewLearnerID("learner-1")
+	if err != nil {
+		t.Fatalf("NewLearnerID() error = %v", err)
+	}
+	engine, err := curriculum.NewEngine(curriculum.EngineConfig{Loader: loader, Progress: tracker})
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+
+	plan, err := engine.PlanTurn(context.Background(), curriculum.PlanTurnInput{
+		LearnerID:   learnerID,
+		TopicID:     "MT1-05",
+		ObjectiveID: "5.1.1",
+	})
+	if err != nil {
+		t.Fatalf("PlanTurn() error = %v", err)
+	}
+
+	if plan.Action != curriculum.TeachingActionDiagnosePrerequisite {
+		t.Fatalf("plan.Action = %q, want %q", plan.Action, curriculum.TeachingActionDiagnosePrerequisite)
+	}
+	if plan.Target.TopicID != "MT1-01" || plan.Target.MasteryKnown {
+		t.Fatalf("plan.Target = %#v, want unknown MT1-01 prerequisite", plan.Target)
+	}
+}
+
+func TestEnginePlanTurnUsesOneCoherentMasterySnapshot(t *testing.T) {
+	root := setupCurriculumEngineFixture(t)
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	learnerID, err := progress.NewLearnerID("learner-1")
+	if err != nil {
+		t.Fatalf("NewLearnerID() error = %v", err)
+	}
+	store := &fixedSnapshotStore{snapshot: []progress.MasterySnapshotItem{
+		{
+			SyllabusID:    "malaysia-kssm",
+			TopicID:       "MT1-01",
+			MasteryScore:  0.9,
+			MasteryKnown:  true,
+			EvidenceCount: 1,
+		},
+		{
+			SyllabusID:    "malaysia-kssm",
+			TopicID:       "MT1-05",
+			MasteryScore:  0.4,
+			MasteryKnown:  true,
+			EvidenceCount: 2,
+		},
+	}}
+	engine, err := curriculum.NewEngine(curriculum.EngineConfig{Loader: loader, Progress: store})
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+
+	plan, err := engine.PlanTurn(context.Background(), curriculum.PlanTurnInput{
+		LearnerID:   learnerID,
+		TopicID:     "MT1-05",
+		ObjectiveID: "5.1.1",
+	})
+	if err != nil {
+		t.Fatalf("PlanTurn() error = %v", err)
+	}
+
+	if store.reads != 1 {
+		t.Fatalf("mastery snapshot reads = %d, want exactly 1", store.reads)
+	}
+	if plan.Action != curriculum.TeachingActionTeachAndCheck {
+		t.Fatalf("plan.Action = %q, want %q", plan.Action, curriculum.TeachingActionTeachAndCheck)
+	}
+	if plan.Target.MasteryScore != 0.4 ||
+		!plan.Target.MasteryKnown ||
+		plan.Target.EvidenceCount != 2 {
+		t.Fatalf("plan.Target = %#v, want coherent target mastery 0.4 with 2 evidence records", plan.Target)
+	}
+}
+
+func TestEnginePlanTurnRejectsLevelZeroStubWithoutProgressMutation(t *testing.T) {
+	root := setupCurriculumEngineFixture(t)
+	subjectGradePath := filepath.Join(
+		root,
+		"curricula",
+		"malaysia",
+		"malaysia-kssm",
+		"malaysia-kssm-matematik",
+		"malaysia-kssm-matematik-tingkatan-1",
+		"subject-grade.yaml",
+	)
+	replaceFixtureText(
+		t,
+		subjectGradePath,
+		"topics:\n  - MT1-01\n  - MT1-05",
+		"topics:\n  - MT1-00\n  - MT1-01\n  - MT1-05",
+	)
+	writeFixtureFile(t, filepath.Join(filepath.Dir(subjectGradePath), "topics", "MT1-00.yaml"), `
+id: MT1-00
+name: Catalog Stub
+subject_grade_id: malaysia-kssm-matematik-tingkatan-1
+subject_id: malaysia-kssm-matematik
+syllabus_id: malaysia-kssm
+language: en
+difficulty: beginner
+content_standards: []
+learning_objectives: []
+quality_level: 0
+provenance: human
+`)
+
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	learnerID, err := progress.NewLearnerID("learner-1")
+	if err != nil {
+		t.Fatalf("NewLearnerID() error = %v", err)
+	}
+	store := &fixedSnapshotStore{}
+	engine, err := curriculum.NewEngine(curriculum.EngineConfig{Loader: loader, Progress: store})
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+
+	_, err = engine.PlanTurn(context.Background(), curriculum.PlanTurnInput{
+		LearnerID: learnerID,
+		TopicID:   "MT1-00",
+	})
+	if err == nil {
+		t.Fatal("PlanTurn() error = nil, want catalog stub rejected")
+	}
+	if !errors.Is(err, curriculum.ErrTopicNotAITeachingReady) {
+		t.Fatalf("PlanTurn() error = %v, want ErrTopicNotAITeachingReady", err)
+	}
+	if store.writes != 0 {
+		t.Fatalf("progress writes = %d, want 0", store.writes)
+	}
+}
+
+func TestEnginePlanTurnRequiresExplicitAITeachingReadyQuality(t *testing.T) {
+	tests := []struct {
+		name         string
+		qualityLine  string
+		wantReady    bool
+		wantPlanTurn bool
+	}{
+		{name: "missing", qualityLine: "", wantReady: false, wantPlanTurn: false},
+		{name: "zero", qualityLine: "quality_level: 0", wantReady: false, wantPlanTurn: false},
+		{name: "one", qualityLine: "quality_level: 1", wantReady: false, wantPlanTurn: false},
+		{name: "two", qualityLine: "quality_level: 2", wantReady: false, wantPlanTurn: false},
+		{name: "three", qualityLine: "quality_level: 3", wantReady: true, wantPlanTurn: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := setupCurriculumEngineFixture(t)
+			topicPath := filepath.Join(
+				root,
+				"curricula",
+				"malaysia",
+				"malaysia-kssm",
+				"malaysia-kssm-matematik",
+				"malaysia-kssm-matematik-tingkatan-1",
+				"topics",
+				"MT1-05.yaml",
+			)
+			replaceFixtureText(t, topicPath, "quality_level: 3", test.qualityLine)
+
+			loader, err := curriculum.NewLoader(root)
+			if err != nil {
+				t.Fatalf("NewLoader() error = %v", err)
+			}
+			topic, found := loader.GetTopic("MT1-05")
+			if !found {
+				t.Fatal("GetTopic(MT1-05) not found")
+			}
+			if got := topic.IsAITeachingReady(); got != test.wantReady {
+				t.Fatalf("topic.IsAITeachingReady() = %v, want %v", got, test.wantReady)
+			}
+			wantReadyTopics := 1
+			if test.wantReady {
+				wantReadyTopics++
+			}
+			if got := loader.SnapshotStats().AITeachingReadyTopics; got != wantReadyTopics {
+				t.Fatalf("SnapshotStats().AITeachingReadyTopics = %d, want %d", got, wantReadyTopics)
+			}
+
+			learnerID, err := progress.NewLearnerID("learner-1")
+			if err != nil {
+				t.Fatalf("NewLearnerID() error = %v", err)
+			}
+			store := &fixedSnapshotStore{snapshot: []progress.MasterySnapshotItem{{
+				SyllabusID:    "malaysia-kssm",
+				TopicID:       "MT1-01",
+				MasteryScore:  1,
+				MasteryKnown:  true,
+				EvidenceCount: 1,
+			}}}
+			engine, err := curriculum.NewEngine(curriculum.EngineConfig{Loader: loader, Progress: store})
+			if err != nil {
+				t.Fatalf("NewEngine() error = %v", err)
+			}
+
+			_, err = engine.PlanTurn(context.Background(), curriculum.PlanTurnInput{
+				LearnerID: learnerID,
+				TopicID:   "MT1-05",
+			})
+			if test.wantPlanTurn {
+				if err != nil {
+					t.Fatalf("PlanTurn() error = %v, want accepted", err)
+				}
+				return
+			}
+			if !errors.Is(err, curriculum.ErrTopicNotAITeachingReady) {
+				t.Fatalf("PlanTurn() error = %v, want ErrTopicNotAITeachingReady", err)
+			}
+			if store.reads != 0 || store.writes != 0 {
+				t.Fatalf("progress calls = %d reads, %d writes; want none", store.reads, store.writes)
+			}
+		})
+	}
+}
+
+func TestEngineRecordAttemptRejectsTopicBelowAITeachingQuality(t *testing.T) {
+	root := setupCurriculumEngineFixture(t)
+	topicPath := filepath.Join(
+		root,
+		"curricula",
+		"malaysia",
+		"malaysia-kssm",
+		"malaysia-kssm-matematik",
+		"malaysia-kssm-matematik-tingkatan-1",
+		"topics",
+		"MT1-05.yaml",
+	)
+	replaceFixtureText(t, topicPath, "quality_level: 3", "quality_level: 2")
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	learnerID, err := progress.NewLearnerID("learner-1")
+	if err != nil {
+		t.Fatalf("NewLearnerID() error = %v", err)
+	}
+	store := &fixedSnapshotStore{}
+	engine, err := curriculum.NewEngine(curriculum.EngineConfig{Loader: loader, Progress: store})
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+
+	_, err = engine.RecordAttempt(context.Background(), curriculum.AttemptInput{
+		AttemptID:  "quality-bypass",
+		LearnerID:  learnerID,
+		TopicID:    "MT1-05",
+		QuestionID: "Q1",
+		Answer:     "6",
+	})
+	if !errors.Is(err, curriculum.ErrTopicNotAITeachingReady) {
+		t.Fatalf("RecordAttempt() error = %v, want ErrTopicNotAITeachingReady", err)
+	}
+	if store.reads != 0 || store.writes != 0 {
+		t.Fatalf("progress calls = %d reads, %d writes; want none", store.reads, store.writes)
+	}
+}
+
+func TestLoaderRequiresCanonicalTeachingArtifactsAtAITeachingQuality(t *testing.T) {
+	tests := []struct {
+		name    string
+		file    string
+		wantErr string
+	}{
+		{
+			name:    "teaching note",
+			file:    "MT1-05.teaching.md",
+			wantErr: `AI-teaching-ready topic "MT1-05" requires canonical teaching notes`,
+		},
+		{
+			name:    "examples",
+			file:    "MT1-05.examples.yaml",
+			wantErr: `AI-teaching-ready topic "MT1-05" requires canonical examples`,
+		},
+		{
+			name:    "assessment",
+			file:    "MT1-05.assessments.yaml",
+			wantErr: `AI-teaching-ready topic "MT1-05" requires canonical assessment`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := setupCurriculumEngineFixture(t)
+			path := filepath.Join(
+				root,
+				"curricula",
+				"malaysia",
+				"malaysia-kssm",
+				"malaysia-kssm-matematik",
+				"malaysia-kssm-matematik-tingkatan-1",
+				"topics",
+				test.file,
+			)
+			if err := os.Remove(path); err != nil {
+				t.Fatalf("Remove(%s) error = %v", path, err)
+			}
+
+			_, err := curriculum.NewLoader(root)
+			if err == nil {
+				t.Fatal("NewLoader() error = nil, want missing AI teaching artifact rejected")
+			}
+			if !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("NewLoader() error = %v, want %q", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestEnginePlanTurnUsesLocalizedObjectiveAndSourceAssessment(t *testing.T) {
+	root := setupCurriculumEngineFixture(t)
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	tracker := progress.NewMemoryTracker()
+	learnerID, err := progress.NewLearnerID("learner-1")
+	if err != nil {
+		t.Fatalf("NewLearnerID() error = %v", err)
+	}
+	recordFixtureEvidence(t, tracker, learnerID, "prerequisite-session-1", "MT1-01", "Q1", 0.8)
+	engine, err := curriculum.NewEngine(curriculum.EngineConfig{
+		Loader:   loader,
+		Progress: tracker,
+	})
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+
+	plan, err := engine.PlanTurn(context.Background(), curriculum.PlanTurnInput{
+		LearnerID:   learnerID,
+		TopicID:     "MT1-05",
+		ObjectiveID: "5.1.1",
+		Locale:      "ms",
+	})
+	if err != nil {
+		t.Fatalf("PlanTurn() error = %v", err)
+	}
+
+	if plan.Action != curriculum.TeachingActionTeachAndCheck {
+		t.Fatalf("plan.Action = %q, want %q", plan.Action, curriculum.TeachingActionTeachAndCheck)
+	}
+	if plan.Target.TopicID != "MT1-05" {
+		t.Fatalf("plan.Target.TopicID = %q, want MT1-05", plan.Target.TopicID)
+	}
+	if plan.Target.Objective != "Menggunakan huruf untuk mewakili kuantiti yang tidak diketahui." {
+		t.Fatalf("plan.Target.Objective = %q, want Malay objective", plan.Target.Objective)
+	}
+	if plan.Target.TopicName != "Ungkapan Algebra" {
+		t.Fatalf("plan.Target.TopicName = %q, want Malay localized name", plan.Target.TopicName)
+	}
+	if len(plan.TeachingSequence) != 1 || plan.TeachingSequence[0] != "Introduce a variable through a mystery-number example." {
+		t.Fatalf("plan.TeachingSequence = %v, want canonical teaching policy", plan.TeachingSequence)
+	}
+	if plan.Check == nil || plan.Check.QuestionID != "Q1" || plan.Check.SourcePath == "" {
+		t.Fatalf("plan.Check = %#v, want source-backed MT1-05/Q1", plan.Check)
+	}
+	if plan.Check.Question != "Hitung 3x apabila x = 2." {
+		t.Fatalf("plan.Check.Question = %q, want Malay assessment text", plan.Check.Question)
+	}
+	if len(plan.Check.Options) != 2 || plan.Check.Options[1] != (curriculum.CheckOption{ID: "B", Text: "6"}) {
+		t.Fatalf("plan.Check.Options = %#v, want ordered localized A/B options", plan.Check.Options)
+	}
+
+	requirePlanRelation(
+		t,
+		plan,
+		curriculum.CurriculumRelationContains,
+		curriculum.CurriculumNodeRef{Kind: curriculum.CurriculumNodeKindSyllabus, ID: "malaysia-kssm"},
+		curriculum.CurriculumNodeRef{Kind: curriculum.CurriculumNodeKindSubject, ID: "malaysia-kssm-matematik"},
+	)
+	requirePlanRelation(
+		t,
+		plan,
+		curriculum.CurriculumRelationContains,
+		curriculum.CurriculumNodeRef{Kind: curriculum.CurriculumNodeKindSubject, ID: "malaysia-kssm-matematik"},
+		curriculum.CurriculumNodeRef{
+			Kind: curriculum.CurriculumNodeKindSubjectGrade,
+			ID:   "malaysia-kssm-matematik-tingkatan-1",
+		},
+	)
+	requirePlanRelation(
+		t,
+		plan,
+		curriculum.CurriculumRelationContains,
+		curriculum.CurriculumNodeRef{
+			Kind: curriculum.CurriculumNodeKindSubjectGrade,
+			ID:   "malaysia-kssm-matematik-tingkatan-1",
+		},
+		curriculum.CurriculumNodeRef{Kind: curriculum.CurriculumNodeKindTopic, ID: "MT1-05"},
+	)
+	canonicalObjective := curriculum.CurriculumNodeRef{
+		Kind:    curriculum.CurriculumNodeKindObjective,
+		ID:      "5.1.1",
+		TopicID: "MT1-05",
+	}
+	canonicalQuestion := curriculum.CurriculumNodeRef{
+		Kind:    curriculum.CurriculumNodeKindQuestion,
+		ID:      "Q1",
+		TopicID: "MT1-05",
+	}
+	requirePlanRelation(
+		t,
+		plan,
+		curriculum.CurriculumRelationContainsObjective,
+		curriculum.CurriculumNodeRef{Kind: curriculum.CurriculumNodeKindTopic, ID: "MT1-05"},
+		canonicalObjective,
+	)
+	requirePlanRelation(
+		t,
+		plan,
+		curriculum.CurriculumRelationAssessedBy,
+		canonicalObjective,
+		canonicalQuestion,
+	)
+	requirePlanRelation(
+		t,
+		plan,
+		curriculum.CurriculumRelationLocalizedBy,
+		curriculum.CurriculumNodeRef{Kind: curriculum.CurriculumNodeKindTopic, ID: "MT1-05"},
+		curriculum.CurriculumNodeRef{
+			Kind:   curriculum.CurriculumNodeKindTopic,
+			ID:     "MT1-05",
+			Locale: "ms",
+		},
+	)
+	requirePlanRelation(
+		t,
+		plan,
+		curriculum.CurriculumRelationLocalizedBy,
+		canonicalObjective,
+		curriculum.CurriculumNodeRef{
+			Kind:    curriculum.CurriculumNodeKindObjective,
+			ID:      "5.1.1",
+			TopicID: "MT1-05",
+			Locale:  "ms",
+		},
+	)
+	requirePlanRelation(
+		t,
+		plan,
+		curriculum.CurriculumRelationLocalizedBy,
+		canonicalQuestion,
+		curriculum.CurriculumNodeRef{
+			Kind:    curriculum.CurriculumNodeKindQuestion,
+			ID:      "Q1",
+			TopicID: "MT1-05",
+			Locale:  "ms",
+		},
+	)
+	for _, relation := range plan.Relations {
+		if relation.Evidence.SourcePath == "" ||
+			!strings.HasPrefix(relation.Evidence.Revision, "sha256:") {
+			t.Fatalf("relation evidence = %#v, want exact artifact citation", relation)
+		}
+	}
+
+	repeated, err := engine.PlanTurn(context.Background(), curriculum.PlanTurnInput{
+		LearnerID:   learnerID,
+		TopicID:     "MT1-05",
+		ObjectiveID: "5.1.1",
+		Locale:      "ms",
+	})
+	if err != nil {
+		t.Fatalf("repeated PlanTurn() error = %v", err)
+	}
+	if !reflect.DeepEqual(repeated.Relations, plan.Relations) {
+		t.Fatalf("repeated relations = %#v, want deterministic %#v", repeated.Relations, plan.Relations)
+	}
+}
+
+func TestEnginePlanTurnPreservesSourceCitedGuidanceAndMaterials(t *testing.T) {
+	root := setupCurriculumEngineFixture(t)
+	topicPath := fixtureTopicPath(root, "MT1-05.yaml")
+	replaceFixtureText(t, topicPath, `prerequisites:
+  required:
+    - MT1-01
+mastery:`, `prerequisites:
+  required:
+    - MT1-01
+background_knowledge:
+  - Substitution and multiplication
+mastery:`)
+	replaceFixtureText(t, topicPath, `teaching:
+  sequence:
+    - Introduce a variable through a mystery-number example.
+quality_level: 3`, `teaching:
+  sequence:
+    - Introduce a variable through a mystery-number example.
+  common_misconceptions:
+    - misconception: The letter x always means multiplication.
+      remediation: Use a multiplication dot before omitting it.
+  engagement_hooks:
+    - Use mystery bags to represent unknown values.
+quality_level: 3`)
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	tracker := progress.NewMemoryTracker()
+	learnerID, err := progress.NewLearnerID("learner-1")
+	if err != nil {
+		t.Fatalf("NewLearnerID() error = %v", err)
+	}
+	recordFixtureEvidence(t, tracker, learnerID, "prerequisite-session-1", "MT1-01", "Q1", 1)
+	engine, err := curriculum.NewEngine(curriculum.EngineConfig{Loader: loader, Progress: tracker})
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+
+	plan, err := engine.PlanTurn(context.Background(), curriculum.PlanTurnInput{
+		LearnerID:   learnerID,
+		TopicID:     "MT1-05",
+		ObjectiveID: "5.1.1",
+	})
+	if err != nil {
+		t.Fatalf("PlanTurn() error = %v", err)
+	}
+	if !reflect.DeepEqual(plan.Guidance.BackgroundKnowledge, []string{"Substitution and multiplication"}) ||
+		len(plan.Guidance.CommonMisconceptions) != 1 ||
+		plan.Guidance.CommonMisconceptions[0].Remediation != "Use a multiplication dot before omitting it." ||
+		!reflect.DeepEqual(plan.Guidance.EngagementHooks, []string{"Use mystery bags to represent unknown values."}) {
+		t.Fatalf("plan.Guidance = %#v, want complete topic guidance", plan.Guidance)
+	}
+	topic, _ := loader.GetTopic("MT1-05")
+	if plan.Guidance.Evidence.SourcePath != topic.Source.Path ||
+		plan.Guidance.Evidence.Revision != topic.Source.Revision {
+		t.Fatalf("plan.Guidance.Evidence = %#v, want topic artifact citation", plan.Guidance.Evidence)
+	}
+
+	note, _ := loader.GetTeachingNote("MT1-05")
+	if plan.Materials.TeachingNote == nil ||
+		plan.Materials.TeachingNote.Content != "# Teach algebraic expressions\n" ||
+		plan.Materials.TeachingNote.Evidence.Revision != note.Source.Revision {
+		t.Fatalf("plan.Materials.TeachingNote = %#v, want cited note", plan.Materials.TeachingNote)
+	}
+	examples, _ := loader.GetExamples("MT1-05")
+	if len(plan.Materials.WorkedExamples) != 1 ||
+		plan.Materials.WorkedExamples[0].Example.Scenario != "Evaluate 3x when x = 2." ||
+		plan.Materials.WorkedExamples[0].Evidence.Revision != examples.Source.Revision {
+		t.Fatalf("plan.Materials.WorkedExamples = %#v, want cited typed example", plan.Materials.WorkedExamples)
+	}
+	constraints := strings.Join(plan.Constraints, "\n")
+	for _, rawProse := range []string{
+		"Substitution and multiplication",
+		"The letter x always means multiplication.",
+		"Use mystery bags to represent unknown values.",
+		"# Teach algebraic expressions",
+		"Evaluate 3x when x = 2.",
+	} {
+		if strings.Contains(constraints, rawProse) {
+			t.Fatalf("plan.Constraints = %q, contains raw source prose %q", constraints, rawProse)
+		}
+	}
+
+	requirePlanRelation(
+		t,
+		plan,
+		curriculum.CurriculumRelationGuidedBy,
+		curriculum.CurriculumNodeRef{Kind: curriculum.CurriculumNodeKindTopic, ID: "MT1-05"},
+		curriculum.CurriculumNodeRef{
+			Kind:    curriculum.CurriculumNodeKindTeachingNote,
+			ID:      "MT1-05",
+			TopicID: "MT1-05",
+		},
+	)
+	requirePlanRelation(
+		t,
+		plan,
+		curriculum.CurriculumRelationIllustratedBy,
+		curriculum.CurriculumNodeRef{
+			Kind:    curriculum.CurriculumNodeKindObjective,
+			ID:      "5.1.1",
+			TopicID: "MT1-05",
+		},
+		curriculum.CurriculumNodeRef{
+			Kind:    curriculum.CurriculumNodeKindWorkedExample,
+			ID:      "WE-01",
+			TopicID: "MT1-05",
+		},
+	)
+}
+
+func TestEnginePlanTurnUsesLocalizedTopicProvenance(t *testing.T) {
+	root := setupOSSContractFixture(t)
+	canonicalPath := fixtureTopicPath(root, "MT1-05.yaml")
+	replaceFixtureText(t, canonicalPath, "quality_level: 2", "quality_level: 3")
+	writeExamplesFixture(
+		t,
+		strings.TrimSuffix(canonicalPath, ".yaml")+".examples.yaml",
+		"MT1-05",
+		"WE-01",
+		"5.1.1",
+		"Evaluate 3x.",
+	)
+	variantPath := filepath.Join(
+		filepath.Dir(canonicalPath),
+		"translations",
+		"ms",
+		"MT1-05.yaml",
+	)
+	replaceFixtureText(t, variantPath, "provenance: ai-assisted", "provenance: human")
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	tracker := progress.NewMemoryTracker()
+	learnerID, err := progress.NewLearnerID("learner-1")
+	if err != nil {
+		t.Fatalf("NewLearnerID() error = %v", err)
+	}
+	engine, err := curriculum.NewEngine(curriculum.EngineConfig{Loader: loader, Progress: tracker})
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+
+	plan, err := engine.PlanTurn(context.Background(), curriculum.PlanTurnInput{
+		LearnerID: learnerID,
+		TopicID:   "MT1-05",
+		Locale:    "ms",
+	})
+	if err != nil {
+		t.Fatalf("PlanTurn() error = %v", err)
+	}
+	var localized curriculum.EvidenceRef
+	for _, evidence := range plan.Evidence {
+		if evidence.SourceKind == "topic_variant" {
+			localized = evidence
+			break
+		}
+	}
+	if localized.Provenance != "human" {
+		t.Fatalf("localized evidence = %#v, want variant provenance", localized)
+	}
+}
+
+func TestEnginePlanTurnProjectsAuthoredConceptMappingsWithoutTopicDuplicates(t *testing.T) {
+	root := setupValidatedCrossCurriculumFixture(t)
+	replaceFixtureText(
+		t,
+		fixtureTopicPath(root, "MT1-05.yaml"),
+		`cross_curriculum:
+  - concept_id: variables
+    syllabus_id: other-syllabus
+    topic_id: OM1-01
+quality_level: 2`,
+		"quality_level: 2",
+	)
+	canonicalPath := fixtureTopicPath(root, "MT1-05.yaml")
+	replaceFixtureText(t, canonicalPath, "quality_level: 2", "quality_level: 3")
+	writeExamplesFixture(
+		t,
+		strings.TrimSuffix(canonicalPath, ".yaml")+".examples.yaml",
+		"MT1-05",
+		"WE-01",
+		"5.1.1",
+		"Evaluate 3x.",
+	)
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	tracker := progress.NewMemoryTracker()
+	learnerID, err := progress.NewLearnerID("learner-1")
+	if err != nil {
+		t.Fatalf("NewLearnerID() error = %v", err)
+	}
+	engine, err := curriculum.NewEngine(curriculum.EngineConfig{Loader: loader, Progress: tracker})
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+
+	plan, err := engine.PlanTurn(context.Background(), curriculum.PlanTurnInput{
+		LearnerID: learnerID,
+		TopicID:   "MT1-05",
+	})
+	if err != nil {
+		t.Fatalf("PlanTurn() error = %v", err)
+	}
+
+	relation := requirePlanRelation(
+		t,
+		plan,
+		curriculum.CurriculumRelationSharesConcept,
+		curriculum.CurriculumNodeRef{Kind: curriculum.CurriculumNodeKindTopic, ID: "MT1-05"},
+		curriculum.CurriculumNodeRef{Kind: curriculum.CurriculumNodeKindTopic, ID: "OM1-01"},
+	)
+	wantConcept := curriculum.CurriculumNodeRef{
+		Kind: curriculum.CurriculumNodeKindConcept,
+		ID:   "variables",
+	}
+	if relation.Via != wantConcept {
+		t.Fatalf("shared-concept relation Via = %#v, want %#v", relation.Via, wantConcept)
+	}
+	concept, _ := loader.GetConcept("variables")
+	if relation.Evidence.TopicID != "MT1-05" ||
+		relation.Evidence.SourceKind != "concept" ||
+		relation.Evidence.Revision != concept.Source.Revision {
+		t.Fatalf("shared-concept evidence = %#v, want authored concept citation", relation.Evidence)
+	}
+}
+
+func TestEnginePlanTurnDiagnosesPrerequisiteWithoutRequiredAssessmentSessions(t *testing.T) {
+	root := setupCurriculumEngineFixture(t)
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	tracker := progress.NewMemoryTracker()
+	learnerID, err := progress.NewLearnerID("learner-1")
+	if err != nil {
+		t.Fatalf("NewLearnerID() error = %v", err)
+	}
+	if err := tracker.UpdateMasteryForLearner(learnerID, "malaysia-kssm", "MT1-01", 0.9); err != nil {
+		t.Fatalf("seed legacy prerequisite mastery: %v", err)
+	}
+	engine, err := curriculum.NewEngine(curriculum.EngineConfig{Loader: loader, Progress: tracker})
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+
+	plan, err := engine.PlanTurn(context.Background(), curriculum.PlanTurnInput{
+		LearnerID: learnerID,
+		TopicID:   "MT1-05",
+	})
+	if err != nil {
+		t.Fatalf("PlanTurn() error = %v", err)
+	}
+
+	if plan.Action != curriculum.TeachingActionDiagnosePrerequisite {
+		t.Fatalf("plan.Action = %q, want %q", plan.Action, curriculum.TeachingActionDiagnosePrerequisite)
+	}
+	if plan.Target.EvidenceCount != 0 || plan.Target.EvidenceRequired != 1 {
+		t.Fatalf("assessment sessions = %d/%d, want 0/1", plan.Target.EvidenceCount, plan.Target.EvidenceRequired)
+	}
+}
+
+func TestEnginePlanTurnPreservesExplicitZeroMasteryThreshold(t *testing.T) {
+	root := setupCurriculumEngineFixture(t)
+	prerequisitePath := fixtureTopicPath(root, "MT1-01.yaml")
+	replaceFixtureText(t, prerequisitePath, "minimum_score: 0.75", "minimum_score: 0")
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	tracker := progress.NewMemoryTracker()
+	learnerID, err := progress.NewLearnerID("learner-1")
+	if err != nil {
+		t.Fatalf("NewLearnerID() error = %v", err)
+	}
+	recordFixtureEvidence(t, tracker, learnerID, "zero-threshold-session", "MT1-01", "Q1", 0)
+	engine, err := curriculum.NewEngine(curriculum.EngineConfig{Loader: loader, Progress: tracker})
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+
+	plan, err := engine.PlanTurn(context.Background(), curriculum.PlanTurnInput{
+		LearnerID: learnerID,
+		TopicID:   "MT1-05",
+	})
+	if err != nil {
+		t.Fatalf("PlanTurn() error = %v", err)
+	}
+	if plan.Action != curriculum.TeachingActionTeachAndCheck || plan.Target.TopicID != "MT1-05" {
+		t.Fatalf("plan = %#v, explicit zero threshold must not become default threshold", plan)
+	}
+}
+
+func TestEnginePlanTurnDiagnosesDeepestUnmetPrerequisite(t *testing.T) {
+	root := setupCurriculumEngineFixture(t)
+	subjectGradePath := filepath.Join(
+		root,
+		"curricula",
+		"malaysia",
+		"malaysia-kssm",
+		"malaysia-kssm-matematik",
+		"malaysia-kssm-matematik-tingkatan-1",
+		"subject-grade.yaml",
+	)
+	replaceFixtureText(t, subjectGradePath, "topics:\n  - MT1-01", "topics:\n  - MT1-00\n  - MT1-01")
+	topicsDir := filepath.Dir(fixtureTopicPath(root, "MT1-01.yaml"))
+	replaceFixtureText(t, fixtureTopicPath(root, "MT1-01.yaml"), "mastery:", `prerequisites:
+  required:
+    - MT1-00
+mastery:`)
+	writeFixtureFile(t, filepath.Join(topicsDir, "MT1-00.yaml"), `
+id: MT1-00
+name: Whole Numbers
+subject_grade_id: malaysia-kssm-matematik-tingkatan-1
+subject_id: malaysia-kssm-matematik
+syllabus_id: malaysia-kssm
+language: en
+difficulty: beginner
+content_standards:
+  - id: "0.1"
+    text_en: Whole numbers
+learning_objectives:
+  - id: "0.1.1"
+    content_standard_id: "0.1"
+    text_en: Compare whole numbers.
+    bloom: understand
+mastery:
+  minimum_score: 0.75
+  assessment_count: 1
+quality_level: 3
+provenance: human
+`)
+	writeFixtureFile(t, filepath.Join(topicsDir, "MT1-00.assessments.yaml"), `
+topic_id: MT1-00
+provenance: human
+questions:
+  - id: Q1
+    text: Which is larger, 2 or 1?
+    difficulty: easy
+    learning_objective: "0.1.1"
+    answer:
+      type: exact
+      value: "2"
+    marks: 1
+`)
+	writeFixtureFile(t, filepath.Join(topicsDir, "MT1-00.examples.yaml"), `
+topic_id: MT1-00
+provenance: human
+worked_examples:
+  - id: WE-01
+    topic: Comparing whole numbers
+    difficulty: easy
+    learning_objective: "0.1.1"
+    misconception_alert: More digits always means a larger number.
+    scenario: Compare 2 and 1.
+    working: Place both on a number line; 2 is farther right.
+`)
+	writeFixtureFile(t, filepath.Join(topicsDir, "MT1-00.teaching.md"), "# Teach whole numbers\n")
+
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	tracker := progress.NewMemoryTracker()
+	learnerID, err := progress.NewLearnerID("learner-1")
+	if err != nil {
+		t.Fatalf("NewLearnerID() error = %v", err)
+	}
+	recordFixtureEvidence(t, tracker, learnerID, "prerequisite-session-1", "MT1-01", "Q1", 1)
+	engine, err := curriculum.NewEngine(curriculum.EngineConfig{Loader: loader, Progress: tracker})
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+
+	plan, err := engine.PlanTurn(context.Background(), curriculum.PlanTurnInput{
+		LearnerID: learnerID,
+		TopicID:   "MT1-05",
+	})
+	if err != nil {
+		t.Fatalf("PlanTurn() error = %v", err)
+	}
+	if plan.Action != curriculum.TeachingActionDiagnosePrerequisite || plan.Target.TopicID != "MT1-00" {
+		t.Fatalf("plan = %#v, want deepest unknown prerequisite MT1-00", plan)
+	}
+}
+
+func TestEngineRecordAttemptGradesSourceQuestionAndUpdatesMastery(t *testing.T) {
+	root := setupCurriculumEngineFixture(t)
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	tracker := progress.NewMemoryTracker()
+	learnerID, err := progress.NewLearnerID("learner-1")
+	if err != nil {
+		t.Fatalf("NewLearnerID() error = %v", err)
+	}
+	engine, err := curriculum.NewEngine(curriculum.EngineConfig{
+		Loader:   loader,
+		Progress: tracker,
+	})
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+
+	result, err := engine.RecordAttempt(context.Background(), curriculum.AttemptInput{
+		AttemptID:  "attempt-correct-1",
+		LearnerID:  learnerID,
+		TopicID:    "MT1-05",
+		QuestionID: "Q1",
+		Answer:     " 6 ",
+	})
+	if err != nil {
+		t.Fatalf("RecordAttempt() error = %v", err)
+	}
+
+	if !result.Correct || result.Score != 1 {
+		t.Fatalf("result = %#v, want correct score 1", result)
+	}
+	if result.MasteryBefore != 0 || result.MasteryAfter != 1 {
+		t.Fatalf("mastery transition = %v -> %v, want 0 -> 1", result.MasteryBefore, result.MasteryAfter)
+	}
+	assessment, _ := loader.GetAssessment("MT1-05")
+	if result.Evidence.QuestionID != "Q1" ||
+		result.Evidence.SourcePath == "" ||
+		result.Evidence.Revision != assessment.Source.Revision {
+		t.Fatalf("result.Evidence = %#v, want source-backed Q1 at exact artifact revision", result.Evidence)
+	}
+}
+
+func TestEngineRecordAttemptTreatsWrongAnswerAsNegativeEvidence(t *testing.T) {
+	root := setupCurriculumEngineFixture(t)
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	tracker := progress.NewMemoryTracker()
+	learnerID, err := progress.NewLearnerID("learner-1")
+	if err != nil {
+		t.Fatalf("NewLearnerID() error = %v", err)
+	}
+	if err := tracker.UpdateMasteryForLearner(learnerID, "malaysia-kssm", "MT1-05", 0.8); err != nil {
+		t.Fatalf("seed topic mastery: %v", err)
+	}
+	engine, err := curriculum.NewEngine(curriculum.EngineConfig{Loader: loader, Progress: tracker})
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+
+	result, err := engine.RecordAttempt(context.Background(), curriculum.AttemptInput{
+		AttemptID:  "attempt-wrong-1",
+		LearnerID:  learnerID,
+		TopicID:    "MT1-05",
+		QuestionID: "Q1",
+		Answer:     "7",
+	})
+	if err != nil {
+		t.Fatalf("RecordAttempt() error = %v", err)
+	}
+
+	if result.Correct || result.Score != 0 {
+		t.Fatalf("result = %#v, want incorrect score 0", result)
+	}
+	if result.MasteryAfter >= result.MasteryBefore {
+		t.Fatalf("mastery transition = %v -> %v, wrong answer must not increase mastery", result.MasteryBefore, result.MasteryAfter)
+	}
+}
+
+func TestEngineRecordAttemptRejectsFreeTextWithoutMutatingMastery(t *testing.T) {
+	root := setupCurriculumEngineFixture(t)
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	tracker := progress.NewMemoryTracker()
+	learnerID, err := progress.NewLearnerID("learner-1")
+	if err != nil {
+		t.Fatalf("NewLearnerID() error = %v", err)
+	}
+	if err := tracker.UpdateMasteryForLearner(learnerID, "malaysia-kssm", "MT1-05", 0.8); err != nil {
+		t.Fatalf("seed topic mastery: %v", err)
+	}
+	engine, err := curriculum.NewEngine(curriculum.EngineConfig{Loader: loader, Progress: tracker})
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+
+	_, err = engine.RecordAttempt(context.Background(), curriculum.AttemptInput{
+		AttemptID:  "attempt-free-text-1",
+		LearnerID:  learnerID,
+		TopicID:    "MT1-05",
+		QuestionID: "Q2",
+		Answer:     "because it changes",
+	})
+	if !errors.Is(err, curriculum.ErrAssessmentNotGradeable) {
+		t.Fatalf("RecordAttempt() error = %v, want ErrAssessmentNotGradeable", err)
+	}
+
+	mastery, err := tracker.GetMasteryForLearner(learnerID, "malaysia-kssm", "MT1-05")
+	if err != nil {
+		t.Fatalf("GetMasteryForLearner() error = %v", err)
+	}
+	if mastery != 0.8 {
+		t.Fatalf("mastery after rejected free text = %v, want unchanged 0.8", mastery)
+	}
+}
+
+func TestEngineRecordAttemptReplayDoesNotApplyEvidenceTwice(t *testing.T) {
+	root := setupCurriculumEngineFixture(t)
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	tracker := progress.NewMemoryTracker()
+	learnerID, err := progress.NewLearnerID("learner-1")
+	if err != nil {
+		t.Fatalf("NewLearnerID() error = %v", err)
+	}
+	if err := tracker.UpdateMasteryForLearner(learnerID, "malaysia-kssm", "MT1-05", 0.8); err != nil {
+		t.Fatalf("seed topic mastery: %v", err)
+	}
+	engine, err := curriculum.NewEngine(curriculum.EngineConfig{Loader: loader, Progress: tracker})
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+	input := curriculum.AttemptInput{
+		AttemptID:  "message-42/Q1",
+		LearnerID:  learnerID,
+		TopicID:    "MT1-05",
+		QuestionID: "Q1",
+		Answer:     "7",
+	}
+
+	first, err := engine.RecordAttempt(context.Background(), input)
+	if err != nil {
+		t.Fatalf("first RecordAttempt() error = %v", err)
+	}
+	replay, err := engine.RecordAttempt(context.Background(), input)
+	if err != nil {
+		t.Fatalf("replayed RecordAttempt() error = %v", err)
+	}
+
+	if !first.Applied || replay.Applied {
+		t.Fatalf("applied flags = %v, %v, want true then false", first.Applied, replay.Applied)
+	}
+	if replay.MasteryBefore != first.MasteryBefore || replay.MasteryAfter != first.MasteryAfter {
+		t.Fatalf("replay transition = %v -> %v, want original %v -> %v", replay.MasteryBefore, replay.MasteryAfter, first.MasteryBefore, first.MasteryAfter)
+	}
+	mastery, err := tracker.GetMasteryForLearner(learnerID, "malaysia-kssm", "MT1-05")
+	if err != nil {
+		t.Fatalf("GetMasteryForLearner() error = %v", err)
+	}
+	if mastery != first.MasteryAfter {
+		t.Fatalf("mastery after replay = %v, want unchanged %v", mastery, first.MasteryAfter)
+	}
+}
+
+func TestEngineRecordAttemptReplaySurvivesUnrelatedLoaderChange(t *testing.T) {
+	root := setupCurriculumEngineFixture(t)
+	firstLoader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("first NewLoader() error = %v", err)
+	}
+	firstAssessment, _ := firstLoader.GetAssessment("MT1-05")
+	firstSnapshotRevision := firstLoader.SnapshotRevision()
+	tracker := progress.NewMemoryTracker()
+	learnerID, err := progress.NewLearnerID("learner-1")
+	if err != nil {
+		t.Fatalf("NewLearnerID() error = %v", err)
+	}
+	firstEngine, err := curriculum.NewEngine(curriculum.EngineConfig{
+		Loader:   firstLoader,
+		Progress: tracker,
+	})
+	if err != nil {
+		t.Fatalf("first NewEngine() error = %v", err)
+	}
+	input := curriculum.AttemptInput{
+		AttemptID:  "stable-artifact-replay/Q1",
+		LearnerID:  learnerID,
+		TopicID:    "MT1-05",
+		QuestionID: "Q1",
+		Answer:     "6",
+	}
+	first, err := firstEngine.RecordAttempt(context.Background(), input)
+	if err != nil || !first.Applied {
+		t.Fatalf("first RecordAttempt() = %#v, %v; want applied", first, err)
+	}
+
+	unrelatedPath := fixtureTopicPath(root, "MT1-01.teaching.md")
+	writeFixtureFile(t, unrelatedPath, "# Revised unrelated rational-number notes\n")
+	secondLoader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("second NewLoader() error = %v", err)
+	}
+	secondAssessment, _ := secondLoader.GetAssessment("MT1-05")
+	if secondLoader.SnapshotRevision() == firstSnapshotRevision {
+		t.Fatal("SnapshotRevision() unchanged after unrelated curriculum artifact changed")
+	}
+	if secondAssessment.Source.Revision != firstAssessment.Source.Revision {
+		t.Fatalf(
+			"assessment revision = %q, want stable %q",
+			secondAssessment.Source.Revision,
+			firstAssessment.Source.Revision,
+		)
+	}
+	secondEngine, err := curriculum.NewEngine(curriculum.EngineConfig{
+		Loader:   secondLoader,
+		Progress: tracker,
+	})
+	if err != nil {
+		t.Fatalf("second NewEngine() error = %v", err)
+	}
+
+	replay, err := secondEngine.RecordAttempt(context.Background(), input)
+	if err != nil {
+		t.Fatalf("replayed RecordAttempt() error = %v", err)
+	}
+	if replay.Applied {
+		t.Fatalf("replay = %#v, want Applied false", replay)
+	}
+}
+
+func TestEngineRecordAttemptAcceptsLocalizedMultipleChoiceLabel(t *testing.T) {
+	root := setupCurriculumEngineFixture(t)
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	tracker := progress.NewMemoryTracker()
+	learnerID, err := progress.NewLearnerID("learner-1")
+	if err != nil {
+		t.Fatalf("NewLearnerID() error = %v", err)
+	}
+	engine, err := curriculum.NewEngine(curriculum.EngineConfig{Loader: loader, Progress: tracker})
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+
+	result, err := engine.RecordAttempt(context.Background(), curriculum.AttemptInput{
+		AttemptID:  "attempt-ms-choice-1",
+		LearnerID:  learnerID,
+		TopicID:    "MT1-05",
+		QuestionID: "Q1",
+		Answer:     "B",
+		Locale:     "ms",
+	})
+	if err != nil {
+		t.Fatalf("RecordAttempt() error = %v", err)
+	}
+	if !result.Correct {
+		t.Fatalf("result = %#v, want localized correct option B accepted", result)
+	}
+}
+
+func TestEngineRecordAttemptAcceptsLocalizedExactAnswer(t *testing.T) {
+	root := setupCurriculumEngineFixture(t)
+	canonicalPath := fixtureTopicPath(root, "MT1-05.assessments.yaml")
+	variantPath := filepath.Join(
+		filepath.Dir(fixtureTopicPath(root, "MT1-05.yaml")),
+		"translations",
+		"ms",
+		"MT1-05.assessments.yaml",
+	)
+	replaceFixtureText(t, canonicalPath, "type: multiple_choice", "type: exact")
+	replaceFixtureText(t, variantPath, "type: multiple_choice", "type: exact")
+	replaceFixtureText(t, variantPath, `value: "6"`, `value: "enam"`)
+
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	tracker := progress.NewMemoryTracker()
+	learnerID, err := progress.NewLearnerID("learner-1")
+	if err != nil {
+		t.Fatalf("NewLearnerID() error = %v", err)
+	}
+	engine, err := curriculum.NewEngine(curriculum.EngineConfig{Loader: loader, Progress: tracker})
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+
+	result, err := engine.RecordAttempt(context.Background(), curriculum.AttemptInput{
+		AttemptID:  "attempt-ms-exact-1",
+		LearnerID:  learnerID,
+		TopicID:    "MT1-05",
+		QuestionID: "Q1",
+		Answer:     "enam",
+		Locale:     "ms",
+	})
+	if err != nil {
+		t.Fatalf("RecordAttempt() error = %v", err)
+	}
+	if !result.Correct {
+		t.Fatalf("result = %#v, want localized exact answer accepted", result)
+	}
+}
+
+func TestEngineGradesMultipleChoiceWithExactValueWhenOptionsAreNotAuthored(t *testing.T) {
+	root := setupCurriculumEngineFixture(t)
+	canonicalPath := fixtureTopicPath(root, "MT1-05.assessments.yaml")
+	variantPath := filepath.Join(
+		filepath.Dir(fixtureTopicPath(root, "MT1-05.yaml")),
+		"translations",
+		"ms",
+		"MT1-05.assessments.yaml",
+	)
+	for _, path := range []string{canonicalPath, variantPath} {
+		replaceFixtureText(
+			t,
+			path,
+			`      options:
+        A: "5"
+        B: "6"
+`,
+			"",
+		)
+	}
+
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	tracker := progress.NewMemoryTracker()
+	learnerID, err := progress.NewLearnerID("learner-1")
+	if err != nil {
+		t.Fatalf("NewLearnerID() error = %v", err)
+	}
+	engine, err := curriculum.NewEngine(curriculum.EngineConfig{Loader: loader, Progress: tracker})
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+
+	plan, err := engine.PlanTurn(context.Background(), curriculum.PlanTurnInput{
+		LearnerID: learnerID,
+		TopicID:   "MT1-05",
+	})
+	if err != nil {
+		t.Fatalf("PlanTurn() error = %v", err)
+	}
+	if plan.Check == nil || len(plan.Check.Options) != 0 {
+		t.Fatalf("plan.Check = %#v, want exact-value check without structured options", plan.Check)
+	}
+
+	result, err := engine.RecordAttempt(context.Background(), curriculum.AttemptInput{
+		AttemptID:  "attempt-optionless-choice-1",
+		LearnerID:  learnerID,
+		TopicID:    "MT1-05",
+		QuestionID: "Q1",
+		Answer:     "6",
+	})
+	if err != nil {
+		t.Fatalf("RecordAttempt() error = %v", err)
+	}
+	if !result.Correct || result.Score != 1 {
+		t.Fatalf("RecordAttempt() = %#v, want correct exact-value grade", result)
+	}
+}
+
+func TestEngineRecordAttemptPreservesExactAnswerOperators(t *testing.T) {
+	root := setupCurriculumEngineFixture(t)
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	tracker := progress.NewMemoryTracker()
+	learnerID, err := progress.NewLearnerID("learner-1")
+	if err != nil {
+		t.Fatalf("NewLearnerID() error = %v", err)
+	}
+	engine, err := curriculum.NewEngine(curriculum.EngineConfig{Loader: loader, Progress: tracker})
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+
+	result, err := engine.RecordAttempt(context.Background(), curriculum.AttemptInput{
+		AttemptID:  "attempt-equation-1",
+		LearnerID:  learnerID,
+		TopicID:    "MT1-05",
+		QuestionID: "Q3",
+		Answer:     "x2",
+	})
+	if err != nil {
+		t.Fatalf("RecordAttempt() error = %v", err)
+	}
+	if result.Correct {
+		t.Fatalf("result = %#v, x2 must not equal x=2", result)
+	}
+}
+
+func setupCurriculumEngineFixture(t *testing.T) string {
+	t.Helper()
+
+	root := setupOSSContractFixture(t)
+	subjectGradePath := filepath.Join(
+		root,
+		"curricula",
+		"malaysia",
+		"malaysia-kssm",
+		"malaysia-kssm-matematik",
+		"malaysia-kssm-matematik-tingkatan-1",
+		"subject-grade.yaml",
+	)
+	replaceFixtureText(t, subjectGradePath, "topics:\n  - MT1-05", "topics:\n  - MT1-01\n  - MT1-05")
+	topicsDir := filepath.Join(
+		root,
+		"curricula",
+		"malaysia",
+		"malaysia-kssm",
+		"malaysia-kssm-matematik",
+		"malaysia-kssm-matematik-tingkatan-1",
+		"topics",
+	)
+
+	writeFixtureFile(t, filepath.Join(topicsDir, "MT1-01.yaml"), `
+id: MT1-01
+name: Nombor Nisbah
+name_en: Rational Numbers
+subject_grade_id: malaysia-kssm-matematik-tingkatan-1
+subject_id: malaysia-kssm-matematik
+syllabus_id: malaysia-kssm
+language: en
+difficulty: beginner
+content_standards:
+  - id: "1.1"
+    text_en: Integers
+learning_objectives:
+  - id: "1.1.1"
+    content_standard_id: "1.1"
+    text_en: Compare integers.
+    bloom: apply
+mastery:
+  minimum_score: 0.75
+  assessment_count: 1
+quality_level: 3
+provenance: human
+`)
+	writeFixtureFile(t, filepath.Join(topicsDir, "MT1-01.assessments.yaml"), `
+topic_id: MT1-01
+provenance: human
+questions:
+  - id: Q1
+    text: Which integer is larger, -2 or -5?
+    difficulty: easy
+    learning_objective: "1.1.1"
+    answer:
+      type: exact
+      value: "-2"
+      working: -2 is to the right of -5 on a number line.
+    marks: 1
+`)
+	writeFixtureFile(t, filepath.Join(topicsDir, "MT1-01.examples.yaml"), `
+topic_id: MT1-01
+provenance: human
+worked_examples:
+  - id: WE-01
+    topic: Comparing integers
+    difficulty: easy
+    learning_objective: "1.1.1"
+    misconception_alert: A larger magnitude is always the larger integer.
+    scenario: Compare -2 and -5.
+    working: Locate both integers on a number line; -2 is farther right.
+`)
+	writeFixtureFile(t, filepath.Join(topicsDir, "MT1-01.teaching.md"), "# Teach rational numbers\n")
+
+	writeFixtureFile(t, filepath.Join(topicsDir, "MT1-05.yaml"), `
+id: MT1-05
+name: Ungkapan Algebra
+name_en: Algebraic Expressions
+subject_grade_id: malaysia-kssm-matematik-tingkatan-1
+subject_id: malaysia-kssm-matematik
+syllabus_id: malaysia-kssm
+language: en
+difficulty: beginner
+content_standards:
+  - id: "5.1"
+    text_en: Variables and algebraic expressions
+learning_objectives:
+  - id: "5.1.1"
+    content_standard_id: "5.1"
+    text_en: Use letters to represent unknown quantities.
+    bloom: understand
+prerequisites:
+  required:
+    - MT1-01
+mastery:
+  minimum_score: 0.75
+  assessment_count: 1
+teaching:
+  sequence:
+    - Introduce a variable through a mystery-number example.
+quality_level: 3
+provenance: human
+`)
+	writeFixtureFile(t, filepath.Join(topicsDir, "MT1-05.assessments.yaml"), `
+topic_id: MT1-05
+provenance: human
+questions:
+  - id: Q1
+    text: Evaluate 3x when x = 2.
+    difficulty: easy
+    learning_objective: "5.1.1"
+    answer:
+      type: multiple_choice
+      value: "6"
+      options:
+        A: "5"
+        B: "6"
+      working: Substitute x = 2, then multiply.
+    marks: 1
+  - id: Q2
+    text: Explain whether x can change.
+    difficulty: medium
+    learning_objective: "5.1.1"
+    answer:
+      type: free_text
+      value: It can vary.
+      working: A variable may represent different values.
+    marks: 1
+  - id: Q3
+    text: Write the equation saying x equals 2.
+    difficulty: easy
+    learning_objective: "5.1.1"
+    answer:
+      type: exact
+      value: "x = 2"
+    marks: 1
+`)
+	writeFixtureFile(t, filepath.Join(topicsDir, "MT1-05.examples.yaml"), `
+topic_id: MT1-05
+provenance: human
+worked_examples:
+  - id: WE-01
+    topic: Evaluating algebraic expressions
+    difficulty: easy
+    learning_objective: "5.1.1"
+    real_world_analogy: Three bags with two apples each.
+    misconception_alert: The letter x always means multiplication.
+    scenario: Evaluate 3x when x = 2.
+    working: Substitute 2 for x, then calculate 3 times 2.
+`)
+	writeFixtureFile(t, filepath.Join(topicsDir, "MT1-05.teaching.md"), "# Teach algebraic expressions\n")
+
+	return root
+}
+
+func recordFixtureEvidence(
+	t *testing.T,
+	tracker *progress.MemoryTracker,
+	learnerID progress.LearnerID,
+	attemptID, topicID, questionID string,
+	score float64,
+) {
+	t.Helper()
+	_, err := tracker.RecordMasteryEvidence(context.Background(), progress.MasteryEvidence{
+		AttemptID:      attemptID,
+		LearnerID:      learnerID,
+		SyllabusID:     "malaysia-kssm",
+		TopicID:        topicID,
+		SourceKind:     "assessment",
+		SourceID:       questionID,
+		SourceRevision: "sha256:fixture",
+		Score:          score,
+		PayloadHash:    sha256.Sum256([]byte(attemptID)),
+	})
+	if err != nil {
+		t.Fatalf("RecordMasteryEvidence() error = %v", err)
+	}
+}
+
+func requirePlanRelation(
+	t *testing.T,
+	plan curriculum.TeachingPlan,
+	relationType curriculum.CurriculumRelationType,
+	from curriculum.CurriculumNodeRef,
+	to curriculum.CurriculumNodeRef,
+) curriculum.CurriculumRelation {
+	t.Helper()
+	for _, relation := range plan.Relations {
+		if relation.Type == relationType && relation.From == from && relation.To == to {
+			return relation
+		}
+	}
+	t.Fatalf(
+		"plan.Relations = %#v, want %q relation from %#v to %#v",
+		plan.Relations,
+		relationType,
+		from,
+		to,
+	)
+	return curriculum.CurriculumRelation{}
+}
+
+type fixedSnapshotStore struct {
+	snapshot []progress.MasterySnapshotItem
+	reads    int
+	writes   int
+}
+
+func (s *fixedSnapshotStore) GetMasterySnapshot(
+	ctx context.Context,
+	_ progress.LearnerID,
+) ([]progress.MasterySnapshotItem, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.reads++
+	return append([]progress.MasterySnapshotItem(nil), s.snapshot...), nil
+}
+
+func (s *fixedSnapshotStore) RecordMasteryEvidence(
+	context.Context,
+	progress.MasteryEvidence,
+) (progress.MasteryEvidenceResult, error) {
+	s.writes++
+	return progress.MasteryEvidenceResult{}, errors.New("unexpected mastery evidence write")
+}

--- a/internal/curriculum/engine_test.go
+++ b/internal/curriculum/engine_test.go
@@ -1365,6 +1365,58 @@ func TestEngineRecordAttemptPreservesExactAnswerOperators(t *testing.T) {
 	}
 }
 
+func TestEnginePlanTurnAdvancesAcrossGradeableObjectives(t *testing.T) {
+	root := setupCurriculumEngineFixture(t)
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	tracker := progress.NewMemoryTracker()
+	learnerID, err := progress.NewLearnerID("learner-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	recordFixtureEvidence(t, tracker, learnerID, "prerequisite/Q1", "MT1-01", "Q1", 1)
+	engine, err := curriculum.NewEngine(curriculum.EngineConfig{Loader: loader, Progress: tracker})
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+
+	assertPlan := func(wantObjective, wantQuestion string) {
+		t.Helper()
+		plan, planErr := engine.PlanTurn(context.Background(), curriculum.PlanTurnInput{
+			LearnerID: learnerID,
+			TopicID:   "MT1-05",
+		})
+		if planErr != nil {
+			t.Fatalf("PlanTurn() error = %v", planErr)
+		}
+		if plan.Target.ObjectiveID != wantObjective || plan.Check == nil || plan.Check.QuestionID != wantQuestion {
+			t.Fatalf("plan target/check = %#v / %#v, want %s/%s", plan.Target, plan.Check, wantObjective, wantQuestion)
+		}
+	}
+	record := func(attemptID, questionID, answer string) {
+		t.Helper()
+		if _, recordErr := engine.RecordAttempt(context.Background(), curriculum.AttemptInput{
+			AttemptID:  attemptID,
+			LearnerID:  learnerID,
+			TopicID:    "MT1-05",
+			QuestionID: questionID,
+			Answer:     answer,
+		}); recordErr != nil {
+			t.Fatalf("RecordAttempt(%s) error = %v", questionID, recordErr)
+		}
+	}
+
+	assertPlan("5.1.1", "Q1")
+	record("turn-1/Q1", "Q1", "6")
+	assertPlan("5.1.1", "Q3")
+	record("turn-2/Q3", "Q3", "x = 2")
+	assertPlan("5.1.2", "Q4")
+	record("turn-3/Q4", "Q4", "11")
+	assertPlan("5.1.2", "Q4")
+}
+
 func setupCurriculumEngineFixture(t *testing.T) string {
 	t.Helper()
 
@@ -1453,10 +1505,18 @@ content_standards:
   - id: "5.1"
     text_en: Variables and algebraic expressions
 learning_objectives:
+  - id: "5.1.0"
+    content_standard_id: "5.1"
+    text_en: Recognize variables in expressions.
+    bloom: understand
   - id: "5.1.1"
     content_standard_id: "5.1"
     text_en: Use letters to represent unknown quantities.
     bloom: understand
+  - id: "5.1.2"
+    content_standard_id: "5.1"
+    text_en: Evaluate expressions after substitution.
+    bloom: apply
 prerequisites:
   required:
     - MT1-01
@@ -1501,6 +1561,14 @@ questions:
     answer:
       type: exact
       value: "x = 2"
+    marks: 1
+  - id: Q4
+    text: Evaluate 2y when y = 5.
+    difficulty: easy
+    learning_objective: "5.1.2"
+    answer:
+      type: exact
+      value: "10"
     marks: 1
 `)
 	writeFixtureFile(t, filepath.Join(topicsDir, "MT1-05.examples.yaml"), `

--- a/internal/curriculum/loader.go
+++ b/internal/curriculum/loader.go
@@ -4,10 +4,12 @@
 package curriculum
 
 import (
+	"crypto/sha256"
+	"encoding/binary"
 	"fmt"
-	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 
@@ -16,31 +18,71 @@ import (
 
 // Loader loads and caches curriculum content from the filesystem.
 type Loader struct {
-	rootDir       string
-	topics        map[string]Topic
-	subjects      map[string]Subject
-	syllabi       map[string]Syllabus
-	assessments   map[string]Assessment
-	teachingNotes map[string]string
-	mu            sync.RWMutex
+	rootDir              string
+	topics               map[string]Topic
+	topicVariants        map[string]map[string]Topic
+	subjects             map[string]Subject
+	subjectGrades        map[string]SubjectGrade
+	syllabi              map[string]Syllabus
+	concepts             map[string]Concept
+	examples             map[string]ExampleSet
+	exampleVariants      map[string]map[string]ExampleSet
+	assessments          map[string]Assessment
+	assessmentVariants   map[string]map[string]Assessment
+	teachingNotes        map[string]TeachingNote
+	teachingNoteVariants map[string]map[string]TeachingNote
+	snapshotRevision     string
+	mu                   sync.RWMutex
+}
+
+// SnapshotStats describes the validated artifact classes consumed by the
+// curriculum engine.
+type SnapshotStats struct {
+	Syllabi               int
+	Subjects              int
+	SubjectGrades         int
+	Topics                int
+	TopicVariants         int
+	Concepts              int
+	Examples              int
+	ExampleVariants       int
+	TeachingNotes         int
+	TeachingNoteVariants  int
+	AITeachingReadyTopics int
+	Assessments           int
+	AssessmentVariants    int
 }
 
 // NewLoader creates a new curriculum loader and loads all content.
 func NewLoader(rootDir string) (*Loader, error) {
+	revision, err := curriculumSnapshotRevision(rootDir)
+	if err != nil {
+		return nil, fmt.Errorf("hashing curriculum snapshot: %w", err)
+	}
 	l := &Loader{
-		rootDir:       rootDir,
-		topics:        make(map[string]Topic),
-		subjects:      make(map[string]Subject),
-		syllabi:       make(map[string]Syllabus),
-		assessments:   make(map[string]Assessment),
-		teachingNotes: make(map[string]string),
+		rootDir:              rootDir,
+		topics:               make(map[string]Topic),
+		topicVariants:        make(map[string]map[string]Topic),
+		subjects:             make(map[string]Subject),
+		subjectGrades:        make(map[string]SubjectGrade),
+		syllabi:              make(map[string]Syllabus),
+		concepts:             make(map[string]Concept),
+		examples:             make(map[string]ExampleSet),
+		exampleVariants:      make(map[string]map[string]ExampleSet),
+		assessments:          make(map[string]Assessment),
+		assessmentVariants:   make(map[string]map[string]Assessment),
+		teachingNotes:        make(map[string]TeachingNote),
+		teachingNoteVariants: make(map[string]map[string]TeachingNote),
+		snapshotRevision:     revision,
 	}
 
 	if err := l.loadAll(); err != nil {
 		return nil, fmt.Errorf("loading curriculum: %w", err)
 	}
+	if err := l.validate(); err != nil {
+		return nil, fmt.Errorf("validating curriculum: %w", err)
+	}
 
-	slog.Info("curriculum loaded", "topics", len(l.topics))
 	return l, nil
 }
 
@@ -49,7 +91,7 @@ func (l *Loader) GetTopic(id string) (Topic, bool) {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
 	t, ok := l.topics[id]
-	return t, ok
+	return cloneTopic(t), ok
 }
 
 // GetSubject returns a subject by ID.
@@ -57,7 +99,15 @@ func (l *Loader) GetSubject(id string) (Subject, bool) {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
 	subject, ok := l.subjects[id]
-	return subject, ok
+	return cloneSubject(subject), ok
+}
+
+// GetSubjectGrade returns a subject-grade and its source-declared topic order.
+func (l *Loader) GetSubjectGrade(id string) (SubjectGrade, bool) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	subjectGrade, ok := l.subjectGrades[id]
+	return cloneSubjectGrade(subjectGrade), ok
 }
 
 // GetSyllabus returns a syllabus by ID.
@@ -65,15 +115,81 @@ func (l *Loader) GetSyllabus(id string) (Syllabus, bool) {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
 	syllabus, ok := l.syllabi[id]
-	return syllabus, ok
+	return cloneSyllabus(syllabus), ok
+}
+
+// GetConcept returns one explicit cross-curriculum concept.
+func (l *Loader) GetConcept(id string) (Concept, bool) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	concept, ok := l.concepts[id]
+	return cloneConcept(concept), ok
+}
+
+// ConceptsForTopic returns explicit concept mappings containing one
+// syllabus-scoped topic, ordered by concept ID.
+func (l *Loader) ConceptsForTopic(syllabusID, topicID string) []Concept {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	concepts := make([]Concept, 0)
+	for _, concept := range l.concepts {
+		if conceptIncludes(concept, syllabusID, topicID) {
+			concepts = append(concepts, cloneConcept(concept))
+		}
+	}
+	sort.Slice(concepts, func(i, j int) bool {
+		return concepts[i].ID < concepts[j].ID
+	})
+	return concepts
 }
 
 // GetTeachingNotes returns teaching notes for a topic ID.
 func (l *Loader) GetTeachingNotes(id string) (string, bool) {
+	note, ok := l.GetTeachingNote(id)
+	return note.Content, ok
+}
+
+// GetTeachingNote returns a source-backed canonical teaching note.
+func (l *Loader) GetTeachingNote(id string) (TeachingNote, bool) {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
 	n, ok := l.teachingNotes[id]
 	return n, ok
+}
+
+// GetTeachingNotesVariant returns locale-specific notes without replacing the
+// canonical notes returned by GetTeachingNotes.
+func (l *Loader) GetTeachingNotesVariant(topicID, locale string) (string, bool) {
+	note, ok := l.GetTeachingNoteVariant(topicID, locale)
+	return note.Content, ok
+}
+
+// GetTeachingNoteVariant returns one source-backed locale teaching note.
+func (l *Loader) GetTeachingNoteVariant(topicID, locale string) (TeachingNote, bool) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	variants := l.teachingNoteVariants[topicID]
+	notes, ok := variants[locale]
+	return notes, ok
+}
+
+// GetExamples returns the canonical worked examples for a topic.
+func (l *Loader) GetExamples(topicID string) (ExampleSet, bool) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	examples, ok := l.examples[topicID]
+	return cloneExampleSet(examples), ok
+}
+
+// GetExamplesVariant returns locale-specific examples without replacing the
+// canonical examples returned by GetExamples.
+func (l *Loader) GetExamplesVariant(topicID, locale string) (ExampleSet, bool) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	variants := l.exampleVariants[topicID]
+	examples, ok := variants[locale]
+	return cloneExampleSet(examples), ok
 }
 
 // GetAssessment returns an assessment by topic ID.
@@ -81,7 +197,27 @@ func (l *Loader) GetAssessment(topicID string) (Assessment, bool) {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
 	assessment, ok := l.assessments[topicID]
-	return assessment, ok
+	return cloneAssessment(assessment), ok
+}
+
+// GetAssessmentVariant returns a locale-specific assessment without replacing
+// the canonical grading contract returned by GetAssessment.
+func (l *Loader) GetAssessmentVariant(topicID, locale string) (Assessment, bool) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	variants := l.assessmentVariants[topicID]
+	assessment, ok := variants[locale]
+	return cloneAssessment(assessment), ok
+}
+
+// GetTopicVariant returns a locale-specific variant without replacing the
+// canonical topic returned by GetTopic.
+func (l *Loader) GetTopicVariant(topicID, locale string) (Topic, bool) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	variants := l.topicVariants[topicID]
+	topic, ok := variants[locale]
+	return cloneTopic(topic), ok
 }
 
 // AllTopics returns all loaded topics.
@@ -90,14 +226,61 @@ func (l *Loader) AllTopics() []Topic {
 	defer l.mu.RUnlock()
 	topics := make([]Topic, 0, len(l.topics))
 	for _, t := range l.topics {
-		topics = append(topics, t)
+		topics = append(topics, cloneTopic(t))
 	}
+	sort.Slice(topics, func(i, j int) bool {
+		return topics[i].ID < topics[j].ID
+	})
 	return topics
+}
+
+// SnapshotRevision identifies the exact curriculum artifact bytes loaded by
+// this instance.
+func (l *Loader) SnapshotRevision() string {
+	return l.snapshotRevision
+}
+
+// SnapshotStats returns exact counts for activation and deployment checks.
+func (l *Loader) SnapshotStats() SnapshotStats {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	stats := SnapshotStats{
+		Syllabi:       len(l.syllabi),
+		Subjects:      len(l.subjects),
+		SubjectGrades: len(l.subjectGrades),
+		Topics:        len(l.topics),
+		Concepts:      len(l.concepts),
+		Examples:      len(l.examples),
+		TeachingNotes: len(l.teachingNotes),
+		Assessments:   len(l.assessments),
+	}
+	for _, variants := range l.topicVariants {
+		stats.TopicVariants += len(variants)
+	}
+	for _, variants := range l.assessmentVariants {
+		stats.AssessmentVariants += len(variants)
+	}
+	for _, variants := range l.exampleVariants {
+		stats.ExampleVariants += len(variants)
+	}
+	for _, variants := range l.teachingNoteVariants {
+		stats.TeachingNoteVariants += len(variants)
+	}
+	for _, topic := range l.topics {
+		if topic.IsAITeachingReady() {
+			stats.AITeachingReadyTopics++
+		}
+	}
+	return stats
 }
 
 func (l *Loader) loadAll() error {
 	return filepath.Walk(l.rootDir, func(path string, info os.FileInfo, err error) error {
-		if err != nil || info.IsDir() {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
 			return nil
 		}
 
@@ -107,13 +290,25 @@ func (l *Loader) loadAll() error {
 			return l.loadTeachingNotes(path)
 		case base == "subject.yaml" || base == "subject.yml":
 			return l.loadSubject(path)
+		case base == "subject-grade.yaml" || base == "subject-grade.yml":
+			return l.loadSubjectGrade(path)
 		case base == "syllabus.yaml" || base == "syllabus.yml":
 			return l.loadSyllabus(path)
+		case isConceptPath(path):
+			return l.loadConcept(path)
+		case isExamplesPath(path):
+			if isTranslationPath(path) {
+				return l.loadExamplesVariant(path)
+			}
+			return l.loadExamples(path)
 		case isAssessmentPath(path):
+			if isTranslationPath(path) {
+				return l.loadAssessmentVariant(path)
+			}
 			return l.loadAssessment(path)
-		case strings.HasSuffix(path, ".yaml") || strings.HasSuffix(path, ".yml"):
-			if strings.HasSuffix(path, ".examples.yaml") {
-				return nil // Skip non-topic YAML
+		case isTopicPath(path):
+			if isTranslationPath(path) {
+				return l.loadTopicVariant(path)
 			}
 			return l.loadTopic(path)
 		}
@@ -121,72 +316,179 @@ func (l *Loader) loadAll() error {
 	})
 }
 
+func isConceptPath(path string) bool {
+	slashPath := filepath.ToSlash(path)
+	if !strings.Contains(slashPath, "/concepts/") {
+		return false
+	}
+	return strings.HasSuffix(path, ".yaml") || strings.HasSuffix(path, ".yml")
+}
+
 func isAssessmentPath(path string) bool {
 	return strings.HasSuffix(path, ".assessments.yaml") || strings.HasSuffix(path, ".assessments.yml")
 }
 
+func isExamplesPath(path string) bool {
+	return strings.HasSuffix(path, ".examples.yaml") || strings.HasSuffix(path, ".examples.yml")
+}
+
+func isTopicPath(path string) bool {
+	slashPath := filepath.ToSlash(path)
+	if !strings.Contains(slashPath, "/topics/") {
+		return false
+	}
+	if isAssessmentPath(path) || strings.HasSuffix(path, ".examples.yaml") || strings.HasSuffix(path, ".examples.yml") {
+		return false
+	}
+	return strings.HasSuffix(path, ".yaml") || strings.HasSuffix(path, ".yml")
+}
+
+func isTranslationPath(path string) bool {
+	return strings.Contains(filepath.ToSlash(path), "/translations/")
+}
+
 func (l *Loader) loadTopic(path string) error {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return err
-	}
-
 	var topic Topic
-	if err := yaml.Unmarshal(data, &topic); err != nil {
-		slog.Warn("skipping invalid topic YAML", "path", path, "error", err)
-		return nil
+	if err := decodeYAMLFile(path, &topic); err != nil {
+		return fmt.Errorf("decode topic %s: %w", path, err)
 	}
-
 	if topic.ID == "" {
-		return nil // Not a topic file
+		return fmt.Errorf("topic %s: id is required", path)
 	}
+	source, err := l.sourceRef(path, "topic", topic.Language)
+	if err != nil {
+		return fmt.Errorf("source topic %s: %w", path, err)
+	}
+	topic.Source = source
 
 	l.mu.Lock()
+	defer l.mu.Unlock()
+	if _, exists := l.topics[topic.ID]; exists {
+		return fmt.Errorf("topic %s: duplicate canonical ID %q", path, topic.ID)
+	}
 	l.topics[topic.ID] = topic
-	l.mu.Unlock()
+	return nil
+}
 
+func (l *Loader) loadTopicVariant(path string) error {
+	var topic Topic
+	if err := decodeYAMLFile(path, &topic); err != nil {
+		return fmt.Errorf("decode topic variant %s: %w", path, err)
+	}
+	locale := translationLocale(path)
+	if topic.ID == "" || topic.Language == "" || locale == "" {
+		return fmt.Errorf("topic variant %s: id, language, and translation locale are required", path)
+	}
+	if topic.Language != locale {
+		return fmt.Errorf("topic variant %s: language %q does not match translation locale %q", path, topic.Language, locale)
+	}
+	source, err := l.sourceRef(path, "topic_variant", locale)
+	if err != nil {
+		return fmt.Errorf("source topic variant %s: %w", path, err)
+	}
+	topic.Source = source
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.topicVariants[topic.ID] == nil {
+		l.topicVariants[topic.ID] = make(map[string]Topic)
+	}
+	if _, exists := l.topicVariants[topic.ID][locale]; exists {
+		return fmt.Errorf("topic variant %s: duplicate locale %q for topic %q", path, locale, topic.ID)
+	}
+	l.topicVariants[topic.ID][locale] = topic
 	return nil
 }
 
 func (l *Loader) loadSubject(path string) error {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return err
-	}
-
 	var subject Subject
-	if err := yaml.Unmarshal(data, &subject); err != nil {
-		slog.Warn("skipping invalid subject YAML", "path", path, "error", err)
-		return nil
+	if err := decodeYAMLFile(path, &subject); err != nil {
+		return fmt.Errorf("decode subject %s: %w", path, err)
 	}
 	if subject.ID == "" {
-		return nil
+		return fmt.Errorf("subject %s: id is required", path)
 	}
+	source, err := l.sourceRef(path, "subject", subject.Language)
+	if err != nil {
+		return fmt.Errorf("source subject %s: %w", path, err)
+	}
+	subject.Source = source
 
 	l.mu.Lock()
+	defer l.mu.Unlock()
+	if _, exists := l.subjects[subject.ID]; exists {
+		return fmt.Errorf("subject %s: duplicate ID %q", path, subject.ID)
+	}
 	l.subjects[subject.ID] = subject
-	l.mu.Unlock()
+	return nil
+}
+
+func (l *Loader) loadSubjectGrade(path string) error {
+	var subjectGrade SubjectGrade
+	if err := decodeYAMLFile(path, &subjectGrade); err != nil {
+		return fmt.Errorf("decode subject grade %s: %w", path, err)
+	}
+	if subjectGrade.ID == "" {
+		return fmt.Errorf("subject grade %s: id is required", path)
+	}
+	source, err := l.sourceRef(path, "subject_grade", subjectGrade.Language)
+	if err != nil {
+		return fmt.Errorf("source subject grade %s: %w", path, err)
+	}
+	subjectGrade.Source = source
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if _, exists := l.subjectGrades[subjectGrade.ID]; exists {
+		return fmt.Errorf("subject grade %s: duplicate ID %q", path, subjectGrade.ID)
+	}
+	l.subjectGrades[subjectGrade.ID] = subjectGrade
 	return nil
 }
 
 func (l *Loader) loadSyllabus(path string) error {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return err
-	}
-
 	var syllabus Syllabus
-	if err := yaml.Unmarshal(data, &syllabus); err != nil {
-		slog.Warn("skipping invalid syllabus YAML", "path", path, "error", err)
-		return nil
+	if err := decodeYAMLFile(path, &syllabus); err != nil {
+		return fmt.Errorf("decode syllabus %s: %w", path, err)
 	}
 	if syllabus.ID == "" {
-		return nil
+		return fmt.Errorf("syllabus %s: id is required", path)
 	}
+	source, err := l.sourceRef(path, "syllabus", syllabus.Language)
+	if err != nil {
+		return fmt.Errorf("source syllabus %s: %w", path, err)
+	}
+	syllabus.Source = source
 
 	l.mu.Lock()
+	defer l.mu.Unlock()
+	if _, exists := l.syllabi[syllabus.ID]; exists {
+		return fmt.Errorf("syllabus %s: duplicate ID %q", path, syllabus.ID)
+	}
 	l.syllabi[syllabus.ID] = syllabus
-	l.mu.Unlock()
+	return nil
+}
+
+func (l *Loader) loadConcept(path string) error {
+	var concept Concept
+	if err := decodeYAMLFile(path, &concept); err != nil {
+		return fmt.Errorf("decode concept %s: %w", path, err)
+	}
+	if concept.ID == "" {
+		return fmt.Errorf("concept %s: id is required", path)
+	}
+	source, err := l.sourceRef(path, "concept", "")
+	if err != nil {
+		return fmt.Errorf("source concept %s: %w", path, err)
+	}
+	concept.Source = source
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if _, exists := l.concepts[concept.ID]; exists {
+		return fmt.Errorf("concept %s: duplicate ID %q", path, concept.ID)
+	}
+	l.concepts[concept.ID] = concept
 	return nil
 }
 
@@ -196,45 +498,263 @@ func (l *Loader) loadTeachingNotes(path string) error {
 		return err
 	}
 
-	// Derive topic ID from matching YAML file
 	yamlPath := strings.TrimSuffix(path, ".teaching.md") + ".yaml"
 	yamlData, err := os.ReadFile(yamlPath)
-	if err != nil {
-		return nil // No matching YAML, skip
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("teaching notes %s: read topic metadata %s: %w", path, yamlPath, err)
 	}
 
-	var partial struct {
-		ID string `yaml:"id"`
+	topicID := strings.TrimSuffix(filepath.Base(path), ".teaching.md")
+	if err == nil {
+		var partial struct {
+			ID string `yaml:"id"`
+		}
+		if err := yaml.Unmarshal(yamlData, &partial); err != nil {
+			return fmt.Errorf("teaching notes %s: decode topic metadata %s: %w", path, yamlPath, err)
+		}
+		topicID = partial.ID
 	}
-	if err := yaml.Unmarshal(yamlData, &partial); err != nil || partial.ID == "" {
-		return nil
+	if topicID == "" {
+		return fmt.Errorf("teaching notes %s: topic metadata %s has no ID", path, yamlPath)
+	}
+
+	locale := ""
+	kind := "teaching_note"
+	if isTranslationPath(path) {
+		locale = translationLocale(path)
+		if locale == "" {
+			return fmt.Errorf("teaching notes %s: translation locale is required", path)
+		}
+		kind = "teaching_note_variant"
+	}
+	source, err := l.sourceRef(path, kind, locale)
+	if err != nil {
+		return fmt.Errorf("source teaching notes %s: %w", path, err)
+	}
+	note := TeachingNote{
+		TopicID: topicID,
+		Content: string(data),
+		Source:  source,
 	}
 
 	l.mu.Lock()
-	l.teachingNotes[partial.ID] = string(data)
-	l.mu.Unlock()
+	defer l.mu.Unlock()
+	if isTranslationPath(path) {
+		if l.teachingNoteVariants[topicID] == nil {
+			l.teachingNoteVariants[topicID] = make(map[string]TeachingNote)
+		}
+		if _, exists := l.teachingNoteVariants[topicID][locale]; exists {
+			return fmt.Errorf("teaching notes %s: duplicate locale %q for topic %q", path, locale, topicID)
+		}
+		l.teachingNoteVariants[topicID][locale] = note
+		return nil
+	}
+	if _, exists := l.teachingNotes[topicID]; exists {
+		return fmt.Errorf("teaching notes %s: duplicate canonical topic ID %q", path, topicID)
+	}
+	l.teachingNotes[topicID] = note
+	return nil
+}
 
+func (l *Loader) loadExamples(path string) error {
+	var examples ExampleSet
+	if err := decodeYAMLFile(path, &examples); err != nil {
+		return fmt.Errorf("decode examples %s: %w", path, err)
+	}
+	if examples.TopicID == "" || len(examples.WorkedExamples) == 0 {
+		return fmt.Errorf("examples %s: topic_id and worked_examples are required", path)
+	}
+	source, err := l.sourceRef(path, "examples", "")
+	if err != nil {
+		return fmt.Errorf("source examples %s: %w", path, err)
+	}
+	examples.Source = source
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if _, exists := l.examples[examples.TopicID]; exists {
+		return fmt.Errorf("examples %s: duplicate canonical topic ID %q", path, examples.TopicID)
+	}
+	l.examples[examples.TopicID] = examples
+	return nil
+}
+
+func (l *Loader) loadExamplesVariant(path string) error {
+	var examples ExampleSet
+	if err := decodeYAMLFile(path, &examples); err != nil {
+		return fmt.Errorf("decode examples variant %s: %w", path, err)
+	}
+	locale := translationLocale(path)
+	if examples.TopicID == "" || len(examples.WorkedExamples) == 0 || locale == "" {
+		return fmt.Errorf("examples variant %s: topic_id, worked_examples, and locale are required", path)
+	}
+	source, err := l.sourceRef(path, "examples_variant", locale)
+	if err != nil {
+		return fmt.Errorf("source examples variant %s: %w", path, err)
+	}
+	examples.Source = source
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.exampleVariants[examples.TopicID] == nil {
+		l.exampleVariants[examples.TopicID] = make(map[string]ExampleSet)
+	}
+	if _, exists := l.exampleVariants[examples.TopicID][locale]; exists {
+		return fmt.Errorf("examples variant %s: duplicate locale %q for topic %q", path, locale, examples.TopicID)
+	}
+	l.exampleVariants[examples.TopicID][locale] = examples
+	return nil
+}
+
+func (l *Loader) loadAssessmentVariant(path string) error {
+	var assessment Assessment
+	if err := decodeYAMLFile(path, &assessment); err != nil {
+		return fmt.Errorf("decode assessment variant %s: %w", path, err)
+	}
+	locale := translationLocale(path)
+	if assessment.TopicID == "" || len(assessment.Questions) == 0 || locale == "" {
+		return fmt.Errorf("assessment variant %s: topic_id, questions, and locale are required", path)
+	}
+	source, err := l.sourceRef(path, "assessment_variant", locale)
+	if err != nil {
+		return fmt.Errorf("source assessment variant %s: %w", path, err)
+	}
+	assessment.Source = source
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.assessmentVariants[assessment.TopicID] == nil {
+		l.assessmentVariants[assessment.TopicID] = make(map[string]Assessment)
+	}
+	if _, exists := l.assessmentVariants[assessment.TopicID][locale]; exists {
+		return fmt.Errorf("assessment variant %s: duplicate locale %q for topic %q", path, locale, assessment.TopicID)
+	}
+	l.assessmentVariants[assessment.TopicID][locale] = assessment
 	return nil
 }
 
 func (l *Loader) loadAssessment(path string) error {
+	var assessment Assessment
+	if err := decodeYAMLFile(path, &assessment); err != nil {
+		return fmt.Errorf("decode assessment %s: %w", path, err)
+	}
+
+	if assessment.TopicID == "" || len(assessment.Questions) == 0 {
+		return fmt.Errorf("assessment %s: topic_id and questions are required", path)
+	}
+	source, err := l.sourceRef(path, "assessment", "")
+	if err != nil {
+		return fmt.Errorf("source assessment %s: %w", path, err)
+	}
+	assessment.Source = source
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if _, exists := l.assessments[assessment.TopicID]; exists {
+		return fmt.Errorf("assessment %s: duplicate canonical topic ID %q", path, assessment.TopicID)
+	}
+	l.assessments[assessment.TopicID] = assessment
+	return nil
+}
+
+func decodeYAMLFile(path string, target any) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
+	return yaml.Unmarshal(data, target)
+}
 
-	var assessment Assessment
-	if err := yaml.Unmarshal(data, &assessment); err != nil {
-		slog.Warn("skipping invalid assessment YAML", "path", path, "error", err)
+func curriculumSnapshotRevision(rootDir string) (string, error) {
+	var paths []string
+	if err := filepath.Walk(rootDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		relative, err := filepath.Rel(rootDir, path)
+		if err != nil {
+			return err
+		}
+		if isSnapshotArtifact(relative) {
+			paths = append(paths, path)
+		}
 		return nil
+	}); err != nil {
+		return "", err
 	}
+	sort.Strings(paths)
 
-	if assessment.TopicID == "" || len(assessment.Questions) == 0 {
-		return nil
+	digest := sha256.New()
+	_, _ = digest.Write([]byte("pai-curriculum-snapshot/v1"))
+	for _, path := range paths {
+		relative, err := filepath.Rel(rootDir, path)
+		if err != nil {
+			return "", err
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return "", err
+		}
+		writeSnapshotDigestPart(digest, []byte(filepath.ToSlash(relative)))
+		writeSnapshotDigestPart(digest, data)
 	}
+	return fmt.Sprintf("sha256:%x", digest.Sum(nil)), nil
+}
 
-	l.mu.Lock()
-	l.assessments[assessment.TopicID] = assessment
-	l.mu.Unlock()
-	return nil
+func isSnapshotArtifact(relativePath string) bool {
+	path := filepath.ToSlash(relativePath)
+	if !strings.HasPrefix(path, "curricula/") && !strings.HasPrefix(path, "concepts/") {
+		return false
+	}
+	return strings.HasSuffix(path, ".yaml") ||
+		strings.HasSuffix(path, ".yml") ||
+		strings.HasSuffix(path, ".teaching.md")
+}
+
+func writeSnapshotDigestPart(digest interface{ Write([]byte) (int, error) }, value []byte) {
+	var length [8]byte
+	binary.BigEndian.PutUint64(length[:], uint64(len(value)))
+	_, _ = digest.Write(length[:])
+	_, _ = digest.Write(value)
+}
+
+func (l *Loader) sourceRef(path, kind, locale string) (SourceRef, error) {
+	relative, err := filepath.Rel(l.rootDir, path)
+	if err != nil {
+		relative = path
+	}
+	revision, err := curriculumArtifactRevision(path)
+	if err != nil {
+		return SourceRef{}, err
+	}
+	return SourceRef{
+		Path:     filepath.ToSlash(relative),
+		Kind:     kind,
+		Locale:   locale,
+		Revision: revision,
+	}, nil
+}
+
+func curriculumArtifactRevision(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	digest := sha256.New()
+	_, _ = digest.Write([]byte("pai-curriculum-artifact/v1\x00"))
+	_, _ = digest.Write(data)
+	return fmt.Sprintf("sha256:%x", digest.Sum(nil)), nil
+}
+
+func translationLocale(path string) string {
+	parts := strings.Split(filepath.ToSlash(path), "/")
+	for index, part := range parts {
+		if part == "translations" && index+1 < len(parts) {
+			return strings.TrimSpace(parts[index+1])
+		}
+	}
+	return ""
 }

--- a/internal/curriculum/loader_test.go
+++ b/internal/curriculum/loader_test.go
@@ -4,8 +4,10 @@
 package curriculum_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/p-n-ai/pai-bot/internal/curriculum"
@@ -22,6 +24,228 @@ func TestLoader_LoadTopics(t *testing.T) {
 	topics := loader.AllTopics()
 	if len(topics) == 0 {
 		t.Error("AllTopics() returned empty")
+	}
+}
+
+func TestLoader_LoadsCanonicalTopicWithEnglishNameOnly(t *testing.T) {
+	dir := setupTestCurriculum(t)
+	topicPath := filepath.Join(
+		dir,
+		"curricula",
+		"malaysia",
+		"kssm",
+		"topics",
+		"algebra",
+		"01-variables.yaml",
+	)
+	replaceFixtureText(
+		t,
+		topicPath,
+		`name: "Variables & Algebraic Expressions"`,
+		`name_en: "Variables & Algebraic Expressions"`,
+	)
+
+	loader, err := curriculum.NewLoader(dir)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	topic, found := loader.GetTopic("F1-01")
+	if !found || topic.NameEN != "Variables & Algebraic Expressions" {
+		t.Fatalf("GetTopic(F1-01) = %#v, found = %v", topic, found)
+	}
+}
+
+func TestLoader_SnapshotStats(t *testing.T) {
+	dir := setupTestCurriculum(t)
+
+	loader, err := curriculum.NewLoader(dir)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+
+	want := curriculum.SnapshotStats{
+		Syllabi:       1,
+		Subjects:      1,
+		SubjectGrades: 1,
+		Topics:        1,
+		TeachingNotes: 1,
+		Assessments:   1,
+	}
+	if got := loader.SnapshotStats(); got != want {
+		t.Fatalf("SnapshotStats() = %#v, want %#v", got, want)
+	}
+}
+
+func TestLoader_LoadsAndCountsLevelZeroCanonicalStub(t *testing.T) {
+	dir := setupTestCurriculum(t)
+	replaceFixtureTopicWithStub(t, dir, 0)
+
+	loader, err := curriculum.NewLoader(dir)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+
+	topic, found := loader.GetTopic("F1-01")
+	if !found {
+		t.Fatal("GetTopic(F1-01) not found")
+	}
+	if topic.QualityLevel != 0 {
+		t.Fatalf("topic.QualityLevel = %d, want 0", topic.QualityLevel)
+	}
+	if len(topic.ContentStandards) != 0 || len(topic.LearningObjectives) != 0 {
+		t.Fatalf(
+			"stub teaching identity = %d standards, %d objectives; want both empty",
+			len(topic.ContentStandards),
+			len(topic.LearningObjectives),
+		)
+	}
+	if got := loader.SnapshotStats().Topics; got != 1 {
+		t.Fatalf("SnapshotStats().Topics = %d, want 1", got)
+	}
+}
+
+func TestLoader_RejectsCatalogStubWithMissingQualityClaim(t *testing.T) {
+	dir := setupTestCurriculum(t)
+	replaceFixtureTopicWithStub(t, dir, 0)
+	topicPath := filepath.Join(
+		dir,
+		"curricula",
+		"malaysia",
+		"kssm",
+		"topics",
+		"algebra",
+		"01-variables.yaml",
+	)
+	replaceFixtureText(t, topicPath, "quality_level: 0", "")
+
+	_, err := curriculum.NewLoader(dir)
+	if err == nil {
+		t.Fatal("NewLoader() error = nil, want missing quality claim rejected as a catalog stub")
+	}
+	if !strings.Contains(err.Error(), `topic "F1-01" requires content standards`) {
+		t.Fatalf("NewLoader() error = %v, want missing teaching identity", err)
+	}
+}
+
+func TestLoader_RejectsEmptyTeachingIdentityAboveLevelZero(t *testing.T) {
+	dir := setupTestCurriculum(t)
+	replaceFixtureTopicWithStub(t, dir, 1)
+
+	_, err := curriculum.NewLoader(dir)
+	if err == nil {
+		t.Fatal("NewLoader() error = nil, want empty teaching identity rejected")
+	}
+	if !strings.Contains(err.Error(), `topic "F1-01" requires content standards`) {
+		t.Fatalf("NewLoader() error = %v, want missing content standards", err)
+	}
+}
+
+func TestLoader_RejectsPartiallyAuthoredLevelZeroTopic(t *testing.T) {
+	dir := setupTestCurriculum(t)
+	replaceFixtureTopicWithStub(t, dir, 0)
+	topicPath := filepath.Join(
+		dir,
+		"curricula",
+		"malaysia",
+		"kssm",
+		"topics",
+		"algebra",
+		"01-variables.yaml",
+	)
+	replaceFixtureText(
+		t,
+		topicPath,
+		"content_standards: []",
+		"content_standards:\n  - id: \"1.1\"\n    text: Variables",
+	)
+
+	_, err := curriculum.NewLoader(dir)
+	if err == nil {
+		t.Fatal("NewLoader() error = nil, want partial Level 0 topic rejected")
+	}
+	if !strings.Contains(err.Error(), `topic "F1-01" requires learning objectives`) {
+		t.Fatalf("NewLoader() error = %v, want missing learning objectives", err)
+	}
+}
+
+func TestLoader_SnapshotRevisionTracksCurriculumContent(t *testing.T) {
+	dir := setupTestCurriculum(t)
+
+	first, err := curriculum.NewLoader(dir)
+	if err != nil {
+		t.Fatalf("first NewLoader() error = %v", err)
+	}
+	firstRevision := first.SnapshotRevision()
+	if !strings.HasPrefix(firstRevision, "sha256:") {
+		t.Fatalf("SnapshotRevision() = %q, want sha256 digest", firstRevision)
+	}
+	firstAssessment, found := first.GetAssessment("F1-01")
+	if !found || !strings.HasPrefix(firstAssessment.Source.Revision, "sha256:") {
+		t.Fatalf("assessment source = %#v, found = %v", firstAssessment.Source, found)
+	}
+	firstTopic, found := first.GetTopic("F1-01")
+	if !found || !strings.HasPrefix(firstTopic.Source.Revision, "sha256:") {
+		t.Fatalf("topic source = %#v, found = %v", firstTopic.Source, found)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("not curriculum"), 0o644); err != nil {
+		t.Fatalf("WriteFile(README.md) error = %v", err)
+	}
+	withReadme, err := curriculum.NewLoader(dir)
+	if err != nil {
+		t.Fatalf("NewLoader() after README error = %v", err)
+	}
+	if got := withReadme.SnapshotRevision(); got != firstRevision {
+		t.Fatalf("revision changed for non-curriculum file: %q != %q", got, firstRevision)
+	}
+	readmeAssessment, _ := withReadme.GetAssessment("F1-01")
+	if readmeAssessment.Source.Revision != firstAssessment.Source.Revision {
+		t.Fatalf(
+			"assessment source revision changed for README: %q != %q",
+			readmeAssessment.Source.Revision,
+			firstAssessment.Source.Revision,
+		)
+	}
+
+	assessmentPath := filepath.Join(
+		dir,
+		"curricula",
+		"malaysia",
+		"kssm",
+		"topics",
+		"algebra",
+		"01-variables.assessments.yaml",
+	)
+	assessment, err := os.ReadFile(assessmentPath)
+	if err != nil {
+		t.Fatalf("ReadFile(assessment) error = %v", err)
+	}
+	if err := os.WriteFile(assessmentPath, append(assessment, []byte("\n# revision change\n")...), 0o644); err != nil {
+		t.Fatalf("WriteFile(assessment) error = %v", err)
+	}
+
+	changed, err := curriculum.NewLoader(dir)
+	if err != nil {
+		t.Fatalf("NewLoader() after assessment change error = %v", err)
+	}
+	if got := changed.SnapshotRevision(); got == firstRevision {
+		t.Fatalf("SnapshotRevision() = %q after curriculum content changed", got)
+	}
+	loadedAssessment, found := changed.GetAssessment("F1-01")
+	if !found || loadedAssessment.Source.Revision == firstAssessment.Source.Revision {
+		t.Fatalf(
+			"assessment source revision = %q after artifact changed, found = %v",
+			loadedAssessment.Source.Revision,
+			found,
+		)
+	}
+	loadedTopic, found := changed.GetTopic("F1-01")
+	if !found || loadedTopic.Source.Revision != firstTopic.Source.Revision {
+		t.Fatalf(
+			"topic source revision = %q after unrelated assessment changed, want %q",
+			loadedTopic.Source.Revision,
+			firstTopic.Source.Revision,
+		)
 	}
 }
 
@@ -73,6 +297,58 @@ func TestLoader_GetTeachingNotes(t *testing.T) {
 	}
 }
 
+func TestLoader_GetTeachingNotePreservesSource(t *testing.T) {
+	dir := setupTestCurriculum(t)
+
+	loader, err := curriculum.NewLoader(dir)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+
+	note, found := loader.GetTeachingNote("F1-01")
+	if !found || !strings.Contains(note.Content, "Variables & Algebraic Expressions") {
+		t.Fatalf("GetTeachingNote(F1-01) = %#v, %v; want typed note content", note, found)
+	}
+	if note.TopicID != "F1-01" ||
+		note.Source.Kind != "teaching_note" ||
+		note.Source.Path == "" ||
+		!strings.HasPrefix(note.Source.Revision, "sha256:") {
+		t.Fatalf("note = %#v, want topic-scoped artifact source", note)
+	}
+	notes, found := loader.GetTeachingNotes("F1-01")
+	if !found || notes != note.Content {
+		t.Fatalf("GetTeachingNotes(F1-01) = %q, %v; want content projection", notes, found)
+	}
+}
+
+func TestLoader_GetTeachingNotesVariantWithoutTopicVariant(t *testing.T) {
+	dir := setupTestCurriculum(t)
+	translationDir := filepath.Join(dir, "curricula", "malaysia", "kssm", "topics", "algebra", "translations", "en")
+	if err := os.MkdirAll(translationDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(translationDir, "F1-01.teaching.md"),
+		[]byte("# Teach variables in English"),
+		0o644,
+	); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	loader, err := curriculum.NewLoader(dir)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+
+	notes, found := loader.GetTeachingNotesVariant("F1-01", "en")
+	if !found || notes == "" {
+		t.Fatalf("GetTeachingNotesVariant(F1-01, en) = %q, %v; want notes", notes, found)
+	}
+	if got := loader.SnapshotStats().TeachingNoteVariants; got != 1 {
+		t.Fatalf("SnapshotStats().TeachingNoteVariants = %d, want 1", got)
+	}
+}
+
 func TestLoader_GetAssessment(t *testing.T) {
 	dir := setupTestCurriculum(t)
 
@@ -94,9 +370,285 @@ func TestLoader_GetAssessment(t *testing.T) {
 	if assessment.Questions[0].Answer.Type != "exact" {
 		t.Fatalf("assessment.Questions[0].Answer.Type = %q, want exact", assessment.Questions[0].Answer.Type)
 	}
+	if assessment.Questions[0].Type != "short_answer" {
+		t.Fatalf("assessment.Questions[0].Type = %q, want short_answer", assessment.Questions[0].Type)
+	}
 }
 
-func TestLoader_LoadsSubjectMetadata(t *testing.T) {
+func TestLoader_GetExamples(t *testing.T) {
+	dir := setupTestCurriculum(t)
+	examplesPath := filepath.Join(
+		dir,
+		"curricula",
+		"malaysia",
+		"kssm",
+		"topics",
+		"algebra",
+		"01-variables.examples.yaml",
+	)
+	if err := os.WriteFile(examplesPath, []byte(`
+topic_id: F1-01
+provenance: human
+description: Worked algebra examples.
+worked_examples:
+  - id: WE-01
+    topic: Evaluating expressions
+    difficulty: easy
+    learning_objective: LO1
+    real_world_analogy: Three bags with two apples each.
+    misconception_alert: Addition and multiplication are interchangeable.
+    scenario: Evaluate 3x when x is 2.
+    working: Substitute 2 for x, then calculate 3 times 2.
+    source_ref: Textbook page 12.
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(examples) error = %v", err)
+	}
+
+	loader, err := curriculum.NewLoader(dir)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+
+	examples, found := loader.GetExamples("F1-01")
+	if !found {
+		t.Fatal("GetExamples(F1-01) not found")
+	}
+	if examples.TopicID != "F1-01" ||
+		examples.Description != "Worked algebra examples." ||
+		len(examples.WorkedExamples) != 1 ||
+		examples.WorkedExamples[0].ID != "WE-01" {
+		t.Fatalf("GetExamples(F1-01) = %#v, want typed worked example", examples)
+	}
+	if examples.Source.Kind != "examples" ||
+		examples.Source.Path == "" ||
+		!strings.HasPrefix(examples.Source.Revision, "sha256:") {
+		t.Fatalf("examples.Source = %#v, want artifact source reference", examples.Source)
+	}
+}
+
+func TestLoader_RejectsExamplesForMissingTopic(t *testing.T) {
+	dir := setupTestCurriculum(t)
+	examplesPath := filepath.Join(
+		dir,
+		"curricula",
+		"malaysia",
+		"kssm",
+		"topics",
+		"algebra",
+		"missing.examples.yaml",
+	)
+	if err := os.WriteFile(examplesPath, []byte(`
+topic_id: F1-99
+worked_examples:
+  - id: WE-01
+    topic: Missing topic example
+    difficulty: easy
+    misconception_alert: Do not guess the topic.
+    scenario: Explain the missing topic.
+    working: Find the canonical topic first.
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(examples) error = %v", err)
+	}
+
+	_, err := curriculum.NewLoader(dir)
+	if err == nil {
+		t.Fatal("NewLoader() error = nil, want missing example topic rejected")
+	}
+	if !strings.Contains(err.Error(), `examples reference missing topic "F1-99"`) {
+		t.Fatalf("NewLoader() error = %v, want missing example topic", err)
+	}
+}
+
+func TestLoader_RejectsInvalidWorkedExamples(t *testing.T) {
+	const validExamples = `
+topic_id: F1-01
+worked_examples:
+  - id: WE-01
+    topic: Evaluating expressions
+    difficulty: easy
+    learning_objective: LO1
+    misconception_alert: Addition and multiplication are interchangeable.
+    scenario: Evaluate 3x when x is 2.
+    working: Substitute 2 for x, then calculate 3 times 2.
+`
+	tests := []struct {
+		name    string
+		old     string
+		new     string
+		wantErr string
+	}{
+		{
+			name:    "missing ID",
+			old:     "id: WE-01",
+			new:     `id: ""`,
+			wantErr: "worked example requires id",
+		},
+		{
+			name: "duplicate ID",
+			old:  "    working: Substitute 2 for x, then calculate 3 times 2.",
+			new: `    working: Substitute 2 for x, then calculate 3 times 2.
+  - id: WE-01
+    topic: Another evaluation
+    difficulty: medium
+    misconception_alert: Repeated IDs are different examples.
+    scenario: Evaluate x plus 1.
+    working: Substitute x, then add 1.`,
+			wantErr: `repeats worked example "WE-01"`,
+		},
+		{
+			name:    "missing topic",
+			old:     "topic: Evaluating expressions",
+			new:     `topic: ""`,
+			wantErr: `worked example "WE-01" requires topic`,
+		},
+		{
+			name:    "invalid difficulty",
+			old:     "difficulty: easy",
+			new:     "difficulty: impossible",
+			wantErr: `worked example "WE-01" has invalid difficulty`,
+		},
+		{
+			name:    "missing misconception",
+			old:     "misconception_alert: Addition and multiplication are interchangeable.",
+			new:     `misconception_alert: ""`,
+			wantErr: `worked example "WE-01" requires misconception_alert`,
+		},
+		{
+			name:    "missing scenario",
+			old:     "scenario: Evaluate 3x when x is 2.",
+			new:     `scenario: ""`,
+			wantErr: `worked example "WE-01" requires scenario`,
+		},
+		{
+			name:    "missing working",
+			old:     "working: Substitute 2 for x, then calculate 3 times 2.",
+			new:     `working: ""`,
+			wantErr: `worked example "WE-01" requires working`,
+		},
+		{
+			name:    "unknown objective",
+			old:     "learning_objective: LO1",
+			new:     "learning_objective: LO-UNKNOWN",
+			wantErr: `worked example "WE-01" references missing objective "LO-UNKNOWN"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := setupTestCurriculum(t)
+			examplesPath := filepath.Join(
+				dir,
+				"curricula",
+				"malaysia",
+				"kssm",
+				"topics",
+				"algebra",
+				"01-variables.examples.yaml",
+			)
+			content := strings.Replace(validExamples, test.old, test.new, 1)
+			if err := os.WriteFile(examplesPath, []byte(content), 0o644); err != nil {
+				t.Fatalf("WriteFile(examples) error = %v", err)
+			}
+
+			_, err := curriculum.NewLoader(dir)
+			if err == nil {
+				t.Fatal("NewLoader() error = nil, want invalid worked example rejected")
+			}
+			if !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("NewLoader() error = %v, want %q", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestLoader_RejectsExampleVariantWithoutCanonicalExample(t *testing.T) {
+	dir := setupTestCurriculum(t)
+	topicsDir := filepath.Join(dir, "curricula", "malaysia", "kssm", "topics", "algebra")
+	writeExamplesFixture(t, filepath.Join(topicsDir, "01-variables.examples.yaml"), "F1-01", "WE-01", "LO1", "Evaluate 3x.")
+	translationDir := filepath.Join(topicsDir, "translations", "ms")
+	if err := os.MkdirAll(translationDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(translation) error = %v", err)
+	}
+	writeExamplesFixture(t, filepath.Join(translationDir, "F1-01.examples.yaml"), "F1-01", "WE-02", "LO1", "Hitung 3x.")
+
+	_, err := curriculum.NewLoader(dir)
+	if err == nil {
+		t.Fatal("NewLoader() error = nil, want non-canonical localized example rejected")
+	}
+	if !strings.Contains(err.Error(), `worked example "WE-02" has no canonical worked example`) {
+		t.Fatalf("NewLoader() error = %v, want missing canonical example", err)
+	}
+}
+
+func TestLoader_GetExamplesVariant(t *testing.T) {
+	dir := setupTestCurriculum(t)
+	topicsDir := filepath.Join(dir, "curricula", "malaysia", "kssm", "topics", "algebra")
+	writeExamplesFixture(t, filepath.Join(topicsDir, "01-variables.examples.yaml"), "F1-01", "WE-01", "LO1", "Evaluate 3x.")
+	translationDir := filepath.Join(topicsDir, "translations", "ms")
+	if err := os.MkdirAll(translationDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(translation) error = %v", err)
+	}
+	writeExamplesFixture(t, filepath.Join(translationDir, "F1-01.examples.yaml"), "F1-01", "WE-01", "LO1", "Hitung 3x.")
+
+	loader, err := curriculum.NewLoader(dir)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	variant, found := loader.GetExamplesVariant("F1-01", "ms")
+	if !found || len(variant.WorkedExamples) != 1 ||
+		variant.WorkedExamples[0].Scenario != "Hitung 3x." {
+		t.Fatalf("GetExamplesVariant(F1-01, ms) = %#v, %v; want Malay example", variant, found)
+	}
+	if variant.Source.Kind != "examples_variant" || variant.Source.Locale != "ms" {
+		t.Fatalf("variant.Source = %#v, want cited Malay example artifact", variant.Source)
+	}
+	stats := loader.SnapshotStats()
+	if stats.Examples != 1 || stats.ExampleVariants != 1 {
+		t.Fatalf("SnapshotStats() = %#v, want one canonical and one variant example set", stats)
+	}
+}
+
+func TestLoader_RejectsExampleVariantObjectiveChange(t *testing.T) {
+	dir := setupTestCurriculum(t)
+	topicsDir := filepath.Join(dir, "curricula", "malaysia", "kssm", "topics", "algebra")
+	writeExamplesFixture(t, filepath.Join(topicsDir, "01-variables.examples.yaml"), "F1-01", "WE-01", "LO1", "Evaluate 3x.")
+	translationDir := filepath.Join(topicsDir, "translations", "ms")
+	if err := os.MkdirAll(translationDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(translation) error = %v", err)
+	}
+	writeExamplesFixture(t, filepath.Join(translationDir, "F1-01.examples.yaml"), "F1-01", "WE-01", "LO2", "Hitung 3x.")
+
+	_, err := curriculum.NewLoader(dir)
+	if err == nil {
+		t.Fatal("NewLoader() error = nil, want localized objective change rejected")
+	}
+	if !strings.Contains(err.Error(), `worked example "WE-01" changes canonical objective identity`) {
+		t.Fatalf("NewLoader() error = %v, want canonical objective identity", err)
+	}
+}
+
+func TestLoader_ExamplesAreImmutableSnapshots(t *testing.T) {
+	dir := setupTestCurriculum(t)
+	topicsDir := filepath.Join(dir, "curricula", "malaysia", "kssm", "topics", "algebra")
+	writeExamplesFixture(t, filepath.Join(topicsDir, "01-variables.examples.yaml"), "F1-01", "WE-01", "LO1", "Evaluate 3x.")
+
+	loader, err := curriculum.NewLoader(dir)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	first, found := loader.GetExamples("F1-01")
+	if !found {
+		t.Fatal("GetExamples(F1-01) not found")
+	}
+	first.WorkedExamples[0].Scenario = "mutated"
+
+	again, found := loader.GetExamples("F1-01")
+	if !found || again.WorkedExamples[0].Scenario != "Evaluate 3x." {
+		t.Fatalf("GetExamples(F1-01) after mutation = %#v, %v; want immutable snapshot", again, found)
+	}
+}
+
+func TestLoader_LoadsSubjectGradeMetadata(t *testing.T) {
 	dir := setupTestCurriculum(t)
 
 	loader, err := curriculum.NewLoader(dir)
@@ -104,9 +656,9 @@ func TestLoader_LoadsSubjectMetadata(t *testing.T) {
 		t.Fatalf("NewLoader() error = %v", err)
 	}
 
-	subject, found := loader.GetSubject("malaysia-kssm-matematik-tingkatan-1")
+	subject, found := loader.GetSubjectGrade("malaysia-kssm-matematik-tingkatan-1")
 	if !found {
-		t.Fatal("GetSubject() not found")
+		t.Fatal("GetSubjectGrade() not found")
 	}
 	if subject.GradeID != "tingkatan-1" {
 		t.Fatalf("subject.GradeID = %q, want tingkatan-1", subject.GradeID)
@@ -137,9 +689,16 @@ func TestLoader_SkipsNonTopicYAML(t *testing.T) {
 	topicsDir := filepath.Join(dir, "curricula", "malaysia", "kssm", "topics", "algebra")
 	_ = os.WriteFile(filepath.Join(topicsDir, "01-variables.assessments.yaml"), []byte(`
 topic_id: F1-01
+provenance: human
 questions:
   - id: Q1
     text: "What is 3x when x=2?"
+    difficulty: easy
+    learning_objective: LO1
+    answer:
+      type: exact
+      value: "6"
+    marks: 1
 `), 0o644)
 
 	loader, err := curriculum.NewLoader(dir)
@@ -176,23 +735,16 @@ func TestLoader_EmptyDir(t *testing.T) {
 	}
 }
 
-func TestLoader_TeachingNotesWithoutYAML(t *testing.T) {
+func TestLoader_RejectsTeachingNotesWithoutYAML(t *testing.T) {
 	dir := t.TempDir()
 
 	topicsDir := filepath.Join(dir, "topics")
 	_ = os.MkdirAll(topicsDir, 0o755)
 
-	// Teaching notes with no matching YAML
 	_ = os.WriteFile(filepath.Join(topicsDir, "orphan.teaching.md"), []byte("# Orphan notes"), 0o644)
 
-	loader, err := curriculum.NewLoader(dir)
-	if err != nil {
-		t.Fatalf("NewLoader() error = %v", err)
-	}
-
-	_, found := loader.GetTeachingNotes("orphan")
-	if found {
-		t.Error("Should not find teaching notes without matching topic YAML")
+	if _, err := curriculum.NewLoader(dir); err == nil {
+		t.Fatal("NewLoader() error = nil, want orphan teaching notes rejected")
 	}
 }
 
@@ -210,12 +762,24 @@ name: "Kurikulum Standard Sekolah Menengah"
 country: malaysia
 board: kssm
 level: secondary
+subjects:
+  - malaysia-kssm-matematik
 `), 0o644)
 
 	_ = os.WriteFile(filepath.Join(curriculumDir, "subject.yaml"), []byte(`
+id: malaysia-kssm-matematik
+name: "Matematik"
+name_en: "Mathematics"
+syllabus_id: malaysia-kssm
+country_id: malaysia
+language: ms
+`), 0o644)
+
+	_ = os.WriteFile(filepath.Join(curriculumDir, "subject-grade.yaml"), []byte(`
 id: malaysia-kssm-matematik-tingkatan-1
 name: "Matematik Tingkatan 1"
 name_en: "Mathematics Form 1"
+subject_id: malaysia-kssm-matematik
 syllabus_id: malaysia-kssm
 grade_id: tingkatan-1
 country_id: malaysia
@@ -228,14 +792,20 @@ topics:
 	_ = os.WriteFile(filepath.Join(topicsDir, "01-variables.yaml"), []byte(`
 id: F1-01
 name: "Variables & Algebraic Expressions"
-subject_id: malaysia-kssm-matematik-tingkatan-1
+subject_grade_id: malaysia-kssm-matematik-tingkatan-1
+subject_id: malaysia-kssm-matematik
 syllabus_id: malaysia-kssm
 difficulty: beginner
+content_standards:
+  - id: "1.1"
+    text: "Variables and algebraic expressions"
 learning_objectives:
   - id: LO1
+    content_standard_id: "1.1"
     text: "Use letters to represent unknown quantities"
     bloom: remember
   - id: LO2
+    content_standard_id: "1.1"
     text: "Write algebraic expressions from word problems"
     bloom: apply
 prerequisites:
@@ -267,6 +837,7 @@ topic_id: F1-01
 provenance: human
 questions:
   - id: Q1
+    type: short_answer
     text: "Evaluate the expression 3x when x = 2. Reply with the final value only."
     difficulty: easy
     learning_objective: LO1
@@ -298,4 +869,50 @@ questions:
 `), 0o644)
 
 	return dir
+}
+
+func writeExamplesFixture(
+	t *testing.T,
+	path, topicID, exampleID, objectiveID, scenario string,
+) {
+	t.Helper()
+	content := fmt.Sprintf(`
+topic_id: %s
+provenance: human
+worked_examples:
+  - id: %s
+    topic: Evaluating expressions
+    difficulty: easy
+    learning_objective: %s
+    misconception_alert: Addition and multiplication are interchangeable.
+    scenario: %s
+    working: Substitute 2 for x, then calculate 3 times 2.
+`, topicID, exampleID, objectiveID, scenario)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s) error = %v", path, err)
+	}
+}
+
+func replaceFixtureTopicWithStub(t *testing.T, root string, qualityLevel int) {
+	t.Helper()
+
+	topicsDir := filepath.Join(root, "curricula", "malaysia", "kssm", "topics", "algebra")
+	topic := []byte(fmt.Sprintf(`
+id: F1-01
+name: "Variables & Algebraic Expressions"
+subject_grade_id: malaysia-kssm-matematik-tingkatan-1
+subject_id: malaysia-kssm-matematik
+syllabus_id: malaysia-kssm
+difficulty: beginner
+content_standards: []
+learning_objectives: []
+quality_level: %d
+provenance: human
+`, qualityLevel))
+	if err := os.WriteFile(filepath.Join(topicsDir, "01-variables.yaml"), topic, 0o644); err != nil {
+		t.Fatalf("WriteFile(topic) error = %v", err)
+	}
+	if err := os.Remove(filepath.Join(topicsDir, "01-variables.assessments.yaml")); err != nil {
+		t.Fatalf("Remove(assessment) error = %v", err)
+	}
 }

--- a/internal/curriculum/oss_contract_test.go
+++ b/internal/curriculum/oss_contract_test.go
@@ -1,0 +1,1019 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package curriculum_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/p-n-ai/pai-bot/internal/curriculum"
+)
+
+func TestLoaderPreservesOSSArtifactIdentityAndLocaleVariants(t *testing.T) {
+	root := setupOSSContractFixture(t)
+
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+
+	topics := loader.AllTopics()
+	if len(topics) != 1 {
+		t.Fatalf("AllTopics() = %d topics, want only the canonical topic", len(topics))
+	}
+
+	subjectGrade, found := loader.GetSubjectGrade("malaysia-kssm-matematik-tingkatan-1")
+	if !found {
+		t.Fatal("GetSubjectGrade() not found")
+	}
+	if len(subjectGrade.Topics) != 1 || subjectGrade.Topics[0] != "MT1-05" {
+		t.Fatalf("subjectGrade.Topics = %v, want [MT1-05]", subjectGrade.Topics)
+	}
+
+	canonical, found := loader.GetTopic("MT1-05")
+	if !found {
+		t.Fatal("GetTopic(MT1-05) not found")
+	}
+	if canonical.Language != "en" {
+		t.Fatalf("canonical.Language = %q, want en", canonical.Language)
+	}
+	if canonical.LearningObjectives[0].TextEN == "" {
+		t.Fatal("canonical learning objective lost text_en")
+	}
+
+	malay, found := loader.GetTopicVariant("MT1-05", "ms")
+	if !found {
+		t.Fatal("GetTopicVariant(MT1-05, ms) not found")
+	}
+	if malay.Language != "ms" || malay.LearningObjectives[0].Text == "" {
+		t.Fatalf("Malay variant = %#v, want Malay localized fields", malay)
+	}
+
+	canonicalAssessment, found := loader.GetAssessment("MT1-05")
+	if !found || canonicalAssessment.Questions[0].Text != "Evaluate 3x when x = 2." {
+		t.Fatalf("canonical assessment = %#v, found = %v", canonicalAssessment, found)
+	}
+	malayAssessment, found := loader.GetAssessmentVariant("MT1-05", "ms")
+	if !found || malayAssessment.Questions[0].Text != "Hitung 3x apabila x = 2." {
+		t.Fatalf("Malay assessment = %#v, found = %v", malayAssessment, found)
+	}
+
+	canonicalNotes, found := loader.GetTeachingNotes("MT1-05")
+	if !found || canonicalNotes != "# Teach algebra\n" {
+		t.Fatalf("canonical teaching notes = %q, found = %v", canonicalNotes, found)
+	}
+	malayNotes, found := loader.GetTeachingNotesVariant("MT1-05", "ms")
+	if !found || malayNotes != "# Ajar algebra\n" {
+		t.Fatalf("Malay teaching notes = %q, found = %v", malayNotes, found)
+	}
+}
+
+func TestLoaderRejectsMalformedCanonicalAssessment(t *testing.T) {
+	root := setupOSSContractFixture(t)
+	assessmentPath := filepath.Join(
+		root,
+		"curricula",
+		"malaysia",
+		"malaysia-kssm",
+		"malaysia-kssm-matematik",
+		"malaysia-kssm-matematik-tingkatan-1",
+		"topics",
+		"MT1-05.assessments.yaml",
+	)
+	writeFixtureFile(t, assessmentPath, `
+topic_id: MT1-05
+provenance: human
+questions:
+  - id: Q1
+    text: "Invalid YAML escape: \circ"
+`)
+
+	_, err := curriculum.NewLoader(root)
+	if err == nil {
+		t.Fatal("NewLoader() error = nil, want malformed assessment rejection")
+	}
+	if !strings.Contains(err.Error(), "MT1-05.assessments.yaml") {
+		t.Fatalf("NewLoader() error = %v, want source path", err)
+	}
+}
+
+func TestLoaderRejectsMissingPrerequisite(t *testing.T) {
+	root := setupOSSContractFixture(t)
+	topicPath := fixtureTopicPath(root, "MT1-05.yaml")
+	replaceFixtureText(t, topicPath, "quality_level: 2", `prerequisites:
+  required:
+    - MT1-99
+quality_level: 2`)
+
+	_, err := curriculum.NewLoader(root)
+	if err == nil {
+		t.Fatal("NewLoader() error = nil, want missing prerequisite rejection")
+	}
+	if !strings.Contains(err.Error(), "MT1-99") || !strings.Contains(err.Error(), "MT1-05.yaml") {
+		t.Fatalf("NewLoader() error = %v, want topic path and missing prerequisite", err)
+	}
+}
+
+func TestLoaderRejectsSubjectOmittedFromSyllabus(t *testing.T) {
+	root := setupOSSContractFixture(t)
+	syllabusPath := filepath.Join(
+		root,
+		"curricula",
+		"malaysia",
+		"malaysia-kssm",
+		"syllabus.yaml",
+	)
+	replaceFixtureText(t, syllabusPath, `subjects:
+  - malaysia-kssm-matematik`, `subjects: []`)
+
+	_, err := curriculum.NewLoader(root)
+	if err == nil {
+		t.Fatal("NewLoader() error = nil, want unlisted subject rejected")
+	}
+	if !strings.Contains(err.Error(), "malaysia-kssm-matematik") || !strings.Contains(err.Error(), "not listed") {
+		t.Fatalf("NewLoader() error = %v, want reciprocal syllabus membership", err)
+	}
+}
+
+func TestLoaderRejectsDuplicateSyllabusSubject(t *testing.T) {
+	root := setupOSSContractFixture(t)
+	syllabusPath := filepath.Join(
+		root,
+		"curricula",
+		"malaysia",
+		"malaysia-kssm",
+		"syllabus.yaml",
+	)
+	replaceFixtureText(t, syllabusPath, `  - malaysia-kssm-matematik`, `  - malaysia-kssm-matematik
+  - malaysia-kssm-matematik`)
+
+	_, err := curriculum.NewLoader(root)
+	if err == nil {
+		t.Fatal("NewLoader() error = nil, want duplicate syllabus subject rejected")
+	}
+	if !strings.Contains(err.Error(), "repeats subject") {
+		t.Fatalf("NewLoader() error = %v, want duplicate subject identity", err)
+	}
+}
+
+func TestLoaderRejectsSubjectGradeOutsideSubjectSyllabus(t *testing.T) {
+	root := setupOSSContractFixture(t)
+	otherDir := filepath.Join(root, "curricula", "other")
+	if err := os.MkdirAll(otherDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s) error = %v", otherDir, err)
+	}
+	writeFixtureFile(t, filepath.Join(otherDir, "syllabus.yaml"), `
+id: other-syllabus
+name: Other
+subjects: []
+`)
+	subjectGradePath := filepath.Join(
+		filepath.Dir(fixtureTopicPath(root, "MT1-05.yaml")),
+		"..",
+		"subject-grade.yaml",
+	)
+	replaceFixtureText(t, subjectGradePath, "syllabus_id: malaysia-kssm", "syllabus_id: other-syllabus")
+
+	_, err := curriculum.NewLoader(root)
+	if err == nil {
+		t.Fatal("NewLoader() error = nil, want cross-syllabus subject grade rejected")
+	}
+	if !strings.Contains(err.Error(), "does not match subject") {
+		t.Fatalf("NewLoader() error = %v, want subject-grade scope mismatch", err)
+	}
+}
+
+func TestLoaderRejectsSubjectListedByWrongSyllabus(t *testing.T) {
+	root := setupOSSContractFixture(t)
+	otherDir := filepath.Join(root, "curricula", "other")
+	if err := os.MkdirAll(otherDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s) error = %v", otherDir, err)
+	}
+	writeFixtureFile(t, filepath.Join(otherDir, "syllabus.yaml"), `
+id: other-syllabus
+name: Other
+subjects:
+  - malaysia-kssm-matematik
+`)
+
+	_, err := curriculum.NewLoader(root)
+	if err == nil {
+		t.Fatal("NewLoader() error = nil, want cross-syllabus subject listing rejected")
+	}
+	if !strings.Contains(err.Error(), "owned by syllabus") {
+		t.Fatalf("NewLoader() error = %v, want subject ownership mismatch", err)
+	}
+}
+
+func TestLoaderPreservesRichPrerequisiteAndBackgroundKnowledge(t *testing.T) {
+	root := setupCurriculumEngineFixture(t)
+	topicPath := fixtureTopicPath(root, "MT1-05.yaml")
+	replaceFixtureText(t, topicPath, `  required:
+    - MT1-01`, `  required:
+    - id: MT1-01
+      name: Rational Numbers
+      reason: Variables can contain rational values.
+background_knowledge:
+  - Know how to compare integers.`)
+
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	topic, _ := loader.GetTopic("MT1-05")
+	if len(topic.Prerequisites.Required) != 1 ||
+		topic.Prerequisites.Required[0].TopicID != "MT1-01" ||
+		topic.Prerequisites.Required[0].Reason != "Variables can contain rational values." {
+		t.Fatalf("required prerequisites = %#v, want rich MT1-01 edge", topic.Prerequisites.Required)
+	}
+	if len(topic.BackgroundKnowledge) != 1 ||
+		topic.BackgroundKnowledge[0] != "Know how to compare integers." {
+		t.Fatalf("background knowledge = %#v", topic.BackgroundKnowledge)
+	}
+}
+
+func TestLoaderNormalizesRootEngagementHooks(t *testing.T) {
+	root := setupOSSContractFixture(t)
+	topicPath := fixtureTopicPath(root, "MT1-05.yaml")
+	replaceFixtureText(t, topicPath, "quality_level: 2", `engagement_hooks:
+  - Find the mystery number.
+quality_level: 2`)
+
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	topic, _ := loader.GetTopic("MT1-05")
+	if len(topic.Teaching.EngagementHooks) != 1 ||
+		topic.Teaching.EngagementHooks[0] != "Find the mystery number." {
+		t.Fatalf("engagement hooks = %#v, want normalized root hook", topic.Teaching.EngagementHooks)
+	}
+}
+
+func TestLoaderPreservesValidatedCrossCurriculumEdge(t *testing.T) {
+	root := setupValidatedCrossCurriculumFixture(t)
+
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	topic, _ := loader.GetTopic("MT1-05")
+	if len(topic.CrossCurriculum) != 1 || topic.CrossCurriculum[0].ConceptID != "variables" {
+		t.Fatalf("cross-curriculum edges = %#v", topic.CrossCurriculum)
+	}
+	concept, found := loader.GetConcept("variables")
+	if !found || len(concept.Curricula) != 2 || concept.Curricula[1].TopicID != "OM1-01" {
+		t.Fatalf("concept = %#v, found = %v", concept, found)
+	}
+}
+
+func TestLoaderRejectsCrossCurriculumSelfLink(t *testing.T) {
+	root := setupOSSContractFixture(t)
+	conceptDir := filepath.Join(root, "concepts", "mathematics")
+	if err := os.MkdirAll(conceptDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s) error = %v", conceptDir, err)
+	}
+	writeFixtureFile(t, filepath.Join(conceptDir, "variables.yaml"), `
+id: variables
+name: Variables
+domain: mathematics
+subdomain: algebra
+definition: A symbol whose value may change.
+curricula:
+  - syllabus: malaysia-kssm
+    topic: MT1-05
+    scope: introduction
+`)
+	topicPath := fixtureTopicPath(root, "MT1-05.yaml")
+	replaceFixtureText(t, topicPath, "quality_level: 2", `cross_curriculum:
+  - concept_id: variables
+    syllabus_id: malaysia-kssm
+    topic_id: MT1-05
+quality_level: 2`)
+
+	_, err := curriculum.NewLoader(root)
+	if err == nil {
+		t.Fatal("NewLoader() error = nil, want cross-curriculum self-link rejected")
+	}
+	if !strings.Contains(err.Error(), "other syllabus") {
+		t.Fatalf("NewLoader() error = %v, want distinct-syllabus contract", err)
+	}
+}
+
+func TestLoaderRejectsDanglingCrossCurriculumConcept(t *testing.T) {
+	root := setupOSSContractFixture(t)
+	topicPath := fixtureTopicPath(root, "MT1-05.yaml")
+	replaceFixtureText(t, topicPath, "quality_level: 2", `cross_curriculum:
+  - concept_id: missing-concept
+    syllabus_id: other-syllabus
+    topic_id: OM1-01
+quality_level: 2`)
+
+	_, err := curriculum.NewLoader(root)
+	if err == nil {
+		t.Fatal("NewLoader() error = nil, want dangling cross-curriculum concept rejected")
+	}
+	if !strings.Contains(err.Error(), "missing-concept") {
+		t.Fatalf("NewLoader() error = %v, want missing concept identity", err)
+	}
+}
+
+func TestLoaderRejectsConflictingEngagementHookPlacements(t *testing.T) {
+	root := setupOSSContractFixture(t)
+	topicPath := fixtureTopicPath(root, "MT1-05.yaml")
+	replaceFixtureText(t, topicPath, "quality_level: 2", `teaching:
+  engagement_hooks:
+    - Nested hook.
+engagement_hooks:
+  - Root hook.
+quality_level: 2`)
+
+	if _, err := curriculum.NewLoader(root); err == nil {
+		t.Fatal("NewLoader() error = nil, want conflicting engagement hooks rejected")
+	}
+}
+
+func TestLoaderRejectsAssessmentObjectiveDrift(t *testing.T) {
+	root := setupOSSContractFixture(t)
+	assessmentPath := fixtureTopicPath(root, "MT1-05.assessments.yaml")
+	replaceFixtureText(t, assessmentPath, `learning_objective: "5.1.1"`, `learning_objective: "5.1.99"`)
+
+	_, err := curriculum.NewLoader(root)
+	if err == nil {
+		t.Fatal("NewLoader() error = nil, want orphan assessment objective rejection")
+	}
+	if !strings.Contains(err.Error(), "Q1") || !strings.Contains(err.Error(), "5.1.99") {
+		t.Fatalf("NewLoader() error = %v, want question and orphan objective", err)
+	}
+}
+
+func TestLoaderRejectsTopicWithoutPlanFields(t *testing.T) {
+	tests := []struct {
+		name        string
+		old         string
+		replacement string
+	}{
+		{
+			name:        "name",
+			old:         "name: Ungkapan Algebra\nname_en: Algebraic Expressions",
+			replacement: "name: \"\"\nname_en: \"\"",
+		},
+		{
+			name: "learning objectives",
+			old: `learning_objectives:
+  - id: "5.1.1"
+    content_standard_id: "5.1"
+    text_en: Use letters to represent unknown quantities.
+    bloom: understand`,
+			replacement: "learning_objectives: []",
+		},
+		{
+			name:        "objective text",
+			old:         "text_en: Use letters to represent unknown quantities.",
+			replacement: `text_en: ""`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := setupOSSContractFixture(t)
+			topicPath := fixtureTopicPath(root, "MT1-05.yaml")
+			replaceFixtureText(t, topicPath, test.old, test.replacement)
+
+			if _, err := curriculum.NewLoader(root); err == nil {
+				t.Fatalf("NewLoader() error = nil, want missing topic %s rejected", test.name)
+			}
+		})
+	}
+}
+
+func TestLoaderPreservesSourceCitationsWithoutOptionalProvenanceMetadata(t *testing.T) {
+	root := setupOSSContractFixture(t)
+	topicPath := fixtureTopicPath(root, "MT1-05.yaml")
+	variantTopicPath := filepath.Join(
+		filepath.Dir(topicPath),
+		"translations",
+		"ms",
+		"MT1-05.yaml",
+	)
+	assessmentPath := fixtureTopicPath(root, "MT1-05.assessments.yaml")
+	variantAssessmentPath := filepath.Join(
+		filepath.Dir(topicPath),
+		"translations",
+		"ms",
+		"MT1-05.assessments.yaml",
+	)
+	for _, fixture := range []struct {
+		path       string
+		provenance string
+	}{
+		{path: topicPath, provenance: "ai-assisted"},
+		{path: variantTopicPath, provenance: "ai-assisted"},
+		{path: assessmentPath, provenance: "human"},
+		{path: variantAssessmentPath, provenance: "human"},
+	} {
+		replaceFixtureText(
+			t,
+			fixture.path,
+			"provenance: "+fixture.provenance,
+			"# provenance intentionally absent",
+		)
+	}
+
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	type sourcedArtifact struct {
+		name       string
+		provenance string
+		source     curriculum.SourceRef
+	}
+	topic, topicFound := loader.GetTopic("MT1-05")
+	variantTopic, variantTopicFound := loader.GetTopicVariant("MT1-05", "ms")
+	assessment, assessmentFound := loader.GetAssessment("MT1-05")
+	variantAssessment, variantAssessmentFound := loader.GetAssessmentVariant("MT1-05", "ms")
+	if !topicFound || !variantTopicFound || !assessmentFound || !variantAssessmentFound {
+		t.Fatalf(
+			"artifacts found = topic:%v variant-topic:%v assessment:%v variant-assessment:%v",
+			topicFound,
+			variantTopicFound,
+			assessmentFound,
+			variantAssessmentFound,
+		)
+	}
+	artifacts := []sourcedArtifact{
+		{name: "topic", provenance: topic.Provenance, source: topic.Source},
+		{name: "topic variant", provenance: variantTopic.Provenance, source: variantTopic.Source},
+		{name: "assessment", provenance: assessment.Provenance, source: assessment.Source},
+		{name: "assessment variant", provenance: variantAssessment.Provenance, source: variantAssessment.Source},
+	}
+	for _, artifact := range artifacts {
+		if artifact.provenance != "" ||
+			artifact.source.Path == "" ||
+			!strings.HasPrefix(artifact.source.Revision, "sha256:") {
+			t.Fatalf(
+				"%s source = %#v, provenance = %q",
+				artifact.name,
+				artifact.source,
+				artifact.provenance,
+			)
+		}
+	}
+}
+
+func TestLoaderRejectsAssessmentWithoutPlanFields(t *testing.T) {
+	tests := []struct {
+		name        string
+		old         string
+		replacement string
+	}{
+		{name: "question text", old: "text: Evaluate 3x when x = 2.", replacement: `text: ""`},
+		{name: "difficulty", old: "difficulty: easy", replacement: "difficulty: mystery"},
+		{name: "marks", old: "marks: 1", replacement: "marks: 0"},
+		{name: "answer type", old: "type: multiple_choice", replacement: "type: mystery"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := setupOSSContractFixture(t)
+			assessmentPath := fixtureTopicPath(root, "MT1-05.assessments.yaml")
+			replaceFixtureText(t, assessmentPath, test.old, test.replacement)
+
+			if _, err := curriculum.NewLoader(root); err == nil {
+				t.Fatalf("NewLoader() error = nil, want invalid assessment %s rejected", test.name)
+			}
+		})
+	}
+}
+
+func TestLoaderAcceptsAssessmentWithoutOptionalMarks(t *testing.T) {
+	root := setupOSSContractFixture(t)
+	canonicalPath := fixtureTopicPath(root, "MT1-05.assessments.yaml")
+	variantPath := filepath.Join(
+		filepath.Dir(fixtureTopicPath(root, "MT1-05.yaml")),
+		"translations",
+		"ms",
+		"MT1-05.assessments.yaml",
+	)
+	for _, path := range []string{canonicalPath, variantPath} {
+		replaceFixtureText(t, path, "    marks: 1\n", "")
+	}
+
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	assessment, found := loader.GetAssessment("MT1-05")
+	if !found || len(assessment.Questions) != 1 || assessment.Questions[0].Marks != 0 {
+		t.Fatalf("GetAssessment(MT1-05) = %#v, found = %v", assessment, found)
+	}
+}
+
+func TestLoaderRejectsLocalizedAssessmentContractDrift(t *testing.T) {
+	root := setupOSSContractFixture(t)
+	variantPath := filepath.Join(
+		filepath.Dir(fixtureTopicPath(root, "MT1-05.yaml")),
+		"translations",
+		"ms",
+		"MT1-05.assessments.yaml",
+	)
+	replaceFixtureText(t, variantPath, "type: multiple_choice", "type: exact")
+
+	_, err := curriculum.NewLoader(root)
+	if err == nil {
+		t.Fatal("NewLoader() error = nil, want localized grading-contract drift rejection")
+	}
+	if !strings.Contains(err.Error(), "assessment variant") || !strings.Contains(err.Error(), "Q1") {
+		t.Fatalf("NewLoader() error = %v, want localized question contract", err)
+	}
+}
+
+func TestLoaderRejectsTopicVariantLocalePathMismatch(t *testing.T) {
+	root := setupOSSContractFixture(t)
+	variantPath := filepath.Join(
+		filepath.Dir(fixtureTopicPath(root, "MT1-05.yaml")),
+		"translations",
+		"ms",
+		"MT1-05.yaml",
+	)
+	replaceFixtureText(t, variantPath, "language: ms", "language: en")
+
+	_, err := curriculum.NewLoader(root)
+	if err == nil {
+		t.Fatal("NewLoader() error = nil, want topic variant locale mismatch rejected")
+	}
+	if !strings.Contains(err.Error(), "language") || !strings.Contains(err.Error(), "locale") {
+		t.Fatalf("NewLoader() error = %v, want language/path locale mismatch", err)
+	}
+}
+
+func TestLoaderRejectsDuplicateLocalizedObjectiveID(t *testing.T) {
+	root := setupOSSContractFixture(t)
+	variantPath := filepath.Join(
+		filepath.Dir(fixtureTopicPath(root, "MT1-05.yaml")),
+		"translations",
+		"ms",
+		"MT1-05.yaml",
+	)
+	replaceFixtureText(t, variantPath, "quality_level: 2", `  - id: "5.1.1"
+    content_standard_id: "5.1"
+    text: Objektif pendua.
+    bloom: understand
+quality_level: 2`)
+
+	_, err := curriculum.NewLoader(root)
+	if err == nil {
+		t.Fatal("NewLoader() error = nil, want duplicate localized objective rejected")
+	}
+	if !strings.Contains(err.Error(), "repeats objective") {
+		t.Fatalf("NewLoader() error = %v, want duplicate localized objective identity", err)
+	}
+}
+
+func TestLoaderRejectsDuplicateLocalizedQuestionID(t *testing.T) {
+	root := setupOSSContractFixture(t)
+	variantPath := filepath.Join(
+		filepath.Dir(fixtureTopicPath(root, "MT1-05.yaml")),
+		"translations",
+		"ms",
+		"MT1-05.assessments.yaml",
+	)
+	replaceFixtureText(t, variantPath, "    marks: 1\n", `    marks: 1
+  - id: Q1
+    text: Soalan pendua.
+    difficulty: easy
+    learning_objective: "5.1.1"
+    answer:
+      type: exact
+      value: "6"
+    marks: 1
+`)
+
+	_, err := curriculum.NewLoader(root)
+	if err == nil {
+		t.Fatal("NewLoader() error = nil, want duplicate localized question rejected")
+	}
+	if !strings.Contains(err.Error(), "repeats question") {
+		t.Fatalf("NewLoader() error = %v, want duplicate localized question identity", err)
+	}
+}
+
+func TestLoaderPreservesLocalizedExactAnswer(t *testing.T) {
+	root := setupOSSContractFixture(t)
+	canonicalPath := fixtureTopicPath(root, "MT1-05.assessments.yaml")
+	variantPath := filepath.Join(
+		filepath.Dir(fixtureTopicPath(root, "MT1-05.yaml")),
+		"translations",
+		"ms",
+		"MT1-05.assessments.yaml",
+	)
+	replaceFixtureText(t, canonicalPath, "type: multiple_choice", "type: exact")
+	replaceFixtureText(t, variantPath, "type: multiple_choice", "type: exact")
+	replaceFixtureText(t, variantPath, `value: "6"`, `value: "enam"`)
+
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	variant, found := loader.GetAssessmentVariant("MT1-05", "ms")
+	if !found ||
+		len(variant.Questions) != 1 ||
+		variant.Questions[0].Answer.Value != "enam" {
+		t.Fatalf("localized assessment = %#v, found = %v", variant, found)
+	}
+}
+
+func TestLoaderRejectsPrerequisiteCycle(t *testing.T) {
+	root := setupOSSContractFixture(t)
+	topicPath := fixtureTopicPath(root, "MT1-05.yaml")
+	replaceFixtureText(t, topicPath, "quality_level: 2", `prerequisites:
+  required:
+    - MT1-05
+quality_level: 2`)
+
+	_, err := curriculum.NewLoader(root)
+	if err == nil {
+		t.Fatal("NewLoader() error = nil, want prerequisite cycle rejection")
+	}
+	if !strings.Contains(err.Error(), "cycle") || !strings.Contains(err.Error(), "MT1-05") {
+		t.Fatalf("NewLoader() error = %v, want prerequisite cycle", err)
+	}
+}
+
+func TestLoaderRejectsExplicitZeroAssessmentCount(t *testing.T) {
+	root := setupOSSContractFixture(t)
+	topicPath := fixtureTopicPath(root, "MT1-05.yaml")
+	replaceFixtureText(t, topicPath, "quality_level: 2", `mastery:
+  assessment_count: 0
+quality_level: 2`)
+
+	_, err := curriculum.NewLoader(root)
+	if err == nil {
+		t.Fatal("NewLoader() error = nil, want explicit zero assessment count rejected")
+	}
+	if !strings.Contains(err.Error(), "mastery policy") {
+		t.Fatalf("NewLoader() error = %v, want invalid mastery policy", err)
+	}
+}
+
+func TestLoaderReturnsImmutableCurriculumSnapshots(t *testing.T) {
+	root := setupOSSContractFixture(t)
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+
+	topic, _ := loader.GetTopic("MT1-05")
+	topic.LearningObjectives[0].TextEN = "mutated"
+	assessment, _ := loader.GetAssessment("MT1-05")
+	assessment.Questions[0].Answer.Options["B"] = "mutated"
+	subjectGrade, _ := loader.GetSubjectGrade("malaysia-kssm-matematik-tingkatan-1")
+	subjectGrade.Topics[0] = "mutated"
+
+	topic, _ = loader.GetTopic("MT1-05")
+	if topic.LearningObjectives[0].TextEN == "mutated" {
+		t.Fatal("GetTopic() exposed mutable loader state")
+	}
+	assessment, _ = loader.GetAssessment("MT1-05")
+	if assessment.Questions[0].Answer.Options["B"] == "mutated" {
+		t.Fatal("GetAssessment() exposed mutable loader state")
+	}
+	subjectGrade, _ = loader.GetSubjectGrade("malaysia-kssm-matematik-tingkatan-1")
+	if subjectGrade.Topics[0] == "mutated" {
+		t.Fatal("GetSubjectGrade() exposed mutable loader state")
+	}
+}
+
+func TestLoaderNormalizesArrayAssessmentOptions(t *testing.T) {
+	root := setupOSSContractFixture(t)
+	assessmentPath := fixtureTopicPath(root, "MT1-05.assessments.yaml")
+	replaceFixtureText(t, assessmentPath, `options:
+        A: "5"
+        B: "6"`, `options:
+        - "5"
+        - "6"`)
+
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	assessment, found := loader.GetAssessment("MT1-05")
+	if !found {
+		t.Fatal("GetAssessment(MT1-05) not found")
+	}
+	options := assessment.Questions[0].Answer.Options
+	if len(options) != 2 || options["A"] != "5" || options["B"] != "6" {
+		t.Fatalf("normalized options = %#v, want A/B IDs in source order", options)
+	}
+}
+
+func TestLoaderPreservesMatchingPairsAsNonScalarAnswer(t *testing.T) {
+	root := setupOSSContractFixture(t)
+	assessmentPath := fixtureTopicPath(root, "MT1-05.assessments.yaml")
+	replaceFixtureText(t, assessmentPath, `      type: multiple_choice
+      value: "6"
+      options:
+        A: "5"
+        B: "6"`, `      type: matching
+      pairs:
+        - left: Variable
+          right: A symbol whose value may change
+        - left: Constant
+          right: A fixed value`)
+	variantPath := filepath.Join(filepath.Dir(assessmentPath), "translations", "ms", "MT1-05.assessments.yaml")
+	if err := os.Remove(variantPath); err != nil {
+		t.Fatalf("Remove(%s) error = %v", variantPath, err)
+	}
+
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	assessment, _ := loader.GetAssessment("MT1-05")
+	answer := assessment.Questions[0].Answer
+	if answer.Value != "" || len(answer.Pairs) != 2 ||
+		answer.Pairs[0].Left != "Variable" ||
+		answer.Pairs[1].Right != "A fixed value" {
+		t.Fatalf("matching answer = %#v, want preserved ordered pairs", answer)
+	}
+}
+
+func TestLoaderRejectsAmbiguousMultipleChoiceAnswer(t *testing.T) {
+	root := setupOSSContractFixture(t)
+	assessmentPath := fixtureTopicPath(root, "MT1-05.assessments.yaml")
+	replaceFixtureText(t, assessmentPath, `        A: "5"
+        B: "6"`, `        A: "6"
+        B: "6"`)
+
+	_, err := curriculum.NewLoader(root)
+	if err == nil {
+		t.Fatal("NewLoader() error = nil, want ambiguous multiple-choice answer rejected")
+	}
+	if !strings.Contains(err.Error(), "Q1") || !strings.Contains(err.Error(), "correct option") {
+		t.Fatalf("NewLoader() error = %v, want ambiguous question identity", err)
+	}
+}
+
+func TestLoaderRejectsAssessmentShapesOutsideSchema(t *testing.T) {
+	tests := []struct {
+		name        string
+		old         string
+		replacement string
+	}{
+		{
+			name: "structured answer value",
+			old:  `      value: "6"`,
+			replacement: `      value:
+        x: "2"`,
+		},
+		{
+			name: "scalar hint",
+			old:  "    marks: 1\n",
+			replacement: `    marks: 1
+    hints:
+      - Substitute the value first.
+`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := setupOSSContractFixture(t)
+			assessmentPath := fixtureTopicPath(root, "MT1-05.assessments.yaml")
+			replaceFixtureText(t, assessmentPath, test.old, test.replacement)
+
+			if _, err := curriculum.NewLoader(root); err == nil {
+				t.Fatal("NewLoader() error = nil, want schema-invalid assessment rejected")
+			}
+		})
+	}
+}
+
+func setupOSSContractFixture(t *testing.T) string {
+	t.Helper()
+
+	root := t.TempDir()
+	curriculumDir := filepath.Join(
+		root,
+		"curricula",
+		"malaysia",
+		"malaysia-kssm",
+		"malaysia-kssm-matematik",
+	)
+	gradeDir := filepath.Join(curriculumDir, "malaysia-kssm-matematik-tingkatan-1")
+	topicsDir := filepath.Join(gradeDir, "topics")
+	translationDir := filepath.Join(topicsDir, "translations", "ms")
+	if err := os.MkdirAll(translationDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	writeFixtureFile(t, filepath.Join(curriculumDir, "..", "syllabus.yaml"), `
+id: malaysia-kssm
+name: KSSM
+subjects:
+  - malaysia-kssm-matematik
+`)
+	writeFixtureFile(t, filepath.Join(curriculumDir, "subject.yaml"), `
+id: malaysia-kssm-matematik
+name: Matematik
+name_en: Mathematics
+syllabus_id: malaysia-kssm
+`)
+	writeFixtureFile(t, filepath.Join(gradeDir, "subject-grade.yaml"), `
+id: malaysia-kssm-matematik-tingkatan-1
+name: Matematik Tingkatan 1
+name_en: Mathematics Form 1
+subject_id: malaysia-kssm-matematik
+syllabus_id: malaysia-kssm
+grade_id: tingkatan-1
+topics:
+  - MT1-05
+`)
+	writeFixtureFile(t, filepath.Join(topicsDir, "MT1-05.yaml"), `
+id: MT1-05
+name: Ungkapan Algebra
+name_en: Algebraic Expressions
+subject_grade_id: malaysia-kssm-matematik-tingkatan-1
+subject_id: malaysia-kssm-matematik
+syllabus_id: malaysia-kssm
+language: en
+difficulty: beginner
+content_standards:
+  - id: "5.1"
+    text_en: Variables and algebraic expressions
+learning_objectives:
+  - id: "5.1.1"
+    content_standard_id: "5.1"
+    text_en: Use letters to represent unknown quantities.
+    bloom: understand
+quality_level: 2
+provenance: ai-assisted
+`)
+	writeFixtureFile(t, filepath.Join(translationDir, "MT1-05.yaml"), `
+id: MT1-05
+name: Ungkapan Algebra
+subject_grade_id: malaysia-kssm-matematik-tingkatan-1
+subject_id: malaysia-kssm-matematik
+syllabus_id: malaysia-kssm
+language: ms
+difficulty: beginner
+content_standards:
+  - id: "5.1"
+    text: Pemboleh ubah dan ungkapan algebra
+learning_objectives:
+  - id: "5.1.1"
+    content_standard_id: "5.1"
+    text: Menggunakan huruf untuk mewakili kuantiti yang tidak diketahui.
+    bloom: understand
+quality_level: 2
+provenance: ai-assisted
+`)
+	writeFixtureFile(t, filepath.Join(topicsDir, "MT1-05.assessments.yaml"), `
+topic_id: MT1-05
+provenance: human
+questions:
+  - id: Q1
+    text: Evaluate 3x when x = 2.
+    difficulty: easy
+    learning_objective: "5.1.1"
+    answer:
+      type: multiple_choice
+      value: "6"
+      options:
+        A: "5"
+        B: "6"
+    marks: 1
+`)
+	writeFixtureFile(t, filepath.Join(translationDir, "MT1-05.assessments.yaml"), `
+topic_id: MT1-05
+provenance: human
+questions:
+  - id: Q1
+    text: Hitung 3x apabila x = 2.
+    difficulty: easy
+    learning_objective: "5.1.1"
+    answer:
+      type: multiple_choice
+      value: "6"
+      options:
+        A: "5"
+        B: "6"
+    marks: 1
+`)
+	writeFixtureFile(t, filepath.Join(topicsDir, "MT1-05.teaching.md"), "# Teach algebra\n")
+	writeFixtureFile(t, filepath.Join(translationDir, "MT1-05.teaching.md"), "# Ajar algebra\n")
+
+	return root
+}
+
+func setupValidatedCrossCurriculumFixture(t *testing.T) string {
+	t.Helper()
+
+	root := setupOSSContractFixture(t)
+	otherDir := filepath.Join(root, "curricula", "other")
+	topicsDir := filepath.Join(otherDir, "topics")
+	if err := os.MkdirAll(topicsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s) error = %v", topicsDir, err)
+	}
+	writeFixtureFile(t, filepath.Join(otherDir, "syllabus.yaml"), `
+id: other-syllabus
+name: Other
+subjects:
+  - other-math
+`)
+	writeFixtureFile(t, filepath.Join(otherDir, "subject.yaml"), `
+id: other-math
+name: Other Mathematics
+syllabus_id: other-syllabus
+`)
+	writeFixtureFile(t, filepath.Join(otherDir, "subject-grade.yaml"), `
+id: other-math-form-1
+name: Other Mathematics Form 1
+subject_id: other-math
+syllabus_id: other-syllabus
+grade_id: form-1
+topics:
+  - OM1-01
+`)
+	writeFixtureFile(t, filepath.Join(topicsDir, "OM1-01.yaml"), `
+id: OM1-01
+name: Variables in Another Curriculum
+subject_grade_id: other-math-form-1
+subject_id: other-math
+syllabus_id: other-syllabus
+language: en
+difficulty: beginner
+content_standards:
+  - id: "1.1"
+    text_en: Variables
+learning_objectives:
+  - id: "1.1.1"
+    content_standard_id: "1.1"
+    text_en: Represent an unknown with a symbol.
+    bloom: understand
+quality_level: 2
+provenance: human
+`)
+	conceptDir := filepath.Join(root, "concepts", "mathematics")
+	if err := os.MkdirAll(conceptDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s) error = %v", conceptDir, err)
+	}
+	writeFixtureFile(t, filepath.Join(conceptDir, "variables.yaml"), `
+id: variables
+name: Variables
+domain: mathematics
+subdomain: algebra
+definition: A symbol whose value may change.
+curricula:
+  - syllabus: malaysia-kssm
+    topic: MT1-05
+    scope: introduction
+  - syllabus: other-syllabus
+    topic: OM1-01
+    scope: introduction
+`)
+	topicPath := fixtureTopicPath(root, "MT1-05.yaml")
+	replaceFixtureText(t, topicPath, "quality_level: 2", `cross_curriculum:
+  - concept_id: variables
+    syllabus_id: other-syllabus
+    topic_id: OM1-01
+quality_level: 2`)
+	return root
+}
+
+func writeFixtureFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s) error = %v", path, err)
+	}
+}
+
+func fixtureTopicPath(root, name string) string {
+	return filepath.Join(
+		root,
+		"curricula",
+		"malaysia",
+		"malaysia-kssm",
+		"malaysia-kssm-matematik",
+		"malaysia-kssm-matematik-tingkatan-1",
+		"topics",
+		name,
+	)
+}
+
+func replaceFixtureText(t *testing.T, path, old, replacement string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", path, err)
+	}
+	content := string(data)
+	if !strings.Contains(content, old) {
+		t.Fatalf("%s does not contain %q", path, old)
+	}
+	writeFixtureFile(t, path, strings.Replace(content, old, replacement, 1))
+}

--- a/internal/curriculum/oss_integration_test.go
+++ b/internal/curriculum/oss_integration_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build ossintegration
+
+package curriculum_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/p-n-ai/pai-bot/internal/curriculum"
+)
+
+func TestLoaderLoadsPinnedOSSCorpus(t *testing.T) {
+	root := filepath.Join("..", "..", "oss")
+	if _, err := os.Stat(filepath.Join(root, "curricula")); err != nil {
+		t.Skip("OSS submodule is not initialized")
+	}
+
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader(pinned OSS) error = %v", err)
+	}
+
+	wantStats := curriculum.SnapshotStats{
+		Syllabi:               1,
+		Subjects:              3,
+		SubjectGrades:         15,
+		Topics:                152,
+		TopicVariants:         53,
+		Concepts:              2,
+		Examples:              114,
+		ExampleVariants:       53,
+		TeachingNotes:         114,
+		TeachingNoteVariants:  56,
+		AITeachingReadyTopics: 37,
+		Assessments:           114,
+		AssessmentVariants:    53,
+	}
+	if got := loader.SnapshotStats(); got != wantStats {
+		t.Fatalf("SnapshotStats() = %#v, want %#v", got, wantStats)
+	}
+	if _, found := loader.GetSubjectGrade("malaysia-kssm-matematik-tingkatan-1"); !found {
+		t.Fatal("pinned OSS subject-grade not loaded")
+	}
+
+	trigonometry, found := loader.GetTopic("MT3-05")
+	if !found {
+		t.Fatal("pinned OSS canonical topic MT3-05 not loaded")
+	}
+	if trigonometry.Mastery.AssessmentCount != 3 {
+		t.Fatalf(
+			"MT3-05 mastery assessment count = %d, want authored 3",
+			trigonometry.Mastery.AssessmentCount,
+		)
+	}
+	if len(trigonometry.LearningObjectives) != 7 {
+		t.Fatalf(
+			"MT3-05 learning objectives = %d, want all 7 authored objectives",
+			len(trigonometry.LearningObjectives),
+		)
+	}
+	if len(trigonometry.Teaching.Sequence) != 5 {
+		t.Fatalf(
+			"MT3-05 teaching sequence = %d steps, want all 5 authored steps",
+			len(trigonometry.Teaching.Sequence),
+		)
+	}
+	if len(trigonometry.Teaching.CommonMisconceptions) != 3 ||
+		len(trigonometry.Teaching.EngagementHooks) != 3 {
+		t.Fatalf(
+			"MT3-05 teaching guidance = %d misconceptions, %d hooks; want 3 and 3",
+			len(trigonometry.Teaching.CommonMisconceptions),
+			len(trigonometry.Teaching.EngagementHooks),
+		)
+	}
+
+	taxAssessment, found := loader.GetAssessment("MT5-04")
+	if !found {
+		t.Fatal("pinned OSS canonical assessment MT5-04 not loaded")
+	}
+	var taxChoice curriculum.AssessmentQuestion
+	for _, question := range taxAssessment.Questions {
+		if question.ID == "Q2" {
+			taxChoice = question
+			break
+		}
+	}
+	if len(taxChoice.Answer.Options) != 4 ||
+		taxChoice.Answer.Value != "a" ||
+		taxChoice.Answer.Options["a"] != "Property Assessment Tax" {
+		t.Fatalf(
+			"MT5-04/Q2 answer = %#v, want canonical four-option grading contract",
+			taxChoice.Answer,
+		)
+	}
+
+	canonical, found := loader.GetTopic("MT1-05")
+	if !found {
+		t.Fatal("pinned OSS canonical topic MT1-05 not loaded")
+	}
+	if canonical.Language != "en" || canonical.NameEN != "Algebraic Expressions" {
+		t.Fatalf("canonical MT1-05 = %#v, want root English variant", canonical)
+	}
+	concepts := loader.ConceptsForTopic("malaysia-kssm", "MT1-05")
+	if len(concepts) != 1 ||
+		concepts[0].ID != "algebraic-expression" ||
+		len(concepts[0].Curricula) != 5 {
+		t.Fatalf("MT1-05 concepts = %#v, want source-authored algebraic-expression graph", concepts)
+	}
+
+	malay, found := loader.GetTopicVariant("MT1-05", "ms")
+	if !found || malay.Language != "ms" {
+		t.Fatalf("Malay MT1-05 variant = %#v, found = %v", malay, found)
+	}
+}

--- a/internal/curriculum/prerequisites.go
+++ b/internal/curriculum/prerequisites.go
@@ -3,8 +3,6 @@
 
 package curriculum
 
-const UnlockMasteryThreshold = 0.8
-
 // PrereqGraph is a reverse dependency graph for curriculum topics.
 // It maps each topic to the topics that depend on it (require it as a prerequisite).
 type PrereqGraph struct {
@@ -25,8 +23,8 @@ func NewPrereqGraph(topics []Topic) *PrereqGraph {
 	}
 	for _, t := range topics {
 		g.topics[t.ID] = t
-		g.prereqs[t.ID] = t.Prerequisites.Required
-		for _, req := range t.Prerequisites.Required {
+		g.prereqs[t.ID] = t.Prerequisites.RequiredTopicIDs()
+		for _, req := range g.prereqs[t.ID] {
 			g.dependents[req] = append(g.dependents[req], t.ID)
 		}
 	}
@@ -46,7 +44,7 @@ func (g *PrereqGraph) RequiredPrereqs(topicID string) []string {
 // UnlockableTopics returns topics that become newly unlockable after mastering
 // the given topic. A topic is unlockable when:
 // 1. It has required prerequisites (topics with no prereqs are always available)
-// 2. ALL of its required prerequisites have mastery ≥ UnlockMasteryThreshold
+// 2. ALL required prerequisites meet their OSS-authored mastery thresholds
 // 3. The topic itself is NOT already mastered (no re-notification)
 func (g *PrereqGraph) UnlockableTopics(masteredTopicID string, scores map[string]float64) []Topic {
 	deps := g.dependents[masteredTopicID]
@@ -63,14 +61,16 @@ func (g *PrereqGraph) UnlockableTopics(masteredTopicID string, scores map[string
 		}
 
 		// Skip if already mastered (don't re-notify).
-		if scores[depID] >= UnlockMasteryThreshold {
+		dependent := g.topics[depID]
+		if score, known := scores[depID]; known && score >= masteryThreshold(dependent) {
 			continue
 		}
 
 		// Check if ALL required prereqs are now mastered.
 		allMet := true
 		for _, req := range prereqs {
-			if scores[req] < UnlockMasteryThreshold {
+			score, known := scores[req]
+			if !known || score < masteryThreshold(g.topics[req]) {
 				allMet = false
 				break
 			}

--- a/internal/curriculum/prerequisites_test.go
+++ b/internal/curriculum/prerequisites_test.go
@@ -10,9 +10,9 @@ import (
 func TestPrereqGraph_DependentsOf(t *testing.T) {
 	topics := []Topic{
 		{ID: "F1-05", Prerequisites: Prerequisites{}},
-		{ID: "F1-06", Prerequisites: Prerequisites{Required: []string{"F1-05"}}},
-		{ID: "F1-07", Prerequisites: Prerequisites{Required: []string{"F1-05", "F1-06"}}},
-		{ID: "F1-08", Prerequisites: Prerequisites{Required: []string{"F1-07"}}},
+		{ID: "F1-06", Prerequisites: Prerequisites{Required: []PrerequisiteRef{{TopicID: "F1-05"}}}},
+		{ID: "F1-07", Prerequisites: Prerequisites{Required: []PrerequisiteRef{{TopicID: "F1-05"}, {TopicID: "F1-06"}}}},
+		{ID: "F1-08", Prerequisites: Prerequisites{Required: []PrerequisiteRef{{TopicID: "F1-07"}}}},
 	}
 
 	g := NewPrereqGraph(topics)
@@ -51,8 +51,8 @@ func TestPrereqGraph_DependentsOf(t *testing.T) {
 func TestPrereqGraph_RequiredPrereqs(t *testing.T) {
 	topics := []Topic{
 		{ID: "F1-05", Prerequisites: Prerequisites{}},
-		{ID: "F1-06", Prerequisites: Prerequisites{Required: []string{"F1-05"}}},
-		{ID: "F1-07", Prerequisites: Prerequisites{Required: []string{"F1-05", "F1-06"}}},
+		{ID: "F1-06", Prerequisites: Prerequisites{Required: []PrerequisiteRef{{TopicID: "F1-05"}}}},
+		{ID: "F1-07", Prerequisites: Prerequisites{Required: []PrerequisiteRef{{TopicID: "F1-05"}, {TopicID: "F1-06"}}}},
 	}
 
 	g := NewPrereqGraph(topics)
@@ -71,9 +71,9 @@ func TestPrereqGraph_RequiredPrereqs(t *testing.T) {
 func TestPrereqGraph_UnlockableTopics(t *testing.T) {
 	topics := []Topic{
 		{ID: "F1-05", Name: "Algebra Basics", Prerequisites: Prerequisites{}},
-		{ID: "F1-06", Name: "Linear Equations", Prerequisites: Prerequisites{Required: []string{"F1-05"}}},
-		{ID: "F1-07", Name: "Inequalities", Prerequisites: Prerequisites{Required: []string{"F1-05", "F1-06"}}},
-		{ID: "F1-08", Name: "Simultaneous Eq", Prerequisites: Prerequisites{Required: []string{"F1-07"}}},
+		{ID: "F1-06", Name: "Linear Equations", Prerequisites: Prerequisites{Required: []PrerequisiteRef{{TopicID: "F1-05"}}}},
+		{ID: "F1-07", Name: "Inequalities", Prerequisites: Prerequisites{Required: []PrerequisiteRef{{TopicID: "F1-05"}, {TopicID: "F1-06"}}}},
+		{ID: "F1-08", Name: "Simultaneous Eq", Prerequisites: Prerequisites{Required: []PrerequisiteRef{{TopicID: "F1-07"}}}},
 	}
 
 	g := NewPrereqGraph(topics)
@@ -123,7 +123,7 @@ func TestPrereqGraph_UnlockableTopics_NoPrereqs(t *testing.T) {
 func TestPrereqGraph_UnlockableTopics_AlreadyMastered(t *testing.T) {
 	topics := []Topic{
 		{ID: "F1-05", Prerequisites: Prerequisites{}},
-		{ID: "F1-06", Prerequisites: Prerequisites{Required: []string{"F1-05"}}},
+		{ID: "F1-06", Prerequisites: Prerequisites{Required: []PrerequisiteRef{{TopicID: "F1-05"}}}},
 	}
 
 	g := NewPrereqGraph(topics)
@@ -136,5 +136,86 @@ func TestPrereqGraph_UnlockableTopics_AlreadyMastered(t *testing.T) {
 	unlocked := g.UnlockableTopics("F1-05", scores)
 	if len(unlocked) != 0 {
 		t.Errorf("expected no unlockable topics (already mastered), got %v", unlocked)
+	}
+}
+
+func TestPrereqGraph_UsesOSSAuthoredMasteryThresholds(t *testing.T) {
+	topics := []Topic{
+		{
+			ID:      "F1-05",
+			Mastery: MasteryCriteria{MinimumScore: 0.6},
+		},
+		{
+			ID:            "F1-06",
+			Mastery:       MasteryCriteria{MinimumScore: 0.9},
+			Prerequisites: Prerequisites{Required: []PrerequisiteRef{{TopicID: "F1-05"}}},
+		},
+	}
+
+	graph := NewPrereqGraph(topics)
+	unlocked := graph.UnlockableTopics("F1-05", map[string]float64{
+		"F1-05": 0.65,
+		"F1-06": 0.8,
+	})
+
+	if len(unlocked) != 1 || unlocked[0].ID != "F1-06" {
+		t.Fatalf("UnlockableTopics() = %v, want F1-06 from OSS-authored thresholds", unlocked)
+	}
+}
+
+func TestPrereqGraph_ZeroThresholdDoesNotTreatUnseenTopicAsAlreadyMastered(t *testing.T) {
+	topics := []Topic{
+		{
+			ID:      "F1-05",
+			Mastery: MasteryCriteria{MinimumScore: 0, minimumScoreSet: true},
+		},
+		{
+			ID:      "F1-06",
+			Mastery: MasteryCriteria{MinimumScore: 0, minimumScoreSet: true},
+			Prerequisites: Prerequisites{
+				Required: []PrerequisiteRef{{TopicID: "F1-05"}},
+			},
+		},
+	}
+
+	graph := NewPrereqGraph(topics)
+	unlocked := graph.UnlockableTopics("F1-05", map[string]float64{
+		"F1-05": 0,
+	})
+
+	if len(unlocked) != 1 || unlocked[0].ID != "F1-06" {
+		t.Fatalf("UnlockableTopics() = %v, want unseen F1-06 unlocked", unlocked)
+	}
+}
+
+func TestPrereqGraph_ZeroThresholdDoesNotTreatUnseenPrerequisiteAsSatisfied(t *testing.T) {
+	topics := []Topic{
+		{
+			ID:      "F1-05",
+			Mastery: MasteryCriteria{MinimumScore: 0.75},
+		},
+		{
+			ID:      "F1-06",
+			Mastery: MasteryCriteria{MinimumScore: 0, minimumScoreSet: true},
+		},
+		{
+			ID:      "F1-07",
+			Mastery: MasteryCriteria{MinimumScore: 0.75},
+			Prerequisites: Prerequisites{
+				Required: []PrerequisiteRef{
+					{TopicID: "F1-05"},
+					{TopicID: "F1-06"},
+				},
+			},
+		},
+	}
+
+	graph := NewPrereqGraph(topics)
+	unlocked := graph.UnlockableTopics("F1-05", map[string]float64{
+		"F1-05": 1,
+	})
+
+	if len(unlocked) != 0 {
+		t.Fatalf("UnlockableTopics() = %v, want unseen F1-06 to block F1-07", unlocked)
 	}
 }

--- a/internal/curriculum/types.go
+++ b/internal/curriculum/types.go
@@ -3,55 +3,303 @@
 
 package curriculum
 
+import (
+	"fmt"
+	"slices"
+
+	"gopkg.in/yaml.v3"
+)
+
 // Topic represents a curriculum topic loaded from YAML.
 type Topic struct {
-	ID                 string              `yaml:"id"`
-	OfficialRef        string              `yaml:"official_ref"`
-	Name               string              `yaml:"name"`
-	SubjectID          string              `yaml:"subject_id"`
-	SyllabusID         string              `yaml:"syllabus_id"`
-	Difficulty         string              `yaml:"difficulty"`
-	Tier               string              `yaml:"tier"`
-	LearningObjectives []LearningObjective `yaml:"learning_objectives"`
-	Prerequisites      Prerequisites       `yaml:"prerequisites"`
-	QualityLevel       int                 `yaml:"quality_level"`
-	Provenance         string              `yaml:"provenance"`
+	ID                   string                `yaml:"id"`
+	OfficialRef          string                `yaml:"official_ref"`
+	Name                 string                `yaml:"name"`
+	NameEN               string                `yaml:"name_en"`
+	SubjectGradeID       string                `yaml:"subject_grade_id"`
+	SubjectID            string                `yaml:"subject_id"`
+	SyllabusID           string                `yaml:"syllabus_id"`
+	CountryID            string                `yaml:"country_id"`
+	Language             string                `yaml:"language"`
+	Difficulty           string                `yaml:"difficulty"`
+	Tier                 string                `yaml:"tier"`
+	ContentStandards     []ContentStandard     `yaml:"content_standards"`
+	LearningObjectives   []LearningObjective   `yaml:"learning_objectives"`
+	PerformanceStandards []PerformanceStandard `yaml:"performance_standards"`
+	Prerequisites        Prerequisites         `yaml:"prerequisites"`
+	BackgroundKnowledge  []string              `yaml:"background_knowledge"`
+	CrossCurriculum      []CrossCurriculumLink `yaml:"cross_curriculum"`
+	Teaching             TeachingGuidance      `yaml:"teaching"`
+	Mastery              MasteryCriteria       `yaml:"mastery"`
+	TeachingNotesFile    string                `yaml:"ai_teaching_notes"`
+	ExamplesFile         string                `yaml:"examples_file"`
+	AssessmentsFile      string                `yaml:"assessments_file"`
+	QualityLevel         int                   `yaml:"quality_level"`
+	Provenance           string                `yaml:"provenance"`
+	Source               SourceRef             `yaml:"-"`
+	qualityLevelSet      bool
+}
+
+// UnmarshalYAML normalizes the schema's root and nested engagement-hook
+// placements into one teaching field.
+func (topic *Topic) UnmarshalYAML(node *yaml.Node) error {
+	type rawTopic Topic
+	var decoded struct {
+		rawTopic        `yaml:",inline"`
+		EngagementHooks []string `yaml:"engagement_hooks"`
+	}
+	if err := node.Decode(&decoded); err != nil {
+		return err
+	}
+	nested := decoded.rawTopic.Teaching.EngagementHooks
+	if len(decoded.EngagementHooks) > 0 && len(nested) > 0 &&
+		!slices.Equal(decoded.EngagementHooks, nested) {
+		return fmt.Errorf("root and teaching engagement_hooks conflict")
+	}
+	if len(decoded.EngagementHooks) > 0 {
+		decoded.rawTopic.Teaching.EngagementHooks = slices.Clone(decoded.EngagementHooks)
+	}
+	*topic = Topic(decoded.rawTopic)
+	var presence struct {
+		QualityLevel *int `yaml:"quality_level"`
+	}
+	if err := node.Decode(&presence); err != nil {
+		return err
+	}
+	topic.qualityLevelSet = presence.QualityLevel != nil
+	return nil
+}
+
+// IsAITeachingReady reports whether OSS explicitly claims the topic meets the
+// minimum quality level for AI teaching.
+func (topic Topic) IsAITeachingReady() bool {
+	return topic.qualityLevelSet && topic.QualityLevel >= 3
+}
+
+// SourceRef identifies the OSS artifact that supplied a curriculum value.
+type SourceRef struct {
+	Path     string
+	Kind     string
+	Locale   string
+	Revision string
+}
+
+// CrossCurriculumLink is an explicit OSS-authored graph edge through a shared
+// concept.
+type CrossCurriculumLink struct {
+	ConceptID  string `yaml:"concept_id"`
+	SyllabusID string `yaml:"syllabus_id"`
+	TopicID    string `yaml:"topic_id"`
+}
+
+// Concept is a curriculum-neutral identity shared by explicit topic edges.
+type Concept struct {
+	ID         string                 `yaml:"id"`
+	Name       string                 `yaml:"name"`
+	Domain     string                 `yaml:"domain"`
+	Subdomain  string                 `yaml:"subdomain"`
+	Definition string                 `yaml:"definition"`
+	Curricula  []ConceptCurriculumRef `yaml:"curricula"`
+	Source     SourceRef              `yaml:"-"`
+}
+
+// ConceptCurriculumRef identifies one syllabus-scoped concept occurrence.
+type ConceptCurriculumRef struct {
+	SyllabusID string `yaml:"syllabus"`
+	TopicID    string `yaml:"topic"`
+	Scope      string `yaml:"scope"`
+}
+
+// ContentStandard is an official curriculum content standard within a topic.
+type ContentStandard struct {
+	ID     string `yaml:"id"`
+	Text   string `yaml:"text"`
+	TextEN string `yaml:"text_en"`
 }
 
 // LearningObjective represents a learning objective within a topic.
 type LearningObjective struct {
-	ID    string `yaml:"id"`
-	Text  string `yaml:"text"`
-	Bloom string `yaml:"bloom"`
+	ID                string `yaml:"id"`
+	ContentStandardID string `yaml:"content_standard_id"`
+	Text              string `yaml:"text"`
+	TextEN            string `yaml:"text_en"`
+	Bloom             string `yaml:"bloom"`
+}
+
+// PerformanceStandard describes one source-defined level of demonstrated mastery.
+type PerformanceStandard struct {
+	Level        int    `yaml:"level"`
+	ID           string `yaml:"id"`
+	Text         string `yaml:"text"`
+	TextEN       string `yaml:"text_en"`
+	Descriptor   string `yaml:"descriptor"`
+	DescriptorEN string `yaml:"descriptor_en"`
+}
+
+// TeachingGuidance contains structured, source-authored teaching guidance.
+type TeachingGuidance struct {
+	Sequence             []string              `yaml:"sequence"`
+	CommonMisconceptions []CommonMisconception `yaml:"common_misconceptions"`
+	EngagementHooks      []string              `yaml:"engagement_hooks"`
+}
+
+// CommonMisconception pairs a known error with its source-authored remediation.
+type CommonMisconception struct {
+	Misconception string `yaml:"misconception"`
+	Remediation   string `yaml:"remediation"`
+}
+
+// MasteryCriteria is the OSS-authored mastery policy for a topic.
+type MasteryCriteria struct {
+	MinimumScore     float64          `yaml:"minimum_score"`
+	AssessmentCount  int              `yaml:"assessment_count"`
+	SpacedRepetition SpacedRepetition `yaml:"spaced_repetition"`
+	minimumScoreSet  bool
+	assessmentSet    bool
+}
+
+// UnmarshalYAML preserves the difference between an absent policy and an
+// explicitly authored zero value.
+func (criteria *MasteryCriteria) UnmarshalYAML(node *yaml.Node) error {
+	var raw struct {
+		MinimumScore     *float64         `yaml:"minimum_score"`
+		AssessmentCount  *int             `yaml:"assessment_count"`
+		SpacedRepetition SpacedRepetition `yaml:"spaced_repetition"`
+	}
+	if err := node.Decode(&raw); err != nil {
+		return err
+	}
+
+	*criteria = MasteryCriteria{SpacedRepetition: raw.SpacedRepetition}
+	if raw.MinimumScore != nil {
+		criteria.MinimumScore = *raw.MinimumScore
+		criteria.minimumScoreSet = true
+	}
+	if raw.AssessmentCount != nil {
+		criteria.AssessmentCount = *raw.AssessmentCount
+		criteria.assessmentSet = true
+	}
+	return nil
+}
+
+// SpacedRepetition is the OSS-authored review schedule for a topic.
+type SpacedRepetition struct {
+	InitialIntervalDays int     `yaml:"initial_interval_days"`
+	Multiplier          float64 `yaml:"multiplier"`
 }
 
 // Prerequisites holds required and recommended prerequisites.
 type Prerequisites struct {
-	Required    []string `yaml:"required"`
-	Recommended []string `yaml:"recommended"`
+	Required    []PrerequisiteRef `yaml:"required"`
+	Recommended []PrerequisiteRef `yaml:"recommended"`
+}
+
+// PrerequisiteRef preserves source context while TopicID remains the only
+// graph-bearing identity.
+type PrerequisiteRef struct {
+	TopicID string `yaml:"id"`
+	Name    string `yaml:"name"`
+	NameEN  string `yaml:"name_en"`
+	Reason  string `yaml:"reason"`
+}
+
+// UnmarshalYAML accepts the compact topic-ID form and the schema's rich edge.
+func (ref *PrerequisiteRef) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind == yaml.ScalarNode && node.Tag != "!!null" {
+		ref.TopicID = node.Value
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("prerequisite must be a topic ID or object")
+	}
+	type rawRef PrerequisiteRef
+	return node.Decode((*rawRef)(ref))
+}
+
+// RequiredTopicIDs returns graph-bearing required topic identities.
+func (prerequisites Prerequisites) RequiredTopicIDs() []string {
+	ids := make([]string, len(prerequisites.Required))
+	for index, ref := range prerequisites.Required {
+		ids[index] = ref.TopicID
+	}
+	return ids
 }
 
 // Syllabus represents a top-level syllabus (e.g., KSSM Matematik Tingkatan 1).
 type Syllabus struct {
-	ID       string    `yaml:"id"`
-	Name     string    `yaml:"name"`
-	Country  string    `yaml:"country"`
-	Board    string    `yaml:"board"`
-	Level    string    `yaml:"level"`
-	Subjects []Subject `yaml:"subjects"`
+	ID          string    `yaml:"id"`
+	Name        string    `yaml:"name"`
+	NameEN      string    `yaml:"name_en"`
+	Country     string    `yaml:"country"`
+	CountryID   string    `yaml:"country_id"`
+	Board       string    `yaml:"board"`
+	Level       string    `yaml:"level"`
+	Language    string    `yaml:"language"`
+	Description string    `yaml:"description"`
+	Subjects    []string  `yaml:"subjects"`
+	Source      SourceRef `yaml:"-"`
 }
 
 // Subject represents a subject within a syllabus (e.g., Algebra).
 type Subject struct {
-	ID          string   `yaml:"id"`
-	Name        string   `yaml:"name"`
-	NameEN      string   `yaml:"name_en"`
-	SyllabusID  string   `yaml:"syllabus_id"`
-	GradeID     string   `yaml:"grade_id"`
-	CountryID   string   `yaml:"country_id"`
-	Language    string   `yaml:"language"`
-	Description string   `yaml:"description"`
-	Topics      []string `yaml:"topics"`
+	ID          string    `yaml:"id"`
+	Name        string    `yaml:"name"`
+	NameEN      string    `yaml:"name_en"`
+	SyllabusID  string    `yaml:"syllabus_id"`
+	GradeID     string    `yaml:"grade_id"`
+	CountryID   string    `yaml:"country_id"`
+	Language    string    `yaml:"language"`
+	Description string    `yaml:"description"`
+	Topics      []string  `yaml:"topics"`
+	Source      SourceRef `yaml:"-"`
+}
+
+// SubjectGrade binds one subject and grade to its source-declared topic order.
+type SubjectGrade struct {
+	ID          string    `yaml:"id"`
+	Name        string    `yaml:"name"`
+	NameEN      string    `yaml:"name_en"`
+	SubjectID   string    `yaml:"subject_id"`
+	SyllabusID  string    `yaml:"syllabus_id"`
+	GradeID     string    `yaml:"grade_id"`
+	CountryID   string    `yaml:"country_id"`
+	Language    string    `yaml:"language"`
+	Description string    `yaml:"description"`
+	Topics      []string  `yaml:"topics"`
+	Provenance  string    `yaml:"provenance"`
+	Source      SourceRef `yaml:"-"`
+}
+
+// ExampleSet groups source-authored worked examples for one topic.
+type ExampleSet struct {
+	ID             string          `yaml:"id"`
+	TopicID        string          `yaml:"topic_id"`
+	Provenance     string          `yaml:"provenance"`
+	Description    string          `yaml:"description"`
+	WorkedExamples []WorkedExample `yaml:"worked_examples"`
+	Source         SourceRef       `yaml:"-"`
+}
+
+// WorkedExample is one source-authored teaching example.
+type WorkedExample struct {
+	ID                   string `yaml:"id"`
+	Topic                string `yaml:"topic"`
+	Difficulty           string `yaml:"difficulty"`
+	TPLevel              int    `yaml:"tp_level"`
+	KBAT                 bool   `yaml:"kbat"`
+	LearningObjective    string `yaml:"learning_objective"`
+	RealWorldAnalogy     string `yaml:"real_world_analogy"`
+	MisconceptionAlert   string `yaml:"misconception_alert"`
+	Scenario             string `yaml:"scenario"`
+	Working              string `yaml:"working"`
+	SourceRefDescription string `yaml:"source_ref"`
+}
+
+// TeachingNote preserves one Markdown teaching artifact with its source.
+type TeachingNote struct {
+	TopicID string
+	Content string
+	Source  SourceRef
 }
 
 // Assessment groups quiz questions for a topic.
@@ -59,26 +307,110 @@ type Assessment struct {
 	TopicID    string               `yaml:"topic_id"`
 	Questions  []AssessmentQuestion `yaml:"questions"`
 	Provenance string               `yaml:"provenance"`
+	Source     SourceRef            `yaml:"-"`
 }
 
 // AssessmentQuestion represents a single assessment item from OSS.
 type AssessmentQuestion struct {
 	ID                string                 `yaml:"id"`
+	Type              string                 `yaml:"type"`
 	Text              string                 `yaml:"text"`
 	Difficulty        string                 `yaml:"difficulty"`
 	LearningObjective string                 `yaml:"learning_objective"`
+	TPLevel           int                    `yaml:"tp_level"`
+	KBAT              bool                   `yaml:"kbat"`
 	Answer            AssessmentAnswer       `yaml:"answer"`
 	Marks             int                    `yaml:"marks"`
 	Rubric            []AssessmentRubricItem `yaml:"rubric"`
 	Hints             []AssessmentHint       `yaml:"hints"`
 	Distractors       []AssessmentDistractor `yaml:"distractors"`
+	marksSet          bool                   `yaml:"-"`
+}
+
+// UnmarshalYAML preserves the distinction between omitted optional marks and
+// an explicitly invalid zero value.
+func (question *AssessmentQuestion) UnmarshalYAML(node *yaml.Node) error {
+	type rawAssessmentQuestion AssessmentQuestion
+	var decoded rawAssessmentQuestion
+	if err := node.Decode(&decoded); err != nil {
+		return err
+	}
+	var presence struct {
+		Marks *int `yaml:"marks"`
+	}
+	if err := node.Decode(&presence); err != nil {
+		return err
+	}
+	*question = AssessmentQuestion(decoded)
+	question.marksSet = presence.Marks != nil
+	return nil
 }
 
 // AssessmentAnswer describes the expected answer format.
 type AssessmentAnswer struct {
-	Type    string `yaml:"type"`
-	Value   string `yaml:"value"`
-	Working string `yaml:"working"`
+	Type        string                 `yaml:"type"`
+	Value       string                 `yaml:"value"`
+	Pairs       []AssessmentPair       `yaml:"pairs"`
+	Working     string                 `yaml:"working"`
+	Options     AssessmentOptions      `yaml:"options"`
+	Distractors []AssessmentDistractor `yaml:"distractors"`
+}
+
+// AssessmentPair is one ordered left/right item in a non-auto-gradeable
+// matching assessment.
+type AssessmentPair struct {
+	Left  string `yaml:"left"`
+	Right string `yaml:"right"`
+}
+
+// AssessmentOptions normalizes schema-valid option arrays and keyed maps to
+// stable learner-visible IDs.
+type AssessmentOptions map[string]string
+
+// UnmarshalYAML accepts both option shapes allowed by the OSS schema.
+func (options *AssessmentOptions) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.SequenceNode:
+		var values []string
+		if err := node.Decode(&values); err != nil {
+			return err
+		}
+		normalized := make(AssessmentOptions, len(values))
+		for index, value := range values {
+			normalized[assessmentOptionID(index)] = value
+		}
+		*options = normalized
+		return nil
+	case yaml.MappingNode:
+		var values map[string]string
+		if err := node.Decode(&values); err != nil {
+			return err
+		}
+		*options = AssessmentOptions(values)
+		return nil
+	case yaml.ScalarNode:
+		if node.Tag == "!!null" {
+			*options = nil
+			return nil
+		}
+	}
+	return fmt.Errorf("assessment options must be an array or object")
+}
+
+func assessmentOptionID(index int) string {
+	var reversed []byte
+	for {
+		reversed = append(reversed, byte('A'+index%26))
+		index = index/26 - 1
+		if index < 0 {
+			break
+		}
+	}
+	result := make([]byte, len(reversed))
+	for index := range reversed {
+		result[len(reversed)-1-index] = reversed[index]
+	}
+	return string(result)
 }
 
 // AssessmentRubricItem describes one rubric line.

--- a/internal/curriculum/types.go
+++ b/internal/curriculum/types.go
@@ -51,13 +51,13 @@ func (topic *Topic) UnmarshalYAML(node *yaml.Node) error {
 	if err := node.Decode(&decoded); err != nil {
 		return err
 	}
-	nested := decoded.rawTopic.Teaching.EngagementHooks
+	nested := decoded.Teaching.EngagementHooks
 	if len(decoded.EngagementHooks) > 0 && len(nested) > 0 &&
 		!slices.Equal(decoded.EngagementHooks, nested) {
 		return fmt.Errorf("root and teaching engagement_hooks conflict")
 	}
 	if len(decoded.EngagementHooks) > 0 {
-		decoded.rawTopic.Teaching.EngagementHooks = slices.Clone(decoded.EngagementHooks)
+		decoded.Teaching.EngagementHooks = slices.Clone(decoded.EngagementHooks)
 	}
 	*topic = Topic(decoded.rawTopic)
 	var presence struct {

--- a/internal/curriculum/validator.go
+++ b/internal/curriculum/validator.go
@@ -1,0 +1,653 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package curriculum
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+func (l *Loader) validate() error {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	for _, id := range sortedKeys(l.syllabi) {
+		syllabus := l.syllabi[id]
+		seen := make(map[string]struct{}, len(syllabus.Subjects))
+		for _, subjectID := range syllabus.Subjects {
+			if _, duplicate := seen[subjectID]; duplicate {
+				return fmt.Errorf("%s: syllabus %q repeats subject %q", sourceName(syllabus.Source, id), id, subjectID)
+			}
+			seen[subjectID] = struct{}{}
+			subject, found := l.subjects[subjectID]
+			if !found {
+				return fmt.Errorf("%s: syllabus %q references missing subject %q", sourceName(syllabus.Source, id), id, subjectID)
+			}
+			if subject.SyllabusID != id {
+				return fmt.Errorf(
+					"%s: syllabus %q lists subject %q owned by syllabus %q",
+					sourceName(syllabus.Source, id),
+					id,
+					subjectID,
+					subject.SyllabusID,
+				)
+			}
+		}
+	}
+	for _, id := range sortedKeys(l.subjects) {
+		subject := l.subjects[id]
+		if _, found := l.syllabi[subject.SyllabusID]; !found {
+			return fmt.Errorf("%s: subject %q references missing syllabus %q", sourceName(subject.Source, id), id, subject.SyllabusID)
+		}
+		if !contains(l.syllabi[subject.SyllabusID].Subjects, id) {
+			return fmt.Errorf("%s: subject %q is not listed by syllabus %q", sourceName(subject.Source, id), id, subject.SyllabusID)
+		}
+	}
+	for _, id := range sortedKeys(l.subjectGrades) {
+		subjectGrade := l.subjectGrades[id]
+		if _, found := l.syllabi[subjectGrade.SyllabusID]; !found {
+			return fmt.Errorf("%s: subject grade %q references missing syllabus %q", sourceName(subjectGrade.Source, id), id, subjectGrade.SyllabusID)
+		}
+		subject, found := l.subjects[subjectGrade.SubjectID]
+		if !found {
+			return fmt.Errorf("%s: subject grade %q references missing subject %q", sourceName(subjectGrade.Source, id), id, subjectGrade.SubjectID)
+		}
+		if subject.SyllabusID != subjectGrade.SyllabusID {
+			return fmt.Errorf(
+				"%s: subject grade %q syllabus %q does not match subject %q syllabus %q",
+				sourceName(subjectGrade.Source, id),
+				id,
+				subjectGrade.SyllabusID,
+				subjectGrade.SubjectID,
+				subject.SyllabusID,
+			)
+		}
+		seen := make(map[string]struct{}, len(subjectGrade.Topics))
+		for _, topicID := range subjectGrade.Topics {
+			if _, duplicate := seen[topicID]; duplicate {
+				return fmt.Errorf("%s: subject grade %q repeats topic %q", sourceName(subjectGrade.Source, id), id, topicID)
+			}
+			seen[topicID] = struct{}{}
+			topic, found := l.topics[topicID]
+			if !found {
+				return fmt.Errorf("%s: subject grade %q references missing topic %q", sourceName(subjectGrade.Source, id), id, topicID)
+			}
+			if topic.SubjectGradeID != id {
+				return fmt.Errorf("%s: topic %q declares subject grade %q, want %q", sourceName(topic.Source, topic.ID), topic.ID, topic.SubjectGradeID, id)
+			}
+		}
+	}
+	for _, id := range sortedKeys(l.concepts) {
+		if err := l.validateConcept(l.concepts[id]); err != nil {
+			return err
+		}
+	}
+	for _, id := range sortedKeys(l.topics) {
+		if err := l.validateTopic(l.topics[id]); err != nil {
+			return err
+		}
+	}
+	if err := l.validateRequiredPrerequisiteGraph(); err != nil {
+		return err
+	}
+	for _, topicID := range sortedKeys(l.assessments) {
+		if err := l.validateAssessment(l.assessments[topicID]); err != nil {
+			return err
+		}
+	}
+	for _, topicID := range sortedKeys(l.examples) {
+		if err := l.validateExamples(l.examples[topicID]); err != nil {
+			return err
+		}
+	}
+	for _, topicID := range sortedKeys(l.exampleVariants) {
+		canonical, found := l.examples[topicID]
+		if !found {
+			variants := l.exampleVariants[topicID]
+			for _, locale := range sortedKeys(variants) {
+				return fmt.Errorf(
+					"%s: example variant references missing canonical examples for topic %q",
+					sourceName(variants[locale].Source, topicID),
+					topicID,
+				)
+			}
+		}
+		for _, locale := range sortedKeys(l.exampleVariants[topicID]) {
+			variant := l.exampleVariants[topicID][locale]
+			if err := l.validateExamples(variant); err != nil {
+				return err
+			}
+			if err := validateExamplesVariant(canonical, locale, variant); err != nil {
+				return err
+			}
+		}
+	}
+	for _, topicID := range sortedKeys(l.topicVariants) {
+		canonical, found := l.topics[topicID]
+		if !found {
+			variants := l.topicVariants[topicID]
+			for _, locale := range sortedKeys(variants) {
+				return fmt.Errorf("%s: topic variant references missing canonical topic %q", sourceName(variants[locale].Source, topicID), topicID)
+			}
+		}
+		for _, locale := range sortedKeys(l.topicVariants[topicID]) {
+			if err := validateTopicVariant(canonical, locale, l.topicVariants[topicID][locale]); err != nil {
+				return err
+			}
+		}
+	}
+	for _, topicID := range sortedKeys(l.assessmentVariants) {
+		canonical, found := l.assessments[topicID]
+		if !found {
+			variants := l.assessmentVariants[topicID]
+			for _, locale := range sortedKeys(variants) {
+				return fmt.Errorf("%s: assessment variant references missing canonical assessment for topic %q", sourceName(variants[locale].Source, topicID), topicID)
+			}
+		}
+		for _, locale := range sortedKeys(l.assessmentVariants[topicID]) {
+			if err := validateAssessmentVariant(canonical, locale, l.assessmentVariants[topicID][locale]); err != nil {
+				return err
+			}
+		}
+	}
+	for topicID := range l.teachingNotes {
+		if _, found := l.topics[topicID]; !found {
+			return fmt.Errorf("teaching notes reference missing topic %q", topicID)
+		}
+	}
+	for topicID := range l.teachingNoteVariants {
+		if _, found := l.topics[topicID]; !found {
+			return fmt.Errorf("teaching note variants reference missing topic %q", topicID)
+		}
+	}
+	return nil
+}
+
+func validateExamplesVariant(canonical ExampleSet, locale string, variant ExampleSet) error {
+	source := sourceName(variant.Source, variant.TopicID)
+	if variant.Source.Locale != locale {
+		return fmt.Errorf("%s: example variant locale does not match %q", source, locale)
+	}
+	canonicalByID := make(map[string]WorkedExample, len(canonical.WorkedExamples))
+	for _, example := range canonical.WorkedExamples {
+		canonicalByID[example.ID] = example
+	}
+	for _, example := range variant.WorkedExamples {
+		canonicalExample, found := canonicalByID[example.ID]
+		if !found {
+			return fmt.Errorf(
+				"%s: worked example %q has no canonical worked example",
+				source,
+				example.ID,
+			)
+		}
+		if example.LearningObjective != canonicalExample.LearningObjective {
+			return fmt.Errorf(
+				"%s: worked example %q changes canonical objective identity",
+				source,
+				example.ID,
+			)
+		}
+	}
+	if len(variant.WorkedExamples) != len(canonical.WorkedExamples) {
+		return fmt.Errorf(
+			"%s: example variant has %d worked examples, want canonical %d",
+			source,
+			len(variant.WorkedExamples),
+			len(canonical.WorkedExamples),
+		)
+	}
+	return nil
+}
+
+func (l *Loader) validateExamples(examples ExampleSet) error {
+	source := sourceName(examples.Source, examples.TopicID)
+	topic, found := l.topics[examples.TopicID]
+	if !found {
+		return fmt.Errorf("%s: examples reference missing topic %q", source, examples.TopicID)
+	}
+	objectives := make(map[string]struct{}, len(topic.LearningObjectives))
+	for _, objective := range topic.LearningObjectives {
+		objectives[objective.ID] = struct{}{}
+	}
+	seen := make(map[string]struct{}, len(examples.WorkedExamples))
+	for _, example := range examples.WorkedExamples {
+		if strings.TrimSpace(example.ID) == "" {
+			return fmt.Errorf("%s: worked example requires id", source)
+		}
+		if _, duplicate := seen[example.ID]; duplicate {
+			return fmt.Errorf("%s: example set repeats worked example %q", source, example.ID)
+		}
+		seen[example.ID] = struct{}{}
+		if strings.TrimSpace(example.Topic) == "" {
+			return fmt.Errorf("%s: worked example %q requires topic", source, example.ID)
+		}
+		if !isWorkedExampleDifficulty(example.Difficulty) {
+			return fmt.Errorf("%s: worked example %q has invalid difficulty %q", source, example.ID, example.Difficulty)
+		}
+		if example.TPLevel < 0 || example.TPLevel > 6 {
+			return fmt.Errorf("%s: worked example %q has invalid tp_level %d", source, example.ID, example.TPLevel)
+		}
+		for field, value := range map[string]string{
+			"misconception_alert": example.MisconceptionAlert,
+			"scenario":            example.Scenario,
+			"working":             example.Working,
+		} {
+			if strings.TrimSpace(value) == "" {
+				return fmt.Errorf("%s: worked example %q requires %s", source, example.ID, field)
+			}
+		}
+		if example.LearningObjective != "" {
+			if _, found := objectives[example.LearningObjective]; !found {
+				return fmt.Errorf(
+					"%s: worked example %q references missing objective %q",
+					source,
+					example.ID,
+					example.LearningObjective,
+				)
+			}
+		}
+	}
+	return nil
+}
+
+func (l *Loader) validateTopic(topic Topic) error {
+	source := sourceName(topic.Source, topic.ID)
+	if strings.TrimSpace(topic.Name) == "" && strings.TrimSpace(topic.NameEN) == "" {
+		return fmt.Errorf("%s: topic %q requires name or name_en", source, topic.ID)
+	}
+	if topic.SyllabusID == "" || topic.SubjectID == "" || topic.SubjectGradeID == "" {
+		return fmt.Errorf("%s: topic %q requires syllabus_id, subject_id, and subject_grade_id", source, topic.ID)
+	}
+	if _, found := l.syllabi[topic.SyllabusID]; !found {
+		return fmt.Errorf("%s: topic %q references missing syllabus %q", source, topic.ID, topic.SyllabusID)
+	}
+	if _, found := l.subjects[topic.SubjectID]; !found {
+		return fmt.Errorf("%s: topic %q references missing subject %q", source, topic.ID, topic.SubjectID)
+	}
+	subjectGrade, found := l.subjectGrades[topic.SubjectGradeID]
+	if !found {
+		return fmt.Errorf("%s: topic %q references missing subject grade %q", source, topic.ID, topic.SubjectGradeID)
+	}
+	if subjectGrade.SyllabusID != topic.SyllabusID || subjectGrade.SubjectID != topic.SubjectID {
+		return fmt.Errorf("%s: topic %q does not match subject grade %q scope", source, topic.ID, topic.SubjectGradeID)
+	}
+	if !contains(subjectGrade.Topics, topic.ID) {
+		return fmt.Errorf("%s: topic %q is not listed by subject grade %q", source, topic.ID, topic.SubjectGradeID)
+	}
+	if topic.Mastery.MinimumScore < 0 || topic.Mastery.MinimumScore > 1 ||
+		topic.Mastery.AssessmentCount < 0 ||
+		(topic.Mastery.assessmentSet && topic.Mastery.AssessmentCount == 0) {
+		return fmt.Errorf("%s: topic %q has invalid mastery policy", source, topic.ID)
+	}
+	catalogStub := topic.qualityLevelSet &&
+		topic.QualityLevel == 0 &&
+		len(topic.ContentStandards) == 0 &&
+		len(topic.LearningObjectives) == 0
+	if len(topic.ContentStandards) == 0 && !catalogStub {
+		return fmt.Errorf("%s: topic %q requires content standards", source, topic.ID)
+	}
+	if len(topic.LearningObjectives) == 0 && !catalogStub {
+		return fmt.Errorf("%s: topic %q requires learning objectives", source, topic.ID)
+	}
+
+	standards := make(map[string]struct{}, len(topic.ContentStandards))
+	for _, standard := range topic.ContentStandards {
+		if standard.ID == "" {
+			return fmt.Errorf("%s: topic %q has content standard without ID", source, topic.ID)
+		}
+		if _, duplicate := standards[standard.ID]; duplicate {
+			return fmt.Errorf("%s: topic %q repeats content standard %q", source, topic.ID, standard.ID)
+		}
+		standards[standard.ID] = struct{}{}
+	}
+	objectives := make(map[string]struct{}, len(topic.LearningObjectives))
+	for _, objective := range topic.LearningObjectives {
+		if objective.ID == "" {
+			return fmt.Errorf("%s: topic %q has learning objective without ID", source, topic.ID)
+		}
+		if _, duplicate := objectives[objective.ID]; duplicate {
+			return fmt.Errorf("%s: topic %q repeats learning objective %q", source, topic.ID, objective.ID)
+		}
+		objectives[objective.ID] = struct{}{}
+		if strings.TrimSpace(objective.Text) == "" && strings.TrimSpace(objective.TextEN) == "" {
+			return fmt.Errorf("%s: objective %q requires text or text_en", source, objective.ID)
+		}
+		if objective.ContentStandardID != "" {
+			if _, found := standards[objective.ContentStandardID]; !found {
+				return fmt.Errorf("%s: objective %q references missing content standard %q", source, objective.ID, objective.ContentStandardID)
+			}
+		}
+	}
+	for _, prerequisiteRefs := range [][]PrerequisiteRef{topic.Prerequisites.Required, topic.Prerequisites.Recommended} {
+		for _, prerequisiteRef := range prerequisiteRefs {
+			if prerequisiteRef.TopicID == "" {
+				return fmt.Errorf("%s: topic %q has prerequisite without topic ID", source, topic.ID)
+			}
+			if _, found := l.topics[prerequisiteRef.TopicID]; !found {
+				return fmt.Errorf("%s: topic %q references missing prerequisite %q", source, topic.ID, prerequisiteRef.TopicID)
+			}
+		}
+	}
+	seenCrossCurriculum := make(map[string]struct{}, len(topic.CrossCurriculum))
+	for _, link := range topic.CrossCurriculum {
+		key := link.ConceptID + "\x00" + link.SyllabusID + "\x00" + link.TopicID
+		if _, duplicate := seenCrossCurriculum[key]; duplicate {
+			return fmt.Errorf("%s: topic %q repeats cross-curriculum edge to %q", source, topic.ID, link.TopicID)
+		}
+		seenCrossCurriculum[key] = struct{}{}
+		if link.SyllabusID == topic.SyllabusID {
+			return fmt.Errorf("%s: topic %q cross-curriculum edge must target another syllabus", source, topic.ID)
+		}
+		concept, found := l.concepts[link.ConceptID]
+		if !found {
+			return fmt.Errorf("%s: topic %q references missing concept %q", source, topic.ID, link.ConceptID)
+		}
+		linkedTopic, found := l.topics[link.TopicID]
+		if !found {
+			return fmt.Errorf("%s: topic %q cross-curriculum edge references missing topic %q", source, topic.ID, link.TopicID)
+		}
+		if linkedTopic.SyllabusID != link.SyllabusID {
+			return fmt.Errorf("%s: cross-curriculum topic %q does not belong to syllabus %q", source, link.TopicID, link.SyllabusID)
+		}
+		if !conceptIncludes(concept, topic.SyllabusID, topic.ID) {
+			return fmt.Errorf("%s: concept %q does not declare source topic %q", source, link.ConceptID, topic.ID)
+		}
+		if !conceptIncludes(concept, link.SyllabusID, link.TopicID) {
+			return fmt.Errorf("%s: concept %q does not declare topic %q in syllabus %q", source, link.ConceptID, link.TopicID, link.SyllabusID)
+		}
+	}
+	if topic.IsAITeachingReady() {
+		if _, found := l.teachingNotes[topic.ID]; !found {
+			return fmt.Errorf("%s: AI-teaching-ready topic %q requires canonical teaching notes", source, topic.ID)
+		}
+		if _, found := l.examples[topic.ID]; !found {
+			return fmt.Errorf("%s: AI-teaching-ready topic %q requires canonical examples", source, topic.ID)
+		}
+		if _, found := l.assessments[topic.ID]; !found {
+			return fmt.Errorf("%s: AI-teaching-ready topic %q requires canonical assessment", source, topic.ID)
+		}
+	}
+	return nil
+}
+
+func (l *Loader) validateConcept(concept Concept) error {
+	source := sourceName(concept.Source, concept.ID)
+	if strings.TrimSpace(concept.Name) == "" ||
+		strings.TrimSpace(concept.Domain) == "" ||
+		strings.TrimSpace(concept.Subdomain) == "" ||
+		strings.TrimSpace(concept.Definition) == "" ||
+		len(concept.Curricula) == 0 {
+		return fmt.Errorf("%s: concept %q is incomplete", source, concept.ID)
+	}
+	seen := make(map[string]struct{}, len(concept.Curricula))
+	for _, occurrence := range concept.Curricula {
+		if strings.TrimSpace(occurrence.SyllabusID) == "" ||
+			strings.TrimSpace(occurrence.TopicID) == "" ||
+			strings.TrimSpace(occurrence.Scope) == "" {
+			return fmt.Errorf("%s: concept %q has incomplete curriculum occurrence", source, concept.ID)
+		}
+		key := occurrence.SyllabusID + "\x00" + occurrence.TopicID
+		if _, duplicate := seen[key]; duplicate {
+			return fmt.Errorf("%s: concept %q repeats curriculum topic %q", source, concept.ID, occurrence.TopicID)
+		}
+		seen[key] = struct{}{}
+		topic, found := l.topics[occurrence.TopicID]
+		if !found {
+			return fmt.Errorf("%s: concept %q references missing topic %q", source, concept.ID, occurrence.TopicID)
+		}
+		if topic.SyllabusID != occurrence.SyllabusID {
+			return fmt.Errorf(
+				"%s: concept %q topic %q does not belong to syllabus %q",
+				source,
+				concept.ID,
+				occurrence.TopicID,
+				occurrence.SyllabusID,
+			)
+		}
+	}
+	return nil
+}
+
+func (l *Loader) validateAssessment(assessment Assessment) error {
+	source := sourceName(assessment.Source, assessment.TopicID)
+	topic, found := l.topics[assessment.TopicID]
+	if !found {
+		return fmt.Errorf("%s: assessment references missing topic %q", source, assessment.TopicID)
+	}
+	objectives := make(map[string]struct{}, len(topic.LearningObjectives))
+	for _, objective := range topic.LearningObjectives {
+		objectives[objective.ID] = struct{}{}
+	}
+	questions := make(map[string]struct{}, len(assessment.Questions))
+	for _, question := range assessment.Questions {
+		if question.ID == "" {
+			return fmt.Errorf("%s: assessment has question without ID", source)
+		}
+		if _, duplicate := questions[question.ID]; duplicate {
+			return fmt.Errorf("%s: assessment repeats question %q", source, question.ID)
+		}
+		questions[question.ID] = struct{}{}
+		if strings.TrimSpace(question.Text) == "" {
+			return fmt.Errorf("%s: question %q requires text", source, question.ID)
+		}
+		if !isAssessmentDifficulty(question.Difficulty) {
+			return fmt.Errorf("%s: question %q has invalid difficulty %q", source, question.ID, question.Difficulty)
+		}
+		if question.marksSet && question.Marks < 1 {
+			return fmt.Errorf("%s: question %q requires positive marks", source, question.ID)
+		}
+		if !isAssessmentAnswerType(question.Answer.Type) {
+			return fmt.Errorf("%s: question %q has unsupported answer type %q", source, question.ID, question.Answer.Type)
+		}
+		if _, found := objectives[question.LearningObjective]; !found {
+			return fmt.Errorf("%s: question %q references missing objective %q", source, question.ID, question.LearningObjective)
+		}
+		if question.Answer.Type == "exact" && strings.TrimSpace(question.Answer.Value) == "" {
+			return fmt.Errorf("%s: exact question %q has no answer value", source, question.ID)
+		}
+		if question.Answer.Type == "multiple_choice" {
+			if strings.TrimSpace(question.Answer.Value) == "" {
+				return fmt.Errorf("%s: multiple-choice question %q has no answer value", source, question.ID)
+			}
+			if len(question.Answer.Options) > 0 &&
+				(len(question.Answer.Options) < 2 || correctOptionID(question) == "") {
+				return fmt.Errorf("%s: multiple-choice question %q has no valid correct option", source, question.ID)
+			}
+		}
+		if question.Answer.Type == "matching" {
+			if len(question.Answer.Pairs) == 0 {
+				return fmt.Errorf("%s: matching question %q has no answer pairs", source, question.ID)
+			}
+			for _, pair := range question.Answer.Pairs {
+				if strings.TrimSpace(pair.Left) == "" || strings.TrimSpace(pair.Right) == "" {
+					return fmt.Errorf("%s: matching question %q has incomplete answer pair", source, question.ID)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func validateTopicVariant(canonical Topic, locale string, variant Topic) error {
+	source := sourceName(variant.Source, variant.ID)
+	if variant.Language != locale || variant.Source.Locale != locale {
+		return fmt.Errorf("%s: topic variant language %q does not match locale %q", source, variant.Language, locale)
+	}
+	for field, values := range map[string][2]string{
+		"syllabus":      {canonical.SyllabusID, variant.SyllabusID},
+		"subject":       {canonical.SubjectID, variant.SubjectID},
+		"subject grade": {canonical.SubjectGradeID, variant.SubjectGradeID},
+	} {
+		if values[1] != "" && values[0] != values[1] {
+			return fmt.Errorf("%s: topic variant %s %q does not match canonical %q", source, field, values[1], values[0])
+		}
+	}
+	canonicalObjectives := make(map[string]struct{}, len(canonical.LearningObjectives))
+	for _, objective := range canonical.LearningObjectives {
+		canonicalObjectives[objective.ID] = struct{}{}
+	}
+	seenObjectives := make(map[string]struct{}, len(variant.LearningObjectives))
+	for _, objective := range variant.LearningObjectives {
+		if _, duplicate := seenObjectives[objective.ID]; duplicate {
+			return fmt.Errorf("%s: topic variant repeats objective %q", source, objective.ID)
+		}
+		seenObjectives[objective.ID] = struct{}{}
+		if strings.TrimSpace(objective.Text) == "" && strings.TrimSpace(objective.TextEN) == "" {
+			return fmt.Errorf("%s: topic variant objective %q requires localized text", source, objective.ID)
+		}
+		if _, found := canonicalObjectives[objective.ID]; !found {
+			return fmt.Errorf("%s: topic variant references missing canonical objective %q", source, objective.ID)
+		}
+	}
+	return nil
+}
+
+func validateAssessmentVariant(canonical Assessment, locale string, variant Assessment) error {
+	source := sourceName(variant.Source, variant.TopicID)
+	if variant.Source.Locale != locale {
+		return fmt.Errorf("%s: assessment variant locale does not match %q", source, locale)
+	}
+	seenQuestions := make(map[string]struct{}, len(variant.Questions))
+	for _, question := range variant.Questions {
+		if _, duplicate := seenQuestions[question.ID]; duplicate {
+			return fmt.Errorf("%s: assessment variant repeats question %q", source, question.ID)
+		}
+		seenQuestions[question.ID] = struct{}{}
+		if strings.TrimSpace(question.Text) == "" ||
+			!isAssessmentDifficulty(question.Difficulty) ||
+			(question.marksSet && question.Marks < 1) ||
+			!isAssessmentAnswerType(question.Answer.Type) {
+			return fmt.Errorf("%s: assessment variant question %q has invalid plan fields", source, question.ID)
+		}
+		canonicalQuestion, found := assessmentQuestion(canonical, question.ID)
+		if !found {
+			return fmt.Errorf("%s: assessment variant question %q has no canonical question", source, question.ID)
+		}
+		if question.LearningObjective != canonicalQuestion.LearningObjective || question.Answer.Type != canonicalQuestion.Answer.Type {
+			return fmt.Errorf("%s: assessment variant question %q changes the canonical grading contract", source, question.ID)
+		}
+		if question.Answer.Type == "exact" && strings.TrimSpace(question.Answer.Value) == "" {
+			return fmt.Errorf("%s: assessment variant exact question %q has no answer value", source, question.ID)
+		}
+		if question.Answer.Type == "multiple_choice" {
+			if !sameKeys(question.Answer.Options, canonicalQuestion.Answer.Options) ||
+				correctOptionID(question) != correctOptionID(canonicalQuestion) {
+				return fmt.Errorf("%s: assessment variant question %q changes canonical option identity", source, question.ID)
+			}
+		}
+	}
+	return nil
+}
+
+func (l *Loader) validateRequiredPrerequisiteGraph() error {
+	state := make(map[string]uint8, len(l.topics))
+	var visit func(string, []string) error
+	visit = func(topicID string, path []string) error {
+		switch state[topicID] {
+		case 1:
+			cycle := append(path, topicID)
+			return fmt.Errorf("%s: required prerequisite cycle: %s", sourceName(l.topics[topicID].Source, topicID), strings.Join(cycle, " -> "))
+		case 2:
+			return nil
+		}
+		state[topicID] = 1
+		for _, prerequisiteRef := range l.topics[topicID].Prerequisites.Required {
+			if err := visit(prerequisiteRef.TopicID, append(path, topicID)); err != nil {
+				return err
+			}
+		}
+		state[topicID] = 2
+		return nil
+	}
+	for _, topicID := range sortedKeys(l.topics) {
+		if err := visit(topicID, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func sortedKeys[V any](values map[string]V) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sourceName(source SourceRef, fallback string) string {
+	if source.Path != "" {
+		return source.Path
+	}
+	return fallback
+}
+
+func contains(values []string, value string) bool {
+	for _, candidate := range values {
+		if candidate == value {
+			return true
+		}
+	}
+	return false
+}
+
+func sameKeys(left, right AssessmentOptions) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for key := range left {
+		if _, found := right[key]; !found {
+			return false
+		}
+	}
+	return true
+}
+
+func conceptIncludes(concept Concept, syllabusID, topicID string) bool {
+	for _, occurrence := range concept.Curricula {
+		if occurrence.SyllabusID == syllabusID && occurrence.TopicID == topicID {
+			return true
+		}
+	}
+	return false
+}
+
+func isAssessmentDifficulty(difficulty string) bool {
+	switch difficulty {
+	case "easy", "medium", "hard":
+		return true
+	default:
+		return false
+	}
+}
+
+func isWorkedExampleDifficulty(difficulty string) bool {
+	switch difficulty {
+	case "easy", "medium", "hard":
+		return true
+	default:
+		return false
+	}
+}
+
+func isAssessmentAnswerType(answerType string) bool {
+	switch answerType {
+	case "exact",
+		"range",
+		"multiple_choice",
+		"true_false",
+		"matching",
+		"free_text",
+		"structured",
+		"structured_response",
+		"subjective",
+		"opb":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/progress/tracker.go
+++ b/internal/progress/tracker.go
@@ -103,11 +103,19 @@ type MasteryEvidenceCount struct {
 // MasterySnapshotItem combines one topic's current score and durable evidence
 // count from the same read boundary.
 type MasterySnapshotItem struct {
-	SyllabusID    string
-	TopicID       string
-	MasteryScore  float64
-	MasteryKnown  bool
-	EvidenceCount int
+	SyllabusID     string
+	TopicID        string
+	MasteryScore   float64
+	MasteryKnown   bool
+	EvidenceCount  int
+	LatestEvidence *MasteryEvidenceSummary
+}
+
+// MasteryEvidenceSummary identifies the latest graded source for a topic.
+type MasteryEvidenceSummary struct {
+	SourceKind string
+	SourceID   string
+	Score      float64
 }
 
 // MasteryEvidenceStore atomically records evidence and reports its coverage.
@@ -137,14 +145,16 @@ func progressKey(userID, syllabusID, topicID string) string {
 
 // MemoryTracker is an in-memory implementation of Tracker for testing and development.
 type MemoryTracker struct {
-	mu       sync.RWMutex
-	items    map[string]*ProgressItem
-	evidence map[string]recordedMasteryEvidence
+	mu               sync.RWMutex
+	items            map[string]*ProgressItem
+	evidence         map[string]recordedMasteryEvidence
+	evidenceSequence uint64
 }
 
 type recordedMasteryEvidence struct {
 	evidence MasteryEvidence
 	result   MasteryEvidenceResult
+	sequence uint64
 }
 
 // NewMemoryTracker creates a new in-memory tracker.
@@ -243,7 +253,12 @@ func (m *MemoryTracker) RecordMasteryEvidence(ctx context.Context, evidence Mast
 		MasteryBefore: before,
 		MasteryAfter:  after,
 	}
-	m.evidence[key] = recordedMasteryEvidence{evidence: evidence, result: result}
+	m.evidenceSequence++
+	m.evidence[key] = recordedMasteryEvidence{
+		evidence: evidence,
+		result:   result,
+		sequence: m.evidenceSequence,
+	}
 	return result, nil
 }
 
@@ -295,6 +310,7 @@ func (m *MemoryTracker) GetMasterySnapshot(ctx context.Context, learnerID Learne
 	defer m.mu.RUnlock()
 
 	items := make(map[string]MasterySnapshotItem)
+	latestSequence := make(map[string]uint64)
 	for _, progressItem := range m.items {
 		if progressItem.UserID != learnerID.String() {
 			continue
@@ -316,6 +332,14 @@ func (m *MemoryTracker) GetMasterySnapshot(ctx context.Context, learnerID Learne
 		item.SyllabusID = recorded.evidence.SyllabusID
 		item.TopicID = recorded.evidence.TopicID
 		item.EvidenceCount++
+		if latestSequence[key] < recorded.sequence {
+			item.LatestEvidence = &MasteryEvidenceSummary{
+				SourceKind: recorded.evidence.SourceKind,
+				SourceID:   recorded.evidence.SourceID,
+				Score:      recorded.evidence.Score,
+			}
+			latestSequence[key] = recorded.sequence
+		}
 		items[key] = item
 	}
 

--- a/internal/progress/tracker.go
+++ b/internal/progress/tracker.go
@@ -4,7 +4,11 @@
 package progress
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"math"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -64,6 +68,54 @@ type LearnerTracker interface {
 	GetDueReviewsForLearner(learnerID LearnerID) ([]ProgressItem, error)
 }
 
+// ErrMasteryEvidenceConflict means an idempotency key was reused for different
+// learner evidence.
+var ErrMasteryEvidenceConflict = errors.New("mastery evidence attempt ID conflicts with an existing attempt")
+
+// MasteryEvidence is one gradeable observation that may update mastery once.
+type MasteryEvidence struct {
+	AttemptID      string
+	LearnerID      LearnerID
+	SyllabusID     string
+	TopicID        string
+	SourceKind     string
+	SourceID       string
+	SourceRevision string
+	Score          float64
+	PayloadHash    [32]byte
+}
+
+// MasteryEvidenceResult describes the stable transition produced by evidence.
+// Applied is false when the exact attempt was already recorded.
+type MasteryEvidenceResult struct {
+	Applied       bool
+	MasteryBefore float64
+	MasteryAfter  float64
+}
+
+// MasteryEvidenceCount is the number of distinct recorded attempts for a topic.
+type MasteryEvidenceCount struct {
+	SyllabusID string
+	TopicID    string
+	Count      int
+}
+
+// MasterySnapshotItem combines one topic's current score and durable evidence
+// count from the same read boundary.
+type MasterySnapshotItem struct {
+	SyllabusID    string
+	TopicID       string
+	MasteryScore  float64
+	MasteryKnown  bool
+	EvidenceCount int
+}
+
+// MasteryEvidenceStore atomically records evidence and reports its coverage.
+type MasteryEvidenceStore interface {
+	RecordMasteryEvidence(context.Context, MasteryEvidence) (MasteryEvidenceResult, error)
+	GetMasteryEvidenceCounts(context.Context, LearnerID) ([]MasteryEvidenceCount, error)
+}
+
 // IsMastered returns true if the score meets or exceeds MasteryThreshold.
 func IsMastered(score float64) bool {
 	return score >= MasteryThreshold
@@ -85,61 +137,246 @@ func progressKey(userID, syllabusID, topicID string) string {
 
 // MemoryTracker is an in-memory implementation of Tracker for testing and development.
 type MemoryTracker struct {
-	mu    sync.RWMutex
-	items map[string]*ProgressItem
+	mu       sync.RWMutex
+	items    map[string]*ProgressItem
+	evidence map[string]recordedMasteryEvidence
+}
+
+type recordedMasteryEvidence struct {
+	evidence MasteryEvidence
+	result   MasteryEvidenceResult
 }
 
 // NewMemoryTracker creates a new in-memory tracker.
 func NewMemoryTracker() *MemoryTracker {
 	return &MemoryTracker{
-		items: make(map[string]*ProgressItem),
+		items:    make(map[string]*ProgressItem),
+		evidence: make(map[string]recordedMasteryEvidence),
 	}
 }
 
 func (m *MemoryTracker) UpdateMastery(userID, syllabusID, topicID string, delta float64) error {
-	delta = clamp(delta, 0.0, 1.0)
-
 	m.mu.Lock()
 	defer m.mu.Unlock()
-
-	key := progressKey(userID, syllabusID, topicID)
-	item, exists := m.items[key]
-	now := time.Now()
-
-	if !exists {
-		// Seed on first update: set score directly to delta.
-		quality := DeltaToQuality(delta)
-		sm2 := SM2Calculate(quality, 0, 2.5, 1)
-		m.items[key] = &ProgressItem{
-			UserID:       userID,
-			SyllabusID:   syllabusID,
-			TopicID:      topicID,
-			MasteryScore: delta,
-			EaseFactor:   sm2.EaseFactor,
-			IntervalDays: sm2.IntervalDays,
-			Repetitions:  sm2.Repetitions,
-			NextReviewAt: now.Add(time.Duration(sm2.IntervalDays*24) * time.Hour),
-			LastStudied:  now,
-		}
-		return nil
-	}
-
-	// Weighted blend on subsequent updates.
-	item.MasteryScore = clamp(item.MasteryScore*0.7+delta*0.3, 0.0, 1.0)
-
-	quality := DeltaToQuality(delta)
-	sm2 := SM2Calculate(quality, item.Repetitions, item.EaseFactor, item.IntervalDays)
-	item.EaseFactor = sm2.EaseFactor
-	item.IntervalDays = sm2.IntervalDays
-	item.Repetitions = sm2.Repetitions
-	item.LastStudied = now
-	item.NextReviewAt = now.Add(time.Duration(sm2.IntervalDays*24) * time.Hour)
-
+	m.updateMasteryLocked(userID, syllabusID, topicID, delta, time.Now())
 	return nil
+}
+
+func (m *MemoryTracker) updateMasteryLocked(userID, syllabusID, topicID string, delta float64, now time.Time) (float64, float64) {
+	key := progressKey(userID, syllabusID, topicID)
+	var existing *ProgressItem
+	if item, found := m.items[key]; found {
+		existing = item
+	}
+	before, next := calculateMasteryTransition(userID, syllabusID, topicID, delta, existing, now)
+	m.items[key] = &next
+	return before, next.MasteryScore
+}
+
+func calculateMasteryTransition(userID, syllabusID, topicID string, delta float64, existing *ProgressItem, now time.Time) (float64, ProgressItem) {
+	delta = clamp(delta, 0.0, 1.0)
+	before := 0.0
+	repetitions := 0
+	easeFactor := 2.5
+	intervalDays := 1
+	score := delta
+	if existing != nil {
+		before = existing.MasteryScore
+		repetitions = existing.Repetitions
+		easeFactor = existing.EaseFactor
+		intervalDays = existing.IntervalDays
+		score = clamp(before*0.7+delta*0.3, 0.0, 1.0)
+	}
+	quality := DeltaToQuality(delta)
+	sm2 := SM2Calculate(quality, repetitions, easeFactor, intervalDays)
+	return before, ProgressItem{
+		UserID:       userID,
+		SyllabusID:   syllabusID,
+		TopicID:      topicID,
+		MasteryScore: score,
+		EaseFactor:   sm2.EaseFactor,
+		IntervalDays: sm2.IntervalDays,
+		Repetitions:  sm2.Repetitions,
+		NextReviewAt: now.Add(time.Duration(sm2.IntervalDays*24) * time.Hour),
+		LastStudied:  now,
+	}
 }
 
 func (m *MemoryTracker) UpdateMasteryForLearner(learnerID LearnerID, syllabusID, topicID string, delta float64) error {
 	return m.UpdateMastery(learnerID.String(), syllabusID, topicID, delta)
+}
+
+// RecordMasteryEvidence records one idempotent mastery transition.
+func (m *MemoryTracker) RecordMasteryEvidence(ctx context.Context, evidence MasteryEvidence) (MasteryEvidenceResult, error) {
+	if err := ctx.Err(); err != nil {
+		return MasteryEvidenceResult{}, err
+	}
+	evidence, err := validateMasteryEvidence(evidence)
+	if err != nil {
+		return MasteryEvidenceResult{}, err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.evidence == nil {
+		m.evidence = make(map[string]recordedMasteryEvidence)
+	}
+	key := evidence.LearnerID.String() + "\x00" + evidence.AttemptID
+	if recorded, found := m.evidence[key]; found {
+		if !sameMasteryEvidence(recorded.evidence, evidence) {
+			return MasteryEvidenceResult{}, ErrMasteryEvidenceConflict
+		}
+		replay := recorded.result
+		replay.Applied = false
+		return replay, nil
+	}
+
+	before, after := m.updateMasteryLocked(
+		evidence.LearnerID.String(),
+		evidence.SyllabusID,
+		evidence.TopicID,
+		evidence.Score,
+		time.Now(),
+	)
+	result := MasteryEvidenceResult{
+		Applied:       true,
+		MasteryBefore: before,
+		MasteryAfter:  after,
+	}
+	m.evidence[key] = recordedMasteryEvidence{evidence: evidence, result: result}
+	return result, nil
+}
+
+// GetMasteryEvidenceCounts returns distinct recorded attempts grouped by topic.
+func (m *MemoryTracker) GetMasteryEvidenceCounts(ctx context.Context, learnerID LearnerID) ([]MasteryEvidenceCount, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if learnerID.String() == "" {
+		return nil, fmt.Errorf("mastery evidence learner ID is required")
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	counts := make(map[string]MasteryEvidenceCount)
+	for _, recorded := range m.evidence {
+		if recorded.evidence.LearnerID.String() != learnerID.String() {
+			continue
+		}
+		key := progressKey("", recorded.evidence.SyllabusID, recorded.evidence.TopicID)
+		count := counts[key]
+		count.SyllabusID = recorded.evidence.SyllabusID
+		count.TopicID = recorded.evidence.TopicID
+		count.Count++
+		counts[key] = count
+	}
+	result := make([]MasteryEvidenceCount, 0, len(counts))
+	for _, count := range counts {
+		result = append(result, count)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].SyllabusID == result[j].SyllabusID {
+			return result[i].TopicID < result[j].TopicID
+		}
+		return result[i].SyllabusID < result[j].SyllabusID
+	})
+	return result, nil
+}
+
+// GetMasterySnapshot returns scores and evidence counts under one read lock.
+func (m *MemoryTracker) GetMasterySnapshot(ctx context.Context, learnerID LearnerID) ([]MasterySnapshotItem, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if learnerID.String() == "" {
+		return nil, fmt.Errorf("mastery snapshot learner ID is required")
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	items := make(map[string]MasterySnapshotItem)
+	for _, progressItem := range m.items {
+		if progressItem.UserID != learnerID.String() {
+			continue
+		}
+		key := progressKey("", progressItem.SyllabusID, progressItem.TopicID)
+		items[key] = MasterySnapshotItem{
+			SyllabusID:   progressItem.SyllabusID,
+			TopicID:      progressItem.TopicID,
+			MasteryScore: progressItem.MasteryScore,
+			MasteryKnown: true,
+		}
+	}
+	for _, recorded := range m.evidence {
+		if recorded.evidence.LearnerID.String() != learnerID.String() {
+			continue
+		}
+		key := progressKey("", recorded.evidence.SyllabusID, recorded.evidence.TopicID)
+		item := items[key]
+		item.SyllabusID = recorded.evidence.SyllabusID
+		item.TopicID = recorded.evidence.TopicID
+		item.EvidenceCount++
+		items[key] = item
+	}
+
+	result := make([]MasterySnapshotItem, 0, len(items))
+	for _, item := range items {
+		result = append(result, item)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].SyllabusID == result[j].SyllabusID {
+			return result[i].TopicID < result[j].TopicID
+		}
+		return result[i].SyllabusID < result[j].SyllabusID
+	})
+	return result, nil
+}
+
+func validateMasteryEvidence(evidence MasteryEvidence) (MasteryEvidence, error) {
+	evidence.AttemptID = strings.TrimSpace(evidence.AttemptID)
+	evidence.SyllabusID = strings.TrimSpace(evidence.SyllabusID)
+	evidence.TopicID = strings.TrimSpace(evidence.TopicID)
+	evidence.SourceKind = strings.TrimSpace(evidence.SourceKind)
+	evidence.SourceID = strings.TrimSpace(evidence.SourceID)
+	evidence.SourceRevision = strings.TrimSpace(evidence.SourceRevision)
+	switch {
+	case evidence.AttemptID == "":
+		return MasteryEvidence{}, fmt.Errorf("mastery evidence attempt ID is required")
+	case len(evidence.AttemptID) > 256:
+		return MasteryEvidence{}, fmt.Errorf("mastery evidence attempt ID must not exceed 256 bytes")
+	case evidence.LearnerID.String() == "":
+		return MasteryEvidence{}, fmt.Errorf("mastery evidence learner ID is required")
+	case evidence.SyllabusID == "":
+		return MasteryEvidence{}, fmt.Errorf("mastery evidence syllabus ID is required")
+	case evidence.TopicID == "":
+		return MasteryEvidence{}, fmt.Errorf("mastery evidence topic ID is required")
+	case evidence.SourceKind == "":
+		return MasteryEvidence{}, fmt.Errorf("mastery evidence source kind is required")
+	case evidence.SourceID == "":
+		return MasteryEvidence{}, fmt.Errorf("mastery evidence source ID is required")
+	case evidence.SourceRevision == "":
+		return MasteryEvidence{}, fmt.Errorf("mastery evidence source revision is required")
+	case len(evidence.SourceRevision) > 256:
+		return MasteryEvidence{}, fmt.Errorf("mastery evidence source revision must not exceed 256 bytes")
+	case evidence.PayloadHash == [32]byte{}:
+		return MasteryEvidence{}, fmt.Errorf("mastery evidence payload hash is required")
+	case math.IsNaN(evidence.Score), math.IsInf(evidence.Score, 0), evidence.Score < 0, evidence.Score > 1:
+		return MasteryEvidence{}, fmt.Errorf("mastery evidence score must be between 0 and 1")
+	default:
+		return evidence, nil
+	}
+}
+
+func sameMasteryEvidence(left, right MasteryEvidence) bool {
+	return left.AttemptID == right.AttemptID &&
+		left.LearnerID.String() == right.LearnerID.String() &&
+		left.SyllabusID == right.SyllabusID &&
+		left.TopicID == right.TopicID &&
+		left.SourceKind == right.SourceKind &&
+		left.SourceID == right.SourceID &&
+		left.SourceRevision == right.SourceRevision &&
+		left.Score == right.Score &&
+		left.PayloadHash == right.PayloadHash
 }
 
 func (m *MemoryTracker) GetMastery(userID, syllabusID, topicID string) (float64, error) {

--- a/internal/progress/tracker_postgres.go
+++ b/internal/progress/tracker_postgres.go
@@ -5,6 +5,7 @@ package progress
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -115,6 +116,300 @@ func (p *PostgresTracker) UpdateMasteryForLearner(learnerID LearnerID, syllabusI
 		learnerID.String(), p.tenantID, topicID, score,
 	)
 	return err
+}
+
+// RecordMasteryEvidence atomically deduplicates one attempt, updates mastery,
+// and records the daily snapshot.
+func (p *PostgresTracker) RecordMasteryEvidence(ctx context.Context, evidence MasteryEvidence) (MasteryEvidenceResult, error) {
+	evidence, err := validateMasteryEvidence(evidence)
+	if err != nil {
+		return MasteryEvidenceResult{}, err
+	}
+	ctx, cancel := context.WithTimeout(ctx, dbTimeout)
+	defer cancel()
+
+	tx, err := p.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return MasteryEvidenceResult{}, err
+	}
+	defer func() {
+		_ = tx.Rollback(context.Background())
+	}()
+
+	attemptLock := strings.Join([]string{p.tenantID, evidence.LearnerID.String(), evidence.AttemptID}, "\x1f")
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`, attemptLock); err != nil {
+		return MasteryEvidenceResult{}, fmt.Errorf("lock mastery attempt: %w", err)
+	}
+
+	recorded, found, err := loadMasteryEvidence(ctx, tx, p.tenantID, evidence.LearnerID, evidence.AttemptID)
+	if err != nil {
+		return MasteryEvidenceResult{}, err
+	}
+	if found {
+		if !sameMasteryEvidence(recorded.evidence, evidence) {
+			return MasteryEvidenceResult{}, ErrMasteryEvidenceConflict
+		}
+		result := recorded.result
+		result.Applied = false
+		return result, nil
+	}
+
+	var learnerExists bool
+	if err := tx.QueryRow(ctx,
+		`SELECT EXISTS (
+			SELECT 1
+			FROM users
+			WHERE id = $1::uuid
+			  AND tenant_id = $2::uuid
+		)`,
+		evidence.LearnerID.String(), p.tenantID,
+	).Scan(&learnerExists); err != nil {
+		return MasteryEvidenceResult{}, fmt.Errorf("validate mastery learner: %w", err)
+	}
+	if !learnerExists {
+		return MasteryEvidenceResult{}, fmt.Errorf("learner %q does not belong to tracker tenant", evidence.LearnerID.String())
+	}
+
+	topicLock := strings.Join([]string{
+		p.tenantID,
+		evidence.LearnerID.String(),
+		evidence.SyllabusID,
+		evidence.TopicID,
+	}, "\x1f")
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended($1, 1))`, topicLock); err != nil {
+		return MasteryEvidenceResult{}, fmt.Errorf("lock mastery topic: %w", err)
+	}
+
+	var existing ProgressItem
+	found = true
+	err = tx.QueryRow(ctx,
+		`SELECT mastery_score, ease_factor, interval_days, repetitions
+		 FROM learning_progress
+		 WHERE user_id = $1::uuid
+		   AND tenant_id = $2::uuid
+		   AND syllabus_id = $3
+		   AND topic_id = $4
+		 FOR UPDATE`,
+		evidence.LearnerID.String(), p.tenantID, evidence.SyllabusID, evidence.TopicID,
+	).Scan(&existing.MasteryScore, &existing.EaseFactor, &existing.IntervalDays, &existing.Repetitions)
+	if err == pgx.ErrNoRows {
+		found = false
+	} else if err != nil {
+		return MasteryEvidenceResult{}, fmt.Errorf("read mastery transition: %w", err)
+	}
+
+	var previous *ProgressItem
+	if found {
+		previous = &existing
+	}
+	now := time.Now()
+	before, next := calculateMasteryTransition(
+		evidence.LearnerID.String(),
+		evidence.SyllabusID,
+		evidence.TopicID,
+		evidence.Score,
+		previous,
+		now,
+	)
+
+	tag, err := tx.Exec(ctx,
+		`INSERT INTO learning_progress (
+			user_id, tenant_id, syllabus_id, topic_id, mastery_score,
+			ease_factor, interval_days, repetitions, next_review_at, last_studied_at
+		)
+		 VALUES ($1::uuid, $2::uuid, $3, $4, $5, $6, $7, $8, $9, $10)
+		 ON CONFLICT (user_id, syllabus_id, topic_id)
+		 DO UPDATE SET
+			mastery_score = EXCLUDED.mastery_score,
+			ease_factor = EXCLUDED.ease_factor,
+			interval_days = EXCLUDED.interval_days,
+			repetitions = EXCLUDED.repetitions,
+			next_review_at = EXCLUDED.next_review_at,
+			last_studied_at = EXCLUDED.last_studied_at,
+			updated_at = NOW()
+		 WHERE learning_progress.tenant_id = EXCLUDED.tenant_id`,
+		evidence.LearnerID.String(), p.tenantID, evidence.SyllabusID, evidence.TopicID,
+		next.MasteryScore, next.EaseFactor, next.IntervalDays, next.Repetitions,
+		next.NextReviewAt, next.LastStudied,
+	)
+	if err != nil {
+		return MasteryEvidenceResult{}, fmt.Errorf("write mastery transition: %w", err)
+	}
+	if tag.RowsAffected() != 1 {
+		return MasteryEvidenceResult{}, fmt.Errorf("write mastery transition: tenant scope mismatch")
+	}
+
+	tag, err = tx.Exec(ctx,
+		`INSERT INTO mastery_snapshots (user_id, tenant_id, topic_id, mastery_score, snapshot_date)
+		 VALUES ($1::uuid, $2::uuid, $3, $4, CURRENT_DATE)
+		 ON CONFLICT (user_id, topic_id, snapshot_date)
+		 DO UPDATE SET mastery_score = EXCLUDED.mastery_score
+		 WHERE mastery_snapshots.tenant_id = EXCLUDED.tenant_id`,
+		evidence.LearnerID.String(), p.tenantID, evidence.TopicID, next.MasteryScore,
+	)
+	if err != nil {
+		return MasteryEvidenceResult{}, fmt.Errorf("write mastery snapshot: %w", err)
+	}
+	if tag.RowsAffected() != 1 {
+		return MasteryEvidenceResult{}, fmt.Errorf("write mastery snapshot: tenant scope mismatch")
+	}
+
+	result := MasteryEvidenceResult{
+		Applied:       true,
+		MasteryBefore: before,
+		MasteryAfter:  next.MasteryScore,
+	}
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO learning_attempts (
+			tenant_id, user_id, attempt_id, syllabus_id, topic_id,
+			source_kind, source_id, source_revision, score, payload_hash,
+			mastery_before, mastery_after
+		)
+		 VALUES ($1::uuid, $2::uuid, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+		p.tenantID, evidence.LearnerID.String(), evidence.AttemptID,
+		evidence.SyllabusID, evidence.TopicID, evidence.SourceKind, evidence.SourceID,
+		evidence.SourceRevision, evidence.Score, evidence.PayloadHash[:],
+		result.MasteryBefore, result.MasteryAfter,
+	); err != nil {
+		return MasteryEvidenceResult{}, fmt.Errorf("write mastery attempt: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return MasteryEvidenceResult{}, err
+	}
+	return result, nil
+}
+
+// GetMasteryEvidenceCounts returns durable attempt counts grouped by topic.
+func (p *PostgresTracker) GetMasteryEvidenceCounts(ctx context.Context, learnerID LearnerID) ([]MasteryEvidenceCount, error) {
+	if learnerID.String() == "" {
+		return nil, fmt.Errorf("mastery evidence learner ID is required")
+	}
+	ctx, cancel := context.WithTimeout(ctx, dbTimeout)
+	defer cancel()
+
+	rows, err := p.pool.Query(ctx,
+		`SELECT syllabus_id, topic_id, COUNT(*)::integer
+		 FROM learning_attempts
+		 WHERE tenant_id = $1::uuid
+		   AND user_id = $2::uuid
+		 GROUP BY syllabus_id, topic_id
+		 ORDER BY syllabus_id, topic_id`,
+		p.tenantID, learnerID.String(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var counts []MasteryEvidenceCount
+	for rows.Next() {
+		var count MasteryEvidenceCount
+		if err := rows.Scan(&count.SyllabusID, &count.TopicID, &count.Count); err != nil {
+			return nil, err
+		}
+		counts = append(counts, count)
+	}
+	return counts, rows.Err()
+}
+
+// GetMasterySnapshot returns scores and evidence counts from one PostgreSQL
+// statement, so every item belongs to the same MVCC read snapshot.
+func (p *PostgresTracker) GetMasterySnapshot(ctx context.Context, learnerID LearnerID) ([]MasterySnapshotItem, error) {
+	if learnerID.String() == "" {
+		return nil, fmt.Errorf("mastery snapshot learner ID is required")
+	}
+	ctx, cancel := context.WithTimeout(ctx, dbTimeout)
+	defer cancel()
+
+	rows, err := p.pool.Query(ctx,
+		`WITH progress_items AS (
+			SELECT syllabus_id, topic_id, mastery_score
+			FROM learning_progress
+			WHERE tenant_id = $1::uuid
+			  AND user_id = $2::uuid
+		),
+		evidence_counts AS (
+			SELECT syllabus_id, topic_id, COUNT(*)::integer AS evidence_count
+			FROM learning_attempts
+			WHERE tenant_id = $1::uuid
+			  AND user_id = $2::uuid
+			GROUP BY syllabus_id, topic_id
+		)
+		SELECT
+			COALESCE(progress_items.syllabus_id, evidence_counts.syllabus_id),
+			COALESCE(progress_items.topic_id, evidence_counts.topic_id),
+			COALESCE(progress_items.mastery_score, 0),
+			progress_items.topic_id IS NOT NULL,
+			COALESCE(evidence_counts.evidence_count, 0)
+		FROM progress_items
+		FULL OUTER JOIN evidence_counts USING (syllabus_id, topic_id)
+		ORDER BY 1, 2`,
+		p.tenantID, learnerID.String(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var snapshot []MasterySnapshotItem
+	for rows.Next() {
+		var item MasterySnapshotItem
+		if err := rows.Scan(
+			&item.SyllabusID,
+			&item.TopicID,
+			&item.MasteryScore,
+			&item.MasteryKnown,
+			&item.EvidenceCount,
+		); err != nil {
+			return nil, err
+		}
+		snapshot = append(snapshot, item)
+	}
+	return snapshot, rows.Err()
+}
+
+func loadMasteryEvidence(
+	ctx context.Context,
+	tx pgx.Tx,
+	tenantID string,
+	learnerID LearnerID,
+	attemptID string,
+) (recordedMasteryEvidence, bool, error) {
+	var recorded recordedMasteryEvidence
+	var payloadHash []byte
+	err := tx.QueryRow(ctx,
+		`SELECT syllabus_id, topic_id, source_kind, source_id, source_revision, score,
+		        payload_hash, mastery_before, mastery_after
+		 FROM learning_attempts
+		 WHERE tenant_id = $1::uuid
+		   AND user_id = $2::uuid
+		   AND attempt_id = $3`,
+		tenantID, learnerID.String(), attemptID,
+	).Scan(
+		&recorded.evidence.SyllabusID,
+		&recorded.evidence.TopicID,
+		&recorded.evidence.SourceKind,
+		&recorded.evidence.SourceID,
+		&recorded.evidence.SourceRevision,
+		&recorded.evidence.Score,
+		&payloadHash,
+		&recorded.result.MasteryBefore,
+		&recorded.result.MasteryAfter,
+	)
+	if err == pgx.ErrNoRows {
+		return recordedMasteryEvidence{}, false, nil
+	}
+	if err != nil {
+		return recordedMasteryEvidence{}, false, fmt.Errorf("read mastery attempt: %w", err)
+	}
+	if len(payloadHash) != len(recorded.evidence.PayloadHash) {
+		return recordedMasteryEvidence{}, false, fmt.Errorf("stored mastery attempt has invalid payload hash")
+	}
+	recorded.evidence.AttemptID = attemptID
+	recorded.evidence.LearnerID = learnerID
+	copy(recorded.evidence.PayloadHash[:], payloadHash)
+	recorded.result.Applied = true
+	return recorded, true, nil
 }
 
 // SetMastery directly sets a topic's mastery score (dev/testing only).

--- a/internal/progress/tracker_postgres.go
+++ b/internal/progress/tracker_postgres.go
@@ -334,15 +334,33 @@ func (p *PostgresTracker) GetMasterySnapshot(ctx context.Context, learnerID Lear
 			WHERE tenant_id = $1::uuid
 			  AND user_id = $2::uuid
 			GROUP BY syllabus_id, topic_id
+		),
+		latest_evidence AS (
+			SELECT DISTINCT ON (syllabus_id, topic_id)
+				syllabus_id, topic_id, source_kind, source_id, score
+			FROM learning_attempts
+			WHERE tenant_id = $1::uuid
+			  AND user_id = $2::uuid
+			ORDER BY syllabus_id, topic_id, created_at DESC, attempt_id DESC
+		),
+		topic_keys AS (
+			SELECT syllabus_id, topic_id FROM progress_items
+			UNION
+			SELECT syllabus_id, topic_id FROM evidence_counts
 		)
 		SELECT
-			COALESCE(progress_items.syllabus_id, evidence_counts.syllabus_id),
-			COALESCE(progress_items.topic_id, evidence_counts.topic_id),
+			topic_keys.syllabus_id,
+			topic_keys.topic_id,
 			COALESCE(progress_items.mastery_score, 0),
 			progress_items.topic_id IS NOT NULL,
-			COALESCE(evidence_counts.evidence_count, 0)
-		FROM progress_items
-		FULL OUTER JOIN evidence_counts USING (syllabus_id, topic_id)
+			COALESCE(evidence_counts.evidence_count, 0),
+			latest_evidence.source_kind,
+			latest_evidence.source_id,
+			latest_evidence.score
+		FROM topic_keys
+		LEFT JOIN progress_items USING (syllabus_id, topic_id)
+		LEFT JOIN evidence_counts USING (syllabus_id, topic_id)
+		LEFT JOIN latest_evidence USING (syllabus_id, topic_id)
 		ORDER BY 1, 2`,
 		p.tenantID, learnerID.String(),
 	)
@@ -354,14 +372,26 @@ func (p *PostgresTracker) GetMasterySnapshot(ctx context.Context, learnerID Lear
 	var snapshot []MasterySnapshotItem
 	for rows.Next() {
 		var item MasterySnapshotItem
+		var latestSourceKind, latestSourceID *string
+		var latestScore *float64
 		if err := rows.Scan(
 			&item.SyllabusID,
 			&item.TopicID,
 			&item.MasteryScore,
 			&item.MasteryKnown,
 			&item.EvidenceCount,
+			&latestSourceKind,
+			&latestSourceID,
+			&latestScore,
 		); err != nil {
 			return nil, err
+		}
+		if latestSourceKind != nil && latestSourceID != nil && latestScore != nil {
+			item.LatestEvidence = &MasteryEvidenceSummary{
+				SourceKind: *latestSourceKind,
+				SourceID:   *latestSourceID,
+				Score:      *latestScore,
+			}
 		}
 		snapshot = append(snapshot, item)
 	}

--- a/internal/progress/tracker_postgres_integration_test.go
+++ b/internal/progress/tracker_postgres_integration_test.go
@@ -1,0 +1,525 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package progress
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+)
+
+func TestPostgresTracker_RecordMasteryEvidence(t *testing.T) {
+	ctx := context.Background()
+	pool := startProgressPostgres(t, ctx)
+
+	t.Run("durable exact replay", func(t *testing.T) {
+		tenantID, learnerID := seedProgressLearner(t, ctx, pool, "durable-replay")
+		evidence := progressTestEvidence(learnerID, "attempt-1", "topic-1", 0.8)
+
+		first, err := NewPostgresTracker(pool, tenantID).RecordMasteryEvidence(ctx, evidence)
+		if err != nil {
+			t.Fatalf("first RecordMasteryEvidence() error = %v", err)
+		}
+		if !first.Applied {
+			t.Fatal("first RecordMasteryEvidence().Applied = false, want true")
+		}
+
+		replay, err := NewPostgresTracker(pool, tenantID).RecordMasteryEvidence(ctx, evidence)
+		if err != nil {
+			t.Fatalf("replayed RecordMasteryEvidence() error = %v", err)
+		}
+		if replay.Applied {
+			t.Fatal("replayed RecordMasteryEvidence().Applied = true, want false")
+		}
+		assertMasteryTransitionEqual(t, replay, first)
+		counts, err := NewPostgresTracker(pool, tenantID).GetMasteryEvidenceCounts(ctx, learnerID)
+		if err != nil {
+			t.Fatalf("GetMasteryEvidenceCounts() error = %v", err)
+		}
+		if len(counts) != 1 || counts[0].Count != 1 || counts[0].TopicID != evidence.TopicID {
+			t.Fatalf("evidence counts = %#v, want one durable attempt", counts)
+		}
+		assertProgressPersistence(t, ctx, pool, tenantID, learnerID, evidence, 1, 1, 1)
+	})
+
+	t.Run("mastery snapshot keeps score and evidence coverage together", func(t *testing.T) {
+		tenantID, learnerID := seedProgressLearner(t, ctx, pool, "coherent-snapshot")
+		tracker := NewPostgresTracker(pool, tenantID)
+		first := progressTestEvidence(learnerID, "attempt-1", "evidence-topic", 0.2)
+		second := progressTestEvidence(learnerID, "attempt-2", "evidence-topic", 0.8)
+		if _, err := tracker.RecordMasteryEvidence(ctx, first); err != nil {
+			t.Fatalf("first RecordMasteryEvidence() error = %v", err)
+		}
+		transition, err := tracker.RecordMasteryEvidence(ctx, second)
+		if err != nil {
+			t.Fatalf("second RecordMasteryEvidence() error = %v", err)
+		}
+		if err := tracker.SetMasteryForLearner(learnerID, "syllabus-1", "progress-only-topic", 0.4); err != nil {
+			t.Fatalf("SetMasteryForLearner() error = %v", err)
+		}
+
+		snapshot, err := tracker.GetMasterySnapshot(ctx, learnerID)
+		if err != nil {
+			t.Fatalf("GetMasterySnapshot() error = %v", err)
+		}
+		if len(snapshot) != 2 {
+			t.Fatalf("snapshot = %#v, want two topics", snapshot)
+		}
+		byTopic := make(map[string]MasterySnapshotItem, len(snapshot))
+		for _, item := range snapshot {
+			byTopic[item.TopicID] = item
+		}
+		evidenceTopic := byTopic["evidence-topic"]
+		if !evidenceTopic.MasteryKnown ||
+			!closeFloat(evidenceTopic.MasteryScore, transition.MasteryAfter) ||
+			evidenceTopic.EvidenceCount != 2 {
+			t.Fatalf(
+				"evidence topic snapshot = %#v, want score %v with 2 evidence records",
+				evidenceTopic,
+				transition.MasteryAfter,
+			)
+		}
+		progressOnly := byTopic["progress-only-topic"]
+		if !progressOnly.MasteryKnown ||
+			!closeFloat(progressOnly.MasteryScore, 0.4) ||
+			progressOnly.EvidenceCount != 0 {
+			t.Fatalf("progress-only snapshot = %#v, want known 0.4 score without evidence", progressOnly)
+		}
+	})
+
+	t.Run("payload conflict does not mutate progress", func(t *testing.T) {
+		tenantID, learnerID := seedProgressLearner(t, ctx, pool, "payload-conflict")
+		tracker := NewPostgresTracker(pool, tenantID)
+		evidence := progressTestEvidence(learnerID, "attempt-1", "topic-1", 0.35)
+
+		if _, err := tracker.RecordMasteryEvidence(ctx, evidence); err != nil {
+			t.Fatalf("first RecordMasteryEvidence() error = %v", err)
+		}
+		before := readProgressPersistence(t, ctx, pool, tenantID, learnerID, evidence)
+
+		conflict := evidence
+		conflict.PayloadHash = sha256.Sum256([]byte("different answer payload"))
+		if _, err := tracker.RecordMasteryEvidence(ctx, conflict); !errors.Is(err, ErrMasteryEvidenceConflict) {
+			t.Fatalf("conflicting RecordMasteryEvidence() error = %v, want ErrMasteryEvidenceConflict", err)
+		}
+
+		after := readProgressPersistence(t, ctx, pool, tenantID, learnerID, evidence)
+		if after != before {
+			t.Fatalf("persistence after conflict = %+v, want unchanged %+v", after, before)
+		}
+	})
+
+	t.Run("source revision conflict does not mutate progress", func(t *testing.T) {
+		tenantID, learnerID := seedProgressLearner(t, ctx, pool, "revision-conflict")
+		tracker := NewPostgresTracker(pool, tenantID)
+		evidence := progressTestEvidence(learnerID, "attempt-1", "topic-1", 0.35)
+
+		if _, err := tracker.RecordMasteryEvidence(ctx, evidence); err != nil {
+			t.Fatalf("first RecordMasteryEvidence() error = %v", err)
+		}
+		before := readProgressPersistence(t, ctx, pool, tenantID, learnerID, evidence)
+
+		conflict := evidence
+		conflict.SourceRevision = "sha256:changed"
+		if _, err := tracker.RecordMasteryEvidence(ctx, conflict); !errors.Is(err, ErrMasteryEvidenceConflict) {
+			t.Fatalf("conflicting RecordMasteryEvidence() error = %v, want ErrMasteryEvidenceConflict", err)
+		}
+
+		after := readProgressPersistence(t, ctx, pool, tenantID, learnerID, evidence)
+		if after != before {
+			t.Fatalf("persistence after conflict = %+v, want unchanged %+v", after, before)
+		}
+	})
+
+	t.Run("tenant mismatch is rejected without mutation", func(t *testing.T) {
+		trackerTenantID, _ := seedProgressLearner(t, ctx, pool, "tenant-mismatch-tracker")
+		otherTenantID, otherLearnerID := seedProgressLearner(t, ctx, pool, "tenant-mismatch-learner")
+		tracker := NewPostgresTracker(pool, trackerTenantID)
+		evidence := progressTestEvidence(otherLearnerID, "attempt-1", "topic-1", 0.9)
+
+		_, err := tracker.RecordMasteryEvidence(ctx, evidence)
+		if err == nil {
+			t.Fatal("RecordMasteryEvidence() error = nil, want tenant mismatch")
+		}
+		if !strings.Contains(err.Error(), "does not belong to tracker tenant") {
+			t.Fatalf("RecordMasteryEvidence() error = %v, want tenant mismatch context", err)
+		}
+		assertProgressPersistence(t, ctx, pool, trackerTenantID, otherLearnerID, evidence, 0, 0, 0)
+		assertProgressPersistence(t, ctx, pool, otherTenantID, otherLearnerID, evidence, 0, 0, 0)
+	})
+
+	t.Run("concurrent duplicate applies once", func(t *testing.T) {
+		tenantID, learnerID := seedProgressLearner(t, ctx, pool, "concurrent-duplicate")
+		tracker := NewPostgresTracker(pool, tenantID)
+		evidence := progressTestEvidence(learnerID, "attempt-1", "topic-1", 0.9)
+
+		const callers = 8
+		start := make(chan struct{})
+		results := make(chan masteryCallResult, callers)
+		var wg sync.WaitGroup
+		for range callers {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				result, err := tracker.RecordMasteryEvidence(ctx, evidence)
+				results <- masteryCallResult{result: result, err: err}
+			}()
+		}
+		close(start)
+		wg.Wait()
+		close(results)
+
+		applied := 0
+		var stable MasteryEvidenceResult
+		calls := make([]masteryCallResult, 0, callers)
+		for call := range results {
+			if call.err != nil {
+				t.Fatalf("concurrent RecordMasteryEvidence() error = %v", call.err)
+			}
+			calls = append(calls, call)
+			if call.result.Applied {
+				applied++
+				stable = call.result
+			}
+		}
+		if applied != 1 {
+			t.Fatalf("concurrent applied count = %d, want 1", applied)
+		}
+		if stable.MasteryBefore != 0 || !closeFloat(stable.MasteryAfter, evidence.Score) {
+			t.Fatalf("applied transition = %+v, want 0 -> %v", stable, evidence.Score)
+		}
+		for _, call := range calls {
+			assertMasteryTransitionEqual(t, call.result, stable)
+		}
+		assertProgressPersistence(t, ctx, pool, tenantID, learnerID, evidence, 1, 1, 1)
+	})
+
+	t.Run("concurrent distinct attempts serialize on the topic", func(t *testing.T) {
+		tenantID, learnerID := seedProgressLearner(t, ctx, pool, "concurrent-distinct")
+		tracker := NewPostgresTracker(pool, tenantID)
+		first := progressTestEvidence(learnerID, "attempt-1", "topic-1", 0.8)
+		second := progressTestEvidence(learnerID, "attempt-2", "topic-1", 0.8)
+
+		start := make(chan struct{})
+		results := make(chan masteryCallResult, 2)
+		var wg sync.WaitGroup
+		for _, evidence := range []MasteryEvidence{first, second} {
+			evidence := evidence
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				result, err := tracker.RecordMasteryEvidence(ctx, evidence)
+				results <- masteryCallResult{result: result, err: err}
+			}()
+		}
+		close(start)
+		wg.Wait()
+		close(results)
+
+		transitions := make([]MasteryEvidenceResult, 0, 2)
+		for call := range results {
+			if call.err != nil {
+				t.Fatalf("concurrent RecordMasteryEvidence() error = %v", call.err)
+			}
+			if !call.result.Applied {
+				t.Fatal("distinct RecordMasteryEvidence().Applied = false, want true")
+			}
+			transitions = append(transitions, call.result)
+		}
+		sort.Slice(transitions, func(i, j int) bool {
+			return transitions[i].MasteryBefore < transitions[j].MasteryBefore
+		})
+		if len(transitions) != 2 ||
+			!closeFloat(transitions[0].MasteryBefore, 0) ||
+			!closeFloat(transitions[0].MasteryAfter, first.Score) ||
+			!closeFloat(transitions[1].MasteryBefore, transitions[0].MasteryAfter) ||
+			!closeFloat(transitions[1].MasteryAfter, first.Score) {
+			t.Fatalf("serialized transitions = %+v, want chained same-score updates", transitions)
+		}
+		assertProgressPersistence(t, ctx, pool, tenantID, learnerID, first, 2, 1, 2)
+	})
+
+	t.Run("snapshot failure rolls back progress and attempt", func(t *testing.T) {
+		tenantID, learnerID := seedProgressLearner(t, ctx, pool, "snapshot-rollback")
+		tracker := NewPostgresTracker(pool, tenantID)
+		evidence := progressTestEvidence(learnerID, "attempt-1", "rollback-topic", 1)
+
+		const constraint = "mastery_snapshots_progress_test_reject_topic"
+		if _, err := pool.Exec(ctx,
+			`ALTER TABLE mastery_snapshots
+			 ADD CONSTRAINT `+constraint+` CHECK (topic_id <> 'rollback-topic')`,
+		); err != nil {
+			t.Fatalf("install snapshot failure constraint: %v", err)
+		}
+		t.Cleanup(func() {
+			_, _ = pool.Exec(context.Background(),
+				`ALTER TABLE mastery_snapshots DROP CONSTRAINT IF EXISTS `+constraint)
+		})
+
+		if _, err := tracker.RecordMasteryEvidence(ctx, evidence); err == nil {
+			t.Fatal("RecordMasteryEvidence() error = nil, want snapshot write failure")
+		} else if !strings.Contains(err.Error(), "write mastery snapshot") {
+			t.Fatalf("RecordMasteryEvidence() error = %v, want snapshot write context", err)
+		}
+		assertProgressPersistence(t, ctx, pool, tenantID, learnerID, evidence, 0, 0, 0)
+	})
+}
+
+type masteryCallResult struct {
+	result MasteryEvidenceResult
+	err    error
+}
+
+type progressPersistence struct {
+	attempts    int
+	snapshots   int
+	progress    int
+	repetitions int
+	mastery     float64
+}
+
+func startProgressPostgres(t *testing.T, ctx context.Context) *pgxpool.Pool {
+	t.Helper()
+
+	container, err := tcpostgres.Run(
+		ctx,
+		"postgres:17-alpine",
+		tcpostgres.WithDatabase("pai"),
+		tcpostgres.WithUsername("pai"),
+		tcpostgres.WithPassword("pai"),
+		tcpostgres.BasicWaitStrategies(),
+	)
+	if err != nil {
+		t.Fatalf("start postgres container: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := container.Terminate(context.Background()); err != nil {
+			t.Errorf("terminate postgres container: %v", err)
+		}
+	})
+
+	connString, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("container connection string: %v", err)
+	}
+	pool, err := pgxpool.New(ctx, connString)
+	if err != nil {
+		t.Fatalf("pgxpool.New() error = %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		if err := pool.Ping(ctx); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("postgres did not become ready before timeout")
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	for _, name := range []string{
+		"20260318100000_initial.sql",
+		"20260318100300_auth_tables.sql",
+		"20260318100400_auth_identity_tenant_consistency.sql",
+		"20260407100000_add_groups.sql",
+		"20260731100000_learning_attempts.sql",
+	} {
+		applyProgressMigration(t, ctx, pool, filepath.Join("..", "..", "migrations", name))
+	}
+	return pool
+}
+
+func applyProgressMigration(t *testing.T, ctx context.Context, pool *pgxpool.Pool, path string) {
+	t.Helper()
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read migration %s: %v", path, err)
+	}
+	upSQL, err := progressGooseUpSQL(string(content))
+	if err != nil {
+		t.Fatalf("parse migration %s: %v", path, err)
+	}
+	if _, err := pool.Exec(ctx, upSQL); err != nil {
+		t.Fatalf("apply migration %s: %v", path, err)
+	}
+}
+
+func progressGooseUpSQL(content string) (string, error) {
+	const (
+		upMarker   = "-- +goose Up"
+		downMarker = "-- +goose Down"
+	)
+	upIndex := strings.Index(content, upMarker)
+	if upIndex < 0 {
+		return strings.TrimSpace(content), nil
+	}
+	body := content[upIndex+len(upMarker):]
+	if downIndex := strings.Index(body, downMarker); downIndex >= 0 {
+		body = body[:downIndex]
+	}
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return "", fmt.Errorf("missing goose Up section")
+	}
+	return body, nil
+}
+
+func seedProgressLearner(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	slug string,
+) (string, LearnerID) {
+	t.Helper()
+
+	var tenantID string
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO tenants (name, slug)
+		 VALUES ($1, $2)
+		 RETURNING id::text`,
+		"Progress test "+slug, "progress-test-"+slug,
+	).Scan(&tenantID); err != nil {
+		t.Fatalf("insert tenant %q: %v", slug, err)
+	}
+
+	var learner string
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO users (tenant_id, role, name, external_id, channel)
+		 VALUES ($1::uuid, 'student', $2, $3, 'telegram')
+		 RETURNING id::text`,
+		tenantID, "Learner "+slug, "learner-"+slug,
+	).Scan(&learner); err != nil {
+		t.Fatalf("insert learner %q: %v", slug, err)
+	}
+	learnerID, err := NewLearnerID(learner)
+	if err != nil {
+		t.Fatalf("NewLearnerID(%q) error = %v", learner, err)
+	}
+	return tenantID, learnerID
+}
+
+func progressTestEvidence(
+	learnerID LearnerID,
+	attemptID string,
+	topicID string,
+	score float64,
+) MasteryEvidence {
+	return MasteryEvidence{
+		AttemptID:      attemptID,
+		LearnerID:      learnerID,
+		SyllabusID:     "syllabus-1",
+		TopicID:        topicID,
+		SourceKind:     "oss_assessment",
+		SourceID:       "question-1",
+		SourceRevision: "sha256:fixture",
+		Score:          score,
+		PayloadHash:    sha256.Sum256([]byte(learnerID.String() + "|" + attemptID + "|" + topicID)),
+	}
+}
+
+func assertMasteryTransitionEqual(t *testing.T, got, want MasteryEvidenceResult) {
+	t.Helper()
+	if !closeFloat(got.MasteryBefore, want.MasteryBefore) ||
+		!closeFloat(got.MasteryAfter, want.MasteryAfter) {
+		t.Fatalf("mastery transition = %+v, want %+v", got, want)
+	}
+}
+
+func assertProgressPersistence(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	tenantID string,
+	learnerID LearnerID,
+	evidence MasteryEvidence,
+	wantAttempts int,
+	wantSnapshots int,
+	wantRepetitions int,
+) {
+	t.Helper()
+	got := readProgressPersistence(t, ctx, pool, tenantID, learnerID, evidence)
+	wantProgress := 0
+	if wantRepetitions > 0 {
+		wantProgress = 1
+	}
+	if got.attempts != wantAttempts ||
+		got.snapshots != wantSnapshots ||
+		got.progress != wantProgress ||
+		got.repetitions != wantRepetitions ||
+		(wantProgress == 1 && !closeFloat(got.mastery, evidence.Score)) {
+		t.Fatalf(
+			"persistence = %+v, want attempts=%d snapshots=%d progress=%d repetitions=%d mastery=%v",
+			got, wantAttempts, wantSnapshots, wantProgress, wantRepetitions, evidence.Score,
+		)
+	}
+}
+
+func readProgressPersistence(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	tenantID string,
+	learnerID LearnerID,
+	evidence MasteryEvidence,
+) progressPersistence {
+	t.Helper()
+
+	var state progressPersistence
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*)
+		 FROM learning_attempts
+		 WHERE tenant_id = $1::uuid
+		   AND user_id = $2::uuid
+		   AND syllabus_id = $3
+		   AND topic_id = $4`,
+		tenantID, learnerID.String(), evidence.SyllabusID, evidence.TopicID,
+	).Scan(&state.attempts); err != nil {
+		t.Fatalf("count learning attempts: %v", err)
+	}
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*)
+		 FROM mastery_snapshots
+		 WHERE tenant_id = $1::uuid
+		   AND user_id = $2::uuid
+		   AND topic_id = $3`,
+		tenantID, learnerID.String(), evidence.TopicID,
+	).Scan(&state.snapshots); err != nil {
+		t.Fatalf("count mastery snapshots: %v", err)
+	}
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*), COALESCE(max(repetitions), 0), COALESCE(max(mastery_score), 0)
+		 FROM learning_progress
+		 WHERE tenant_id = $1::uuid
+		   AND user_id = $2::uuid
+		   AND syllabus_id = $3
+		   AND topic_id = $4`,
+		tenantID, learnerID.String(), evidence.SyllabusID, evidence.TopicID,
+	).Scan(&state.progress, &state.repetitions, &state.mastery); err != nil {
+		t.Fatalf("read learning progress: %v", err)
+	}
+	return state
+}
+
+func closeFloat(left, right float64) bool {
+	return math.Abs(left-right) <= 1e-6
+}

--- a/internal/progress/tracker_postgres_integration_test.go
+++ b/internal/progress/tracker_postgres_integration_test.go
@@ -87,7 +87,10 @@ func TestPostgresTracker_RecordMasteryEvidence(t *testing.T) {
 		evidenceTopic := byTopic["evidence-topic"]
 		if !evidenceTopic.MasteryKnown ||
 			!closeFloat(evidenceTopic.MasteryScore, transition.MasteryAfter) ||
-			evidenceTopic.EvidenceCount != 2 {
+			evidenceTopic.EvidenceCount != 2 ||
+			evidenceTopic.LatestEvidence == nil ||
+			evidenceTopic.LatestEvidence.SourceID != second.SourceID ||
+			!closeFloat(evidenceTopic.LatestEvidence.Score, second.Score) {
 			t.Fatalf(
 				"evidence topic snapshot = %#v, want score %v with 2 evidence records",
 				evidenceTopic,
@@ -97,7 +100,8 @@ func TestPostgresTracker_RecordMasteryEvidence(t *testing.T) {
 		progressOnly := byTopic["progress-only-topic"]
 		if !progressOnly.MasteryKnown ||
 			!closeFloat(progressOnly.MasteryScore, 0.4) ||
-			progressOnly.EvidenceCount != 0 {
+			progressOnly.EvidenceCount != 0 ||
+			progressOnly.LatestEvidence != nil {
 			t.Fatalf("progress-only snapshot = %#v, want known 0.4 score without evidence", progressOnly)
 		}
 	})

--- a/internal/progress/tracker_test.go
+++ b/internal/progress/tracker_test.go
@@ -111,6 +111,14 @@ func TestMemoryTracker_RecordMasteryEvidenceIsIdempotent(t *testing.T) {
 	if len(counts) != 1 || counts[0].SyllabusID != "syllabus" || counts[0].TopicID != "topic" || counts[0].Count != 1 {
 		t.Fatalf("evidence counts = %#v, want one distinct topic attempt", counts)
 	}
+	snapshot, err := tracker.GetMasterySnapshot(context.Background(), learnerID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot) != 1 || snapshot[0].LatestEvidence == nil ||
+		snapshot[0].LatestEvidence.SourceID != "Q1" || snapshot[0].LatestEvidence.Score != 0 {
+		t.Fatalf("latest evidence = %#v, want wrong Q1 attempt", snapshot)
+	}
 }
 
 func TestMemoryTracker_RecordMasteryEvidenceRejectsAttemptIDCollision(t *testing.T) {

--- a/internal/progress/tracker_test.go
+++ b/internal/progress/tracker_test.go
@@ -4,6 +4,11 @@
 package progress
 
 import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"math"
 	"testing"
 	"time"
 )
@@ -53,6 +58,236 @@ func TestLearnerTracker_IsolatesInternalLearnerIDs(t *testing.T) {
 func TestNewLearnerIDRejectsEmptyValue(t *testing.T) {
 	if _, err := NewLearnerID(" "); err == nil {
 		t.Fatal("NewLearnerID(empty) error = nil, want error")
+	}
+}
+
+func TestMemoryTracker_RecordMasteryEvidenceIsIdempotent(t *testing.T) {
+	tracker := NewMemoryTracker()
+	learnerID, err := NewLearnerID("learner-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tracker.UpdateMasteryForLearner(learnerID, "syllabus", "topic", 0.8); err != nil {
+		t.Fatal(err)
+	}
+	evidence := MasteryEvidence{
+		AttemptID:      "message-42/Q1",
+		LearnerID:      learnerID,
+		SyllabusID:     "syllabus",
+		TopicID:        "topic",
+		SourceKind:     "oss_assessment",
+		SourceID:       "Q1",
+		SourceRevision: "sha256:fixture",
+		Score:          0,
+		PayloadHash:    sha256.Sum256([]byte("wrong answer")),
+	}
+
+	first, err := tracker.RecordMasteryEvidence(context.Background(), evidence)
+	if err != nil {
+		t.Fatalf("first RecordMasteryEvidence() error = %v", err)
+	}
+	replay, err := tracker.RecordMasteryEvidence(context.Background(), evidence)
+	if err != nil {
+		t.Fatalf("replayed RecordMasteryEvidence() error = %v", err)
+	}
+
+	if !first.Applied || replay.Applied {
+		t.Fatalf("applied flags = %v, %v, want true then false", first.Applied, replay.Applied)
+	}
+	if replay.MasteryBefore != first.MasteryBefore || replay.MasteryAfter != first.MasteryAfter {
+		t.Fatalf("replay result = %#v, want original %#v", replay, first)
+	}
+	score, err := tracker.GetMasteryForLearner(learnerID, "syllabus", "topic")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if score != first.MasteryAfter {
+		t.Fatalf("mastery after replay = %v, want %v", score, first.MasteryAfter)
+	}
+	counts, err := tracker.GetMasteryEvidenceCounts(context.Background(), learnerID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(counts) != 1 || counts[0].SyllabusID != "syllabus" || counts[0].TopicID != "topic" || counts[0].Count != 1 {
+		t.Fatalf("evidence counts = %#v, want one distinct topic attempt", counts)
+	}
+}
+
+func TestMemoryTracker_RecordMasteryEvidenceRejectsAttemptIDCollision(t *testing.T) {
+	tracker := NewMemoryTracker()
+	learnerID, err := NewLearnerID("learner-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidence := MasteryEvidence{
+		AttemptID:      "message-42/Q1",
+		LearnerID:      learnerID,
+		SyllabusID:     "syllabus",
+		TopicID:        "topic",
+		SourceKind:     "oss_assessment",
+		SourceID:       "Q1",
+		SourceRevision: "sha256:fixture",
+		Score:          1,
+		PayloadHash:    sha256.Sum256([]byte("correct answer")),
+	}
+	if _, err := tracker.RecordMasteryEvidence(context.Background(), evidence); err != nil {
+		t.Fatal(err)
+	}
+	evidence.PayloadHash = sha256.Sum256([]byte("different answer"))
+
+	if _, err := tracker.RecordMasteryEvidence(context.Background(), evidence); !errors.Is(err, ErrMasteryEvidenceConflict) {
+		t.Fatalf("RecordMasteryEvidence() error = %v, want ErrMasteryEvidenceConflict", err)
+	}
+	score, err := tracker.GetMasteryForLearner(learnerID, "syllabus", "topic")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if score != 1 {
+		t.Fatalf("mastery after collision = %v, want unchanged 1", score)
+	}
+}
+
+func TestMemoryTracker_RecordMasteryEvidenceRejectsSourceRevisionCollision(t *testing.T) {
+	tracker := NewMemoryTracker()
+	learnerID, err := NewLearnerID("learner-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidence := MasteryEvidence{
+		AttemptID:      "message-42/Q1",
+		LearnerID:      learnerID,
+		SyllabusID:     "syllabus",
+		TopicID:        "topic",
+		SourceKind:     "oss_assessment",
+		SourceID:       "Q1",
+		SourceRevision: "sha256:first",
+		Score:          1,
+		PayloadHash:    sha256.Sum256([]byte("correct answer")),
+	}
+	if _, err := tracker.RecordMasteryEvidence(context.Background(), evidence); err != nil {
+		t.Fatal(err)
+	}
+	evidence.SourceRevision = "sha256:changed"
+
+	if _, err := tracker.RecordMasteryEvidence(context.Background(), evidence); !errors.Is(err, ErrMasteryEvidenceConflict) {
+		t.Fatalf("RecordMasteryEvidence() error = %v, want ErrMasteryEvidenceConflict", err)
+	}
+}
+
+func TestMemoryTracker_GetMasterySnapshotStaysCoherentDuringEvidenceWrites(t *testing.T) {
+	tracker := NewMemoryTracker()
+	learnerID, err := NewLearnerID("learner-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const attempts = 500
+	expectedScores := make([]float64, attempts+1)
+	for attempt := 1; attempt <= attempts; attempt++ {
+		score := float64(attempt % 2)
+		if attempt == 1 {
+			expectedScores[attempt] = score
+			continue
+		}
+		expectedScores[attempt] = expectedScores[attempt-1]*0.7 + score*0.3
+	}
+
+	start := make(chan struct{})
+	writerDone := make(chan struct{})
+	writeErr := make(chan error, 1)
+	go func() {
+		defer close(writerDone)
+		<-start
+		for attempt := 1; attempt <= attempts; attempt++ {
+			attemptID := fmt.Sprintf("attempt-%d", attempt)
+			_, err := tracker.RecordMasteryEvidence(context.Background(), MasteryEvidence{
+				AttemptID:      attemptID,
+				LearnerID:      learnerID,
+				SyllabusID:     "syllabus",
+				TopicID:        "topic",
+				SourceKind:     "oss_assessment",
+				SourceID:       "question",
+				SourceRevision: "sha256:fixture",
+				Score:          float64(attempt % 2),
+				PayloadHash:    sha256.Sum256([]byte(attemptID)),
+			})
+			if err != nil {
+				writeErr <- err
+				return
+			}
+		}
+	}()
+
+	close(start)
+	for {
+		snapshot, err := tracker.GetMasterySnapshot(context.Background(), learnerID)
+		if err != nil {
+			t.Fatalf("GetMasterySnapshot() error = %v", err)
+		}
+		if len(snapshot) > 1 {
+			t.Fatalf("snapshot = %#v, want at most one topic", snapshot)
+		}
+		if len(snapshot) == 1 {
+			item := snapshot[0]
+			if !item.MasteryKnown {
+				t.Fatalf("snapshot item = %#v, recorded evidence must have known mastery", item)
+			}
+			if item.EvidenceCount < 1 || item.EvidenceCount > attempts {
+				t.Fatalf("snapshot evidence count = %d, want 1..%d", item.EvidenceCount, attempts)
+			}
+			wantScore := expectedScores[item.EvidenceCount]
+			if math.Abs(item.MasteryScore-wantScore) > 1e-12 {
+				t.Fatalf(
+					"snapshot mixed score %v with evidence count %d; want score %v",
+					item.MasteryScore,
+					item.EvidenceCount,
+					wantScore,
+				)
+			}
+		}
+
+		select {
+		case <-writerDone:
+			if len(writeErr) != 0 {
+				t.Fatal(<-writeErr)
+			}
+			final, err := tracker.GetMasterySnapshot(context.Background(), learnerID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(final) != 1 || final[0].EvidenceCount != attempts {
+				t.Fatalf("final snapshot = %#v, want %d attempts", final, attempts)
+			}
+			return
+		default:
+		}
+	}
+}
+
+func TestMemoryTracker_GetMasterySnapshotIncludesProgressWithoutEvidence(t *testing.T) {
+	tracker := NewMemoryTracker()
+	learnerID, err := NewLearnerID("learner-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tracker.UpdateMasteryForLearner(learnerID, "syllabus", "topic", 0.4); err != nil {
+		t.Fatal(err)
+	}
+
+	snapshot, err := tracker.GetMasterySnapshot(context.Background(), learnerID)
+	if err != nil {
+		t.Fatalf("GetMasterySnapshot() error = %v", err)
+	}
+	if len(snapshot) != 1 {
+		t.Fatalf("snapshot = %#v, want one item", snapshot)
+	}
+	item := snapshot[0]
+	if item.SyllabusID != "syllabus" ||
+		item.TopicID != "topic" ||
+		item.MasteryScore != 0.4 ||
+		!item.MasteryKnown ||
+		item.EvidenceCount != 0 {
+		t.Fatalf("snapshot item = %#v, want known 0.4 mastery without evidence", item)
 	}
 }
 

--- a/internal/retrieval/curriculum_seed.go
+++ b/internal/retrieval/curriculum_seed.go
@@ -42,9 +42,13 @@ func SeedCurriculum(service *Service, loader *curriculum.Loader) error {
 	var docs []UpsertDocumentInput
 
 	for _, topic := range loader.AllTopics() {
+		if !topic.IsAITeachingReady() {
+			continue
+		}
 		subject, _ := loader.GetSubject(topic.SubjectID)
+		subjectGrade, _ := loader.GetSubjectGrade(topic.SubjectGradeID)
 		syllabus, _ := loader.GetSyllabus(topic.SyllabusID)
-		form := inferTopicForm(topic, subject)
+		form := inferTopicForm(topic, subject, subjectGrade)
 
 		collectionID := topic.SubjectID
 		if collectionID == "" {
@@ -173,8 +177,18 @@ func splitTeachingNoteSections(markdown string) []noteSection {
 	return out
 }
 
-func inferTopicForm(topic curriculum.Topic, subject curriculum.Subject) string {
-	for _, text := range []string{subject.GradeID, subject.Name, topic.SubjectID, topic.SyllabusID} {
+func inferTopicForm(topic curriculum.Topic, subject curriculum.Subject, subjectGrade curriculum.SubjectGrade) string {
+	for _, text := range []string{
+		subjectGrade.GradeID,
+		subjectGrade.Name,
+		subjectGrade.NameEN,
+		subjectGrade.ID,
+		subject.GradeID,
+		subject.Name,
+		topic.SubjectGradeID,
+		topic.SubjectID,
+		topic.SyllabusID,
+	} {
 		match := formPattern.FindStringSubmatch(strings.ToLower(strings.TrimSpace(text)))
 		if len(match) == 2 {
 			return match[1]

--- a/internal/retrieval/curriculum_seed_test.go
+++ b/internal/retrieval/curriculum_seed_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package retrieval_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/p-n-ai/pai-bot/internal/curriculum"
+	"github.com/p-n-ai/pai-bot/internal/retrieval"
+)
+
+func TestSeedCurriculumIndexesOnlyAITeachingReadyTopics(t *testing.T) {
+	loader := newSeedCurriculumLoader(t)
+	service := retrieval.NewService()
+
+	if err := retrieval.SeedCurriculum(service, loader); err != nil {
+		t.Fatalf("SeedCurriculum() error = %v", err)
+	}
+	if _, err := service.GetDocument("topic:F1-01"); err != nil {
+		t.Fatalf("GetDocument(ready topic) error = %v", err)
+	}
+	if _, err := service.GetDocument("topic:F1-02"); !errors.Is(err, retrieval.ErrNotFound) {
+		t.Fatalf("GetDocument(lower-quality topic) error = %v, want ErrNotFound", err)
+	}
+}
+
+func newSeedCurriculumLoader(t *testing.T) *curriculum.Loader {
+	t.Helper()
+	root := t.TempDir()
+	curriculumDir := filepath.Join(root, "curricula", "test")
+	topicsDir := filepath.Join(curriculumDir, "grade", "topics")
+	if err := os.MkdirAll(topicsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(topics) error = %v", err)
+	}
+	write := func(path, content string) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s) error = %v", path, err)
+		}
+	}
+	write(filepath.Join(curriculumDir, "syllabus.yaml"), `
+id: test-syllabus
+name: Test Syllabus
+subjects:
+  - test-math
+`)
+	write(filepath.Join(curriculumDir, "subject.yaml"), `
+id: test-math
+name: Test Mathematics
+syllabus_id: test-syllabus
+`)
+	write(filepath.Join(curriculumDir, "grade", "subject-grade.yaml"), `
+id: test-math-form-1
+name: Test Mathematics Form 1
+subject_id: test-math
+syllabus_id: test-syllabus
+grade_id: form-1
+topics:
+  - F1-01
+  - F1-02
+`)
+	write(filepath.Join(topicsDir, "F1-01.yaml"), `
+id: F1-01
+name: Ready Algebra
+subject_grade_id: test-math-form-1
+subject_id: test-math
+syllabus_id: test-syllabus
+content_standards:
+  - id: CS1
+    text: Algebra
+learning_objectives:
+  - id: LO1
+    content_standard_id: CS1
+    text: Solve an equation.
+quality_level: 3
+`)
+	write(filepath.Join(topicsDir, "F1-01.teaching.md"), "# Ready algebra\n")
+	write(filepath.Join(topicsDir, "F1-01.examples.yaml"), `
+topic_id: F1-01
+worked_examples:
+  - id: WE-01
+    topic: Solving equations
+    difficulty: easy
+    learning_objective: LO1
+    misconception_alert: Equality applies to only one side.
+    scenario: Solve x plus 1 equals 2.
+    working: Subtract 1 from both sides.
+`)
+	write(filepath.Join(topicsDir, "F1-01.assessments.yaml"), `
+topic_id: F1-01
+questions:
+  - id: Q1
+    text: Solve x plus 1 equals 2.
+    difficulty: easy
+    learning_objective: LO1
+    answer:
+      type: exact
+      value: "1"
+`)
+	write(filepath.Join(topicsDir, "F1-02.yaml"), `
+id: F1-02
+name: Draft Geometry
+subject_grade_id: test-math-form-1
+subject_id: test-math
+syllabus_id: test-syllabus
+content_standards:
+  - id: CS2
+    text: Geometry
+learning_objectives:
+  - id: LO2
+    content_standard_id: CS2
+    text: Identify an angle.
+quality_level: 2
+`)
+
+	loader, err := curriculum.NewLoader(root)
+	if err != nil {
+		t.Fatalf("NewLoader() error = %v", err)
+	}
+	return loader
+}

--- a/migrations/20260731100000_learning_attempts.sql
+++ b/migrations/20260731100000_learning_attempts.sql
@@ -1,0 +1,27 @@
+-- +goose Up
+CREATE TABLE learning_attempts (
+    tenant_id       UUID NOT NULL REFERENCES tenants(id),
+    user_id         UUID NOT NULL,
+    attempt_id      TEXT NOT NULL CHECK (length(attempt_id) BETWEEN 1 AND 256),
+    syllabus_id     TEXT NOT NULL,
+    topic_id        TEXT NOT NULL,
+    source_kind     TEXT NOT NULL,
+    source_id       TEXT NOT NULL,
+    source_revision TEXT NOT NULL CHECK (length(source_revision) BETWEEN 1 AND 256),
+    score           DOUBLE PRECISION NOT NULL CHECK (score BETWEEN 0 AND 1),
+    payload_hash    BYTEA NOT NULL CHECK (octet_length(payload_hash) = 32),
+    mastery_before  DOUBLE PRECISION NOT NULL CHECK (mastery_before BETWEEN 0 AND 1),
+    mastery_after   DOUBLE PRECISION NOT NULL CHECK (mastery_after BETWEEN 0 AND 1),
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (tenant_id, user_id, attempt_id),
+    CONSTRAINT learning_attempts_user_tenant_fkey
+        FOREIGN KEY (user_id, tenant_id)
+        REFERENCES users(id, tenant_id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX idx_learning_attempts_topic
+    ON learning_attempts(tenant_id, user_id, syllabus_id, topic_id, created_at DESC);
+
+-- +goose Down
+DROP TABLE IF EXISTS learning_attempts;


### PR DESCRIPTION
## Summary

- load and validate the pinned OSS curriculum as a typed, fail-closed teaching source
- plan source-backed teaching turns with prerequisite, locale, and provenance boundaries
- record idempotent mastery evidence atomically in memory and Postgres

## Dependency

- p-n-ai/oss#15 publishes the pinned curriculum revision consumed here

## Risk

- API contract: internal additive behavior; no public API removal
- Database migrations: adds `learning_attempts`; reversible with the included down migration
- Release and deployment: no release automation changes
- Rollback: revert the commits and run the migration down before code rollback if the table was applied

## Verification

- focused curriculum, progress, agent, and retrieval tests passed locally
- exact numeric answers use deterministic value equivalence, with equivalent and non-equivalent decimal regression coverage
- OSS contract integration passed against the pinned curriculum revision
- GitHub: lint, vet, API compatibility, focused-page integration, backend E2E, and Docker pass