### PR TITLE
fix(release): handle missing tag responses

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -169,7 +169,7 @@ jobs:
           SHA: ${{ needs.candidate.outputs.sha }}
           VERSION: ${{ inputs.version }}
         run: |
-          tag_sha=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$VERSION" --jq .object.sha 2>/dev/null || true)
+          tag_sha=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$VERSION" --jq .object.sha 2>/dev/null) || tag_sha=""
           if [ -z "$tag_sha" ]; then
             gh api "repos/$GITHUB_REPOSITORY/git/refs" \
               --method POST \

--- a/internal/releaseworkflow/workflows_test.go
+++ b/internal/releaseworkflow/workflows_test.go
@@ -693,6 +693,7 @@ if [ "$1" = "api" ] && [[ "$2" == */git/ref/tags/* ]]; then
     echo "$FAKE_TAG_SHA"
     exit 0
   fi
+  echo '{"message":"Not Found","status":"404"}'
   exit 1
 fi
 if [ "$1" = "release" ] && [ "$2" = "view" ]; then


### PR DESCRIPTION
## Summary

- clear the GitHub API error body when the semantic tag does not exist
- create the tag instead of mistaking a 404 response for a conflicting SHA
- reproduce the real GitHub CLI missing-ref output in the retry-safety test

## Verification

- `./scripts/agent-check changed` passed `internal/releaseworkflow`