### PR TITLE
fix(deploy): wait for admin readiness

### DIFF
--- a/internal/releaseworkflow/workflows_test.go
+++ b/internal/releaseworkflow/workflows_test.go
@@ -956,6 +956,7 @@ type fakeDeployOptions struct {
 	smokeFails           bool
 	gooseFails           bool
 	adminHTTPFails       bool
+	adminHTTPFailures    int
 	aiStatusFails        bool
 	appLookupFails       bool
 	missingPreviousAdmin bool
@@ -1068,7 +1069,11 @@ if [ "$1" = "compose" ] && [[ "$args" == *"--profile tools run --rm goose"* ]]; 
   exit 0
 fi
 if [ "$1" = "compose" ] && [[ "$args" == *"exec -T admin wget"* ]]; then
-  if [ "$FAKE_ADMIN_HTTP_FAIL" = "true" ]; then exit 8; fi
+  count_file="$FAKE_DOCKER_STATE/admin-http"
+  count=$(cat "$count_file" 2>/dev/null || echo 0)
+  count=$((count + 1))
+  echo "$count" > "$count_file"
+  if [ "$FAKE_ADMIN_HTTP_FAIL" = "true" ] || [ "$count" -le "$FAKE_ADMIN_HTTP_FAILURES" ]; then exit 8; fi
   exit 0
 fi
 if [ "$1" = "compose" ] && [[ "$args" == *"http://localhost:8080/health/status"* ]]; then
@@ -1119,6 +1124,7 @@ exit 0
 		fmt.Sprintf("FAKE_SMOKE_FAIL=%t", options.smokeFails),
 		fmt.Sprintf("FAKE_GOOSE_FAIL=%t", options.gooseFails),
 		fmt.Sprintf("FAKE_ADMIN_HTTP_FAIL=%t", options.adminHTTPFails),
+		fmt.Sprintf("FAKE_ADMIN_HTTP_FAILURES=%d", options.adminHTTPFailures),
 		fmt.Sprintf("FAKE_AI_STATUS_FAIL=%t", options.aiStatusFails),
 		fmt.Sprintf("FAKE_APP_LOOKUP_FAIL=%t", options.appLookupFails),
 		fmt.Sprintf("FAKE_MISSING_PREVIOUS_ADMIN=%t", options.missingPreviousAdmin),
@@ -1246,6 +1252,20 @@ func TestRemoteDeploymentFreshInstallAndRollbackBehavior(t *testing.T) {
 	)
 	if strings.Contains(log, "up -d --force-recreate") {
 		t.Fatal("rollback restarted services without a complete previous image pair")
+	}
+}
+
+func TestRemoteDeploymentRetriesAdminHTTPReadiness(t *testing.T) {
+	output, log, err := runFakeDeploy(t, fakeDeployOptions{
+		appHealth:         "healthy",
+		adminHTTPFailures: 2,
+	})
+	if err != nil {
+		t.Fatalf("deployment after transient admin HTTP failures: %v\n%s", err, output)
+	}
+	requireContains(t, output, "Admin HTTP ready after attempt 3", "Deploy successful")
+	if attempts := strings.Count(log, "exec -T admin wget"); attempts != 3 {
+		t.Fatalf("admin HTTP attempts = %d, want 3", attempts)
 	}
 }
 

--- a/scripts/deploy-remote.sh
+++ b/scripts/deploy-remote.sh
@@ -206,8 +206,17 @@ RUNNING_ADMIN_ID=$(docker inspect --format '{{.Image}}' "$ADMIN_CONTAINER")
 if [ "$RUNNING_ADMIN_ID" != "$EXPECTED_ADMIN_ID" ]; then
   fail_release "admin image $RUNNING_ADMIN_ID does not match candidate $EXPECTED_ADMIN_ID"
 fi
-if ! docker compose -f docker-compose.yml -f docker-compose.prod.yml \
-  exec -T admin wget -qO- http://localhost:3000/ > /dev/null; then
+ADMIN_HTTP_READY=false
+for i in $(seq 1 30); do
+  if $COMPOSE exec -T admin wget -qO- http://localhost:3000/ > /dev/null; then
+    ADMIN_HTTP_READY=true
+    echo "Admin HTTP ready after attempt $i"
+    break
+  fi
+  echo "Attempt $i/30: admin HTTP not ready"
+  sleep 1
+done
+if [ "$ADMIN_HTTP_READY" != "true" ]; then
   fail_release "admin HTTP check failed"
 fi
 echo "Admin container is running the candidate image"


### PR DESCRIPTION
## Summary

- retry the admin nginx HTTP check for up to 30 seconds after container startup
- retain rollback when readiness never succeeds
- cover transient readiness failures with the deployment harness

## Evidence

- stable run 30643168843 passed the primary Codex completion probe in 6.16 seconds, then hit `connection refused` on the immediate admin HTTP check
- `./scripts/agent-check changed` passed `internal/releaseworkflow`, including the new transient-failure regression