### PR TITLE
fix(deploy): probe admin on IPv4 loopback

### DIFF
--- a/internal/releaseworkflow/workflows_test.go
+++ b/internal/releaseworkflow/workflows_test.go
@@ -1286,6 +1286,7 @@ func TestRemoteDeploymentContracts(t *testing.T) {
 		`SELECT to_regclass('public.users') IS NOT NULL`,
 		`RUNNING_APP_ID=$(docker inspect --format '{{.Image}}' "$APP_CONTAINER")`,
 		`RUNNING_ADMIN_ID=$(docker inspect --format '{{.Image}}' "$ADMIN_CONTAINER")`,
+		`http://127.0.0.1:3000/`,
 		`if [ "$RUNNING_APP_ID" != "$EXPECTED_APP_ID" ]`,
 		`if [ "$RUNNING_ADMIN_ID" != "$EXPECTED_ADMIN_ID" ]`,
 		`fail_release "$SMOKE_FAIL bot smoke test(s) failed"`,

--- a/scripts/deploy-remote.sh
+++ b/scripts/deploy-remote.sh
@@ -208,7 +208,7 @@ if [ "$RUNNING_ADMIN_ID" != "$EXPECTED_ADMIN_ID" ]; then
 fi
 ADMIN_HTTP_READY=false
 for i in $(seq 1 30); do
-  if $COMPOSE exec -T admin wget -qO- http://localhost:3000/ > /dev/null; then
+  if $COMPOSE exec -T admin wget -qO- http://127.0.0.1:3000/ > /dev/null; then
     ADMIN_HTTP_READY=true
     echo "Admin HTTP ready after attempt $i"
     break


### PR DESCRIPTION
## Summary

- probe nginx on `127.0.0.1:3000` instead of the ambiguous `localhost`
- lock the container-local IPv4 endpoint into the deployment contract test

## Evidence

- stable run 30644800934 passed the Codex completion check, then all 30 BusyBox wget attempts to `localhost` were refused while nginx's config listens on IPv4 `3000`
- `./scripts/agent-check changed` passed `internal/releaseworkflow`