### PR TITLE
feat(harness): harden scripted conversation fixtures

### DIFF
--- a/cmd/conversation-harness/main.go
+++ b/cmd/conversation-harness/main.go
@@ -292,7 +292,7 @@ func loadFixture(path string) (fixtureFile, error) {
 	if err != nil {
 		return fixtureFile{}, err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	decoder := yaml.NewDecoder(file)
 	decoder.KnownFields(true)

--- a/cmd/conversation-harness/main.go
+++ b/cmd/conversation-harness/main.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -22,6 +23,7 @@ import (
 	"github.com/p-n-ai/pai-bot/internal/ai"
 	"github.com/p-n-ai/pai-bot/internal/chat"
 	"github.com/p-n-ai/pai-bot/internal/curriculum"
+	"github.com/p-n-ai/pai-bot/internal/i18n"
 	"github.com/p-n-ai/pai-bot/internal/platform/airouter"
 	"github.com/p-n-ai/pai-bot/internal/platform/config"
 	"github.com/p-n-ai/pai-bot/internal/platform/featureflags"
@@ -39,20 +41,31 @@ const (
 type fixtureFile struct {
 	Version       int                `yaml:"version"`
 	Provider      string             `yaml:"provider"`
+	Characters    []characterSpec    `yaml:"characters"`
 	Conversations []conversationSpec `yaml:"conversations"`
 }
 
+type characterSpec struct {
+	ID        string `yaml:"id"`
+	FirstName string `yaml:"first_name"`
+	Username  string `yaml:"username"`
+	Language  string `yaml:"language"`
+}
+
 type conversationSpec struct {
-	ID       string         `yaml:"id"`
-	Title    string         `yaml:"title"`
-	Tags     []string       `yaml:"tags"`
-	Evidence []evidenceSpec `yaml:"evidence"`
-	Turns    []turnSpec     `yaml:"turns"`
-	Checks   behaviorChecks `yaml:"checks"`
+	ID          string         `yaml:"id"`
+	Title       string         `yaml:"title"`
+	CharacterID string         `yaml:"character"`
+	Character   characterSpec  `yaml:"-"`
+	Tags        []string       `yaml:"tags"`
+	Evidence    []evidenceSpec `yaml:"evidence"`
+	Turns       []turnSpec     `yaml:"turns"`
+	Checks      behaviorChecks `yaml:"checks"`
 }
 
 type turnSpec struct {
-	User string `yaml:"user"`
+	User   string         `yaml:"user"`
+	Checks behaviorChecks `yaml:"checks"`
 }
 
 type evidenceSpec struct {
@@ -275,18 +288,140 @@ func validateRequestOnlyMode(requestOnly bool, dumpRequestsPath string) error {
 }
 
 func loadFixture(path string) (fixtureFile, error) {
-	b, err := os.ReadFile(path)
+	file, err := os.Open(path)
 	if err != nil {
 		return fixtureFile{}, err
 	}
+	defer file.Close()
+
+	decoder := yaml.NewDecoder(file)
+	decoder.KnownFields(true)
 	var fixture fixtureFile
-	if err := yaml.Unmarshal(b, &fixture); err != nil {
+	if err := decoder.Decode(&fixture); err != nil {
 		return fixtureFile{}, err
 	}
-	if fixture.Version != 1 {
-		return fixtureFile{}, fmt.Errorf("version = %d, want 1", fixture.Version)
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return fixtureFile{}, fmt.Errorf("fixture must contain exactly one YAML document")
+		}
+		return fixtureFile{}, err
+	}
+	if err := normalizeFixture(&fixture); err != nil {
+		return fixtureFile{}, err
 	}
 	return fixture, nil
+}
+
+func normalizeFixture(fixture *fixtureFile) error {
+	if fixture.Version != 1 {
+		return fmt.Errorf("version = %d, want 1", fixture.Version)
+	}
+
+	charactersByID := make(map[string]characterSpec, len(fixture.Characters))
+	for i := range fixture.Characters {
+		character := &fixture.Characters[i]
+		character.ID = strings.TrimSpace(character.ID)
+		character.FirstName = strings.TrimSpace(character.FirstName)
+		character.Username = strings.TrimSpace(character.Username)
+		character.Language = strings.TrimSpace(character.Language)
+		if character.ID == "" {
+			return fmt.Errorf("characters[%d].id is required", i)
+		}
+		if character.Language != "" {
+			normalized := i18n.NormalizeLocale(character.Language)
+			if normalized == "" {
+				return fmt.Errorf("character %q has unsupported language %q", character.ID, character.Language)
+			}
+			character.Language = normalized
+		}
+		if _, exists := charactersByID[character.ID]; exists {
+			return fmt.Errorf("duplicate character id %q", character.ID)
+		}
+		charactersByID[character.ID] = *character
+	}
+
+	conversationIDs := make(map[string]struct{}, len(fixture.Conversations))
+	for i := range fixture.Conversations {
+		conversation := &fixture.Conversations[i]
+		conversation.ID = strings.TrimSpace(conversation.ID)
+		conversation.Title = strings.TrimSpace(conversation.Title)
+		conversation.CharacterID = strings.TrimSpace(conversation.CharacterID)
+
+		if conversation.ID == "" {
+			return fmt.Errorf("conversations[%d].id is required", i)
+		}
+		if _, exists := conversationIDs[conversation.ID]; exists {
+			return fmt.Errorf("duplicate conversation id %q", conversation.ID)
+		}
+		conversationIDs[conversation.ID] = struct{}{}
+		if conversation.Title == "" {
+			return fmt.Errorf("conversation %q title is required", conversation.ID)
+		}
+		if conversation.CharacterID != "" {
+			character, exists := charactersByID[conversation.CharacterID]
+			if !exists {
+				return fmt.Errorf("conversation %q references unknown character %q", conversation.ID, conversation.CharacterID)
+			}
+			conversation.Character = character
+		}
+		if len(conversation.Turns) == 0 {
+			return fmt.Errorf("conversation %q requires at least one turn", conversation.ID)
+		}
+		if err := normalizeBehaviorChecks(&conversation.Checks, len(conversation.Turns), fmt.Sprintf("conversation %q checks", conversation.ID)); err != nil {
+			return err
+		}
+		for j := range conversation.Turns {
+			turn := &conversation.Turns[j]
+			turn.User = strings.TrimSpace(turn.User)
+			if turn.User == "" {
+				return fmt.Errorf("conversation %q turn %d user text is required", conversation.ID, j+1)
+			}
+			if err := normalizeBehaviorChecks(&turn.Checks, len(conversation.Turns), fmt.Sprintf("conversation %q turn %d checks", conversation.ID, j+1)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func normalizeBehaviorChecks(checks *behaviorChecks, turnCount int, location string) error {
+	checks.ExpectedLanguage = strings.TrimSpace(checks.ExpectedLanguage)
+	normalizeStrings(checks.RequireResponsePhrases)
+	normalizeStrings(checks.ForbidResponsePhrases)
+	switch checks.ExpectedLanguage {
+	case "", "bm_or_mixed", "en_or_mixed":
+	default:
+		return fmt.Errorf("%s expected_language %q is unsupported", location, checks.ExpectedLanguage)
+	}
+	if checks.MaxResponseLines < 0 {
+		return fmt.Errorf("%s max_response_lines must be non-negative", location)
+	}
+	if checks.MaxResponseChars < 0 {
+		return fmt.Errorf("%s max_response_chars must be non-negative", location)
+	}
+	if err := validateTurnReferences(checks.ForbidFinalAnswerOnTurn, turnCount, location, "forbid_final_answer_on_turn"); err != nil {
+		return err
+	}
+	if err := validateTurnReferences(checks.ForbidSectionLabelsOnTurn, turnCount, location, "forbid_section_labels_on_turn"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateTurnReferences(turns []int, turnCount int, location, field string) error {
+	for _, turn := range turns {
+		if turn < 1 || turn > turnCount {
+			return fmt.Errorf("%s %s contains turn %d outside 1..%d", location, field, turn, turnCount)
+		}
+	}
+	return nil
+}
+
+func normalizeStrings(values []string) {
+	for i := range values {
+		values[i] = strings.TrimSpace(values[i])
+	}
 }
 
 func buildEngine(memory bool, mockResponse string, progressSideEffects bool, traceFunc func(ai.CompletionTrace), evidenceRetriever retrieval.TutorEvidenceRetriever) (*agent.Engine, func(), error) {
@@ -443,7 +578,11 @@ func selectConversations(conversations []conversationSpec, caseID, tag string, m
 	return selected
 }
 
-func runConversation(engine *agent.Engine, conv conversationSpec, timeout time.Duration, showResponses bool, runChecks bool) caseResult {
+type conversationProcessor interface {
+	ProcessMessage(context.Context, chat.InboundMessage) (string, error)
+}
+
+func runConversation(engine conversationProcessor, conv conversationSpec, timeout time.Duration, showResponses bool, runChecks bool) caseResult {
 	userID := "harness-" + strings.ToLower(conv.ID) + "-" + fmt.Sprint(time.Now().UnixNano())
 	responses := make([]string, 0, len(conv.Turns))
 	failures := []string{}
@@ -455,6 +594,9 @@ func runConversation(engine *agent.Engine, conv conversationSpec, timeout time.D
 			UserID:     userID,
 			DeliveryID: fmt.Sprintf("harness:%s:%d", userID, i+1),
 			Text:       turn.User,
+			FirstName:  conv.Character.FirstName,
+			Username:   conv.Character.Username,
+			Language:   conv.Character.Language,
 		})
 		cancel()
 		if err != nil {
@@ -466,6 +608,10 @@ func runConversation(engine *agent.Engine, conv conversationSpec, timeout time.D
 			fmt.Printf("\n[%s turn %d]\nUser: %s\nAssistant: %s\n", conv.ID, i+1, turn.User, resp)
 		}
 		if runChecks {
+			failures = append(failures, checkTurn(i+1, resp, turn.Checks)...)
+			for _, failure := range checkConversation(turn.Checks, responses[len(responses)-1:]) {
+				failures = append(failures, fmt.Sprintf("turn %d: %s", i+1, failure))
+			}
 			failures = append(failures, checkTurn(i+1, resp, conv.Checks)...)
 		}
 	}

--- a/cmd/conversation-harness/main_test.go
+++ b/cmd/conversation-harness/main_test.go
@@ -8,9 +8,12 @@ import (
 	"encoding/json"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/p-n-ai/pai-bot/internal/ai"
+	"github.com/p-n-ai/pai-bot/internal/chat"
 	"github.com/p-n-ai/pai-bot/internal/retrieval"
 )
 
@@ -179,6 +182,71 @@ func TestHarnessEvidenceRetrieverRejectsUnscopedLearner(t *testing.T) {
 	}
 }
 
+func TestRunConversationPropagatesCharacterOnEveryTurn(t *testing.T) {
+	processor := &recordingConversationProcessor{responses: []string{"first reply", "second reply"}}
+	conv := conversationSpec{
+		ID: "PERSONA",
+		Character: characterSpec{
+			ID:        "faris-terse",
+			FirstName: "Faris",
+			Username:  "faris",
+			Language:  "ms",
+		},
+		Turns: []turnSpec{{User: "first turn"}, {User: "second turn"}},
+	}
+
+	result := runConversation(processor, conv, time.Second, false, false)
+	if !result.Passed {
+		t.Fatalf("runConversation() failures = %v", result.Failures)
+	}
+	if len(processor.messages) != 2 {
+		t.Fatalf("ProcessMessage() calls = %d, want 2", len(processor.messages))
+	}
+	for i, msg := range processor.messages {
+		if msg.FirstName != "Faris" || msg.Username != "faris" || msg.Language != "ms" {
+			t.Errorf("turn %d persona = (%q, %q, %q), want (Faris, faris, ms)", i+1, msg.FirstName, msg.Username, msg.Language)
+		}
+	}
+	if processor.messages[0].UserID == "" || processor.messages[0].UserID != processor.messages[1].UserID {
+		t.Errorf("learner IDs = %q and %q, want one non-empty conversation learner ID", processor.messages[0].UserID, processor.messages[1].UserID)
+	}
+	if processor.messages[0].DeliveryID == processor.messages[1].DeliveryID {
+		t.Errorf("delivery IDs are not unique: %q", processor.messages[0].DeliveryID)
+	}
+}
+
+func TestRunConversationAppliesTurnLocalResponseLimitOnlyToDeclaredTurn(t *testing.T) {
+	conv := conversationSpec{
+		ID: "TURN-CHECK",
+		Turns: []turnSpec{
+			{User: "first turn"},
+			{User: "second turn", Checks: behaviorChecks{MaxResponseChars: 4}},
+		},
+	}
+
+	processor := &recordingConversationProcessor{responses: []string{"long first response", "tiny"}}
+	if result := runConversation(processor, conv, time.Second, false, true); !result.Passed {
+		t.Fatalf("turn-local limit affected another turn: %v", result.Failures)
+	}
+
+	processor = &recordingConversationProcessor{responses: []string{"long first response", "large"}}
+	result := runConversation(processor, conv, time.Second, false, true)
+	want := []string{"turn 2: response has 5 chars, max 4"}
+	if !reflect.DeepEqual(result.Failures, want) {
+		t.Fatalf("runConversation() failures = %v, want %v", result.Failures, want)
+	}
+}
+
+type recordingConversationProcessor struct {
+	responses []string
+	messages  []chat.InboundMessage
+}
+
+func (p *recordingConversationProcessor) ProcessMessage(_ context.Context, msg chat.InboundMessage) (string, error) {
+	p.messages = append(p.messages, msg)
+	return p.responses[len(p.messages)-1], nil
+}
+
 func engineTrackerIsNil(engine any) bool {
 	field := reflect.ValueOf(engine).Elem().FieldByName("tracker")
 	return field.IsNil()
@@ -187,4 +255,108 @@ func engineTrackerIsNil(engine any) bool {
 func engineCurriculumRuntimeIsNil(engine any) bool {
 	field := reflect.ValueOf(engine).Elem().FieldByName("curriculumRuntime")
 	return field.IsNil()
+}
+
+const validFixtureYAML = `version: 1
+characters:
+  - id: " teacher "
+    first_name: " Ada "
+    username: " ada-teacher "
+    language: " BM-my "
+conversations:
+  - id: " CASE-1 "
+    title: " Linear equations "
+    character: " teacher "
+    turns:
+      - user: " learner question "
+        checks:
+          expected_language: " en_or_mixed "
+          max_response_lines: 3
+    checks:
+      require_response_phrases: [" explain "]
+      forbid_final_answer_on_turn: [1]
+      max_response_chars: 200
+`
+
+func TestLoadFixtureNormalizesAndResolvesCharacter(t *testing.T) {
+	fixture, err := loadFixture(writeFixture(t, validFixtureYAML))
+	if err != nil {
+		t.Fatalf("loadFixture() error = %v", err)
+	}
+
+	wantCharacter := characterSpec{ID: "teacher", FirstName: "Ada", Username: "ada-teacher", Language: "ms"}
+	if len(fixture.Characters) != 1 || !reflect.DeepEqual(fixture.Characters[0], wantCharacter) {
+		t.Fatalf("Characters = %#v, want %#v", fixture.Characters, wantCharacter)
+	}
+	conversation := fixture.Conversations[0]
+	if conversation.ID != "CASE-1" || conversation.Title != "Linear equations" || conversation.CharacterID != "teacher" {
+		t.Fatalf("conversation identifiers were not normalized: %#v", conversation)
+	}
+	if !reflect.DeepEqual(conversation.Character, wantCharacter) {
+		t.Fatalf("resolved Character = %#v, want %#v", conversation.Character, wantCharacter)
+	}
+
+	if conversation.Turns[0].User != "learner question" || conversation.Turns[0].Checks.ExpectedLanguage != "en_or_mixed" {
+		t.Fatalf("turn was not normalized: %#v", conversation.Turns[0])
+	}
+	if conversation.Checks.RequireResponsePhrases[0] != "explain" {
+		t.Fatalf("conversation checks were not normalized: %#v", conversation.Checks)
+	}
+}
+
+func TestLoadFixtureRejectsInvalidYAMLContracts(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{name: "unknown field", yaml: validFixtureYAML + "typo: true\n", want: "field typo not found"},
+		{name: "multiple documents", yaml: validFixtureYAML + "---\nversion: 1\n", want: "exactly one YAML document"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := loadFixture(writeFixture(t, test.yaml))
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("loadFixture() error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestLoadFixtureRejectsInvalidSemantics(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{name: "unsupported version", yaml: strings.Replace(validFixtureYAML, "version: 1", "version: 2", 1), want: "want 1"},
+
+		{name: "duplicate character id", yaml: strings.Replace(validFixtureYAML, "conversations:\n", "  - id: teacher\n    first_name: Other\n    username: other\n    language: en\nconversations:\n", 1), want: `duplicate character id "teacher"`},
+
+		{name: "unknown character", yaml: strings.Replace(validFixtureYAML, `    character: " teacher "`, `    character: missing`, 1), want: `unknown character "missing"`},
+		{name: "unsupported character language", yaml: strings.Replace(validFixtureYAML, `    language: " BM-my "`, `    language: klingon`, 1), want: `unsupported language "klingon"`},
+
+		{name: "missing learner text", yaml: strings.Replace(validFixtureYAML, `      - user: " learner question "`, `      - user: "   "`, 1), want: "user text is required"},
+		{name: "unsupported language", yaml: strings.Replace(validFixtureYAML, `expected_language: " en_or_mixed "`, `expected_language: klingon`, 1), want: "expected_language"},
+		{name: "negative turn limit", yaml: strings.Replace(validFixtureYAML, "max_response_lines: 3", "max_response_lines: -1", 1), want: "max_response_lines must be non-negative"},
+
+		{name: "out of range conversation turn reference", yaml: strings.Replace(validFixtureYAML, "forbid_final_answer_on_turn: [1]", "forbid_final_answer_on_turn: [2]", 1), want: "outside 1..1"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := loadFixture(writeFixture(t, test.yaml))
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("loadFixture() error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
+func writeFixture(t *testing.T, contents string) string {
+	t.Helper()
+	path := t.TempDir() + "/fixture.yaml"
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	return path
 }

--- a/internal/agent/testdata/ai_quality_conversations.yaml
+++ b/internal/agent/testdata/ai_quality_conversations.yaml
@@ -1,5 +1,10 @@
 version: 1
 provider: openai
+characters:
+  - id: faris-terse
+    first_name: Faris
+    username: faris
+    language: ms
 conversations:
   - id: G01
     title: Teacher slide and OSS guidance are fused with citations
@@ -221,3 +226,24 @@ conversations:
       forbid_section_labels_on_turn: [1]
       max_response_lines: 5
       max_response_chars: 420
+
+  - id: Q12
+    title: Terse follow-ups retain context without over-answering
+    tags: [short-replies, continuity, bm, naturalness]
+    character: faris-terse
+    turns:
+      - user: "Saya tak faham kenapa 2x bermaksud dua kali x."
+      - user: "hah?"
+        checks:
+          max_response_lines: 4
+          max_response_chars: 260
+      - user: "kenapa?"
+        checks:
+          max_response_lines: 4
+          max_response_chars: 260
+    checks:
+      require_non_empty_replies: true
+      forbid_fallback_message: true
+      forbid_markdown_and_latex: true
+      forbid_section_labels_on_turn: [2, 3]
+      expected_language: bm_or_mixed


### PR DESCRIPTION
## Summary

- decode conversation fixtures strictly and reject invalid IDs, locales, turn references, and limits before execution
- resolve character profiles once and attach the selected persona to every scripted learner turn
- support turn-local response checks while retaining conversation-wide checks, including a sequential Bahasa Melayu terse-follow-up case

## Verification

- `./scripts/agent-check changed`