### PR TITLE
fix(deploy): allow Codex health probe latency

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -48,7 +48,7 @@ jobs:
           VERIFICATION_MODE: ${{ inputs.verification_mode }}
         run: |
           if [ "$VERIFICATION_MODE" = "deliberate-failure" ]; then
-            python3 scripts/uptime_probe.py "$TARGET_URL" --check status --timeout 10 --deliberate-failure
+            python3 scripts/uptime_probe.py "$TARGET_URL" --check status --timeout 30 --deliberate-failure
           else
-            python3 scripts/uptime_probe.py "$TARGET_URL" --check status --timeout 10
+            python3 scripts/uptime_probe.py "$TARGET_URL" --check status --timeout 30
           fi

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -156,7 +156,7 @@ func run(ctx context.Context, cfg *config.Config) (runErr error) {
 			aiHealthCheck := server.NewCachedHealthCheck(
 				server.NewAIHealthCheck(router),
 				time.Minute,
-				5*time.Second,
+				20*time.Second,
 			)
 			if !router.HasProvider() {
 				if cfg.Runtime.DevMode {

--- a/scripts/deploy-remote.sh
+++ b/scripts/deploy-remote.sh
@@ -181,7 +181,7 @@ fi
 
 echo "--- Health check: application and AI provider status ---"
 STATUS_EXPECTED='{"status":"ok","components":[{"id":"application","status":"operational"},{"id":"ai_provider","status":"operational"}]}'
-STATUS_RESPONSE=$($COMPOSE exec -T app curl -fsS --max-time 15 http://localhost:8080/health/status) || STATUS_RESPONSE=""
+STATUS_RESPONSE=$($COMPOSE exec -T app curl -fsS --max-time 30 http://localhost:8080/health/status) || STATUS_RESPONSE=""
 if [ "$STATUS_RESPONSE" != "$STATUS_EXPECTED" ]; then
   fail_release "AI response health check failed"
 fi

--- a/scripts/test_deployment_config.py
+++ b/scripts/test_deployment_config.py
@@ -181,7 +181,7 @@ class ProductionSecretDeploymentTests(unittest.TestCase):
         self.assertIn("http://localhost:8080/health/status", deploy)
         self.assertIn('"id":"ai_provider","status":"operational"', deploy)
         self.assertNotIn("PAI_AI_HEALTH_TOKEN", deploy)
-        self.assertIn("--max-time 15", deploy)
+        self.assertIn("--max-time 30", deploy)
 
     def test_remote_deploy_rolls_back_when_ai_response_is_unhealthy(self) -> None:
         deploy = source("scripts/deploy-remote.sh")


### PR DESCRIPTION
## Summary

- allow 20 seconds for the server-side primary AI completion probe
- give deployment and scheduled status clients 30 seconds, preserving a 10-second client margin
- update the deployment contract assertion

## Evidence

- a direct GPT-5.4 Codex `Reply with only OK.` probe completed in 11.67 seconds, beyond the old 5-second server timeout
- `./scripts/agent-check changed` passed the affected Go package and 9 deployment configuration tests