### PR TITLE
feat(agent): support Agent Skills

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -127,6 +127,10 @@ LEARN_TENANT_MODE=single
 # --- Curriculum ---
 LEARN_CURRICULUM_PATH=./oss
 
+# --- Agent Skills ---
+# Built-in system skills; override only to use another trusted directory.
+LEARN_SKILLS_PATH=./skills
+
 # --- Features ---
 PAI_FEATURES=
 LEARN_DEV_MODE=true

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/p-n-ai/pai-bot/internal/adminapi"
 	"github.com/p-n-ai/pai-bot/internal/agent"
+	"github.com/p-n-ai/pai-bot/internal/agentskills"
 	"github.com/p-n-ai/pai-bot/internal/ai"
 	"github.com/p-n-ai/pai-bot/internal/auth"
 	"github.com/p-n-ai/pai-bot/internal/chat"
@@ -245,6 +246,13 @@ func run(ctx context.Context, cfg *config.Config) (runErr error) {
 				topics := loader.AllTopics()
 				slog.Info("curriculum ready", "topics", len(topics))
 			}
+			skillRegistry, err := agentskills.LoadOptional(cfg.SkillsPath)
+			if err != nil {
+				return nil, nil, fmt.Errorf("load agent skills: %w", err)
+			}
+			if skillRegistry != nil {
+				slog.Info("agent skills ready", "skills", skillRegistry.Len())
+			}
 			retrievalService := server.NewBootstrapRetrievalService(loader)
 			var retrievalEmbedder retrieval.Embedder
 			if strings.TrimSpace(cfg.Retrieval.EmbeddingBaseURL) != "" {
@@ -315,6 +323,7 @@ func run(ctx context.Context, cfg *config.Config) (runErr error) {
 				DevMode:              cfg.Runtime.DevMode,
 				FeatureFlags:         flagsProvider,
 				FocusedPages:         focusedPageService,
+				Skills:               skillRegistry,
 				FocusedPageEnabled: func(msg chat.InboundMessage) bool {
 					return focusedPageChannelEnabled(cfg.Runtime.DevMode, msg)
 				},
@@ -459,6 +468,7 @@ func run(ctx context.Context, cfg *config.Config) (runErr error) {
 					DevMode:              cfg.Runtime.DevMode,
 					FeatureFlags:         flagsProvider,
 					FocusedPages:         focusedPageService,
+					Skills:               skillRegistry,
 					FocusedPageEnabled: func(msg chat.InboundMessage) bool {
 						return focusedPageChannelEnabled(cfg.Runtime.DevMode, msg)
 					},

--- a/cmd/terminal-chat/main.go
+++ b/cmd/terminal-chat/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/coder/websocket"
 
 	"github.com/p-n-ai/pai-bot/internal/agent"
+	"github.com/p-n-ai/pai-bot/internal/agentskills"
 	"github.com/p-n-ai/pai-bot/internal/ai"
 	"github.com/p-n-ai/pai-bot/internal/chat"
 	"github.com/p-n-ai/pai-bot/internal/curriculum"
@@ -138,6 +139,11 @@ func main() {
 	if err != nil {
 		slog.Warn("curriculum not loaded", "path", cfg.CurriculumPath, "error", err)
 	}
+	skillRegistry, err := agentskills.LoadOptional(cfg.SkillsPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "load agent skills: %v\n", err)
+		os.Exit(1)
+	}
 
 	state, cleanup, err := terminalchat.BuildState(sessionCtx, cfg.Database, terminalchat.StateOptions{
 		Memory:  memory,
@@ -188,6 +194,7 @@ func main() {
 		DevMode:              cfg.Runtime.DevMode,
 		FeatureFlags:         func() featureflags.Features { return cfg.FeatureFlags },
 		FocusedPages:         focusedPageService,
+		Skills:               skillRegistry,
 		FocusedPageEnabled: func(msg chat.InboundMessage) bool {
 			return msg.Channel == "telegram"
 		},
@@ -230,6 +237,11 @@ func main() {
 	if interactive {
 		factory := func(candidate terminalchat.Candidate) (terminalchat.Processor, error) {
 			localCfg := engineCfg
+			reloadedSkills, err := agentskills.LoadOptional(cfg.SkillsPath)
+			if err != nil {
+				return nil, fmt.Errorf("reload agent skills: %w", err)
+			}
+			localCfg.Skills = reloadedSkills
 			localCfg.Store = agent.NewMemoryStore()
 			localCfg.EventLogger = agent.NewMemoryEventLogger()
 			localCfg.Goals = agent.NewMemoryGoalStore()

--- a/cmd/terminal-chat/session_test.go
+++ b/cmd/terminal-chat/session_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/p-n-ai/pai-bot/internal/agent"
+	"github.com/p-n-ai/pai-bot/internal/agentskills"
 	"github.com/p-n-ai/pai-bot/internal/chat"
 	"github.com/p-n-ai/pai-bot/internal/terminalchat"
 )
@@ -171,6 +172,59 @@ characters:
 	}
 }
 
+func TestInteractiveTerminalSessionReloadsSkillsAtomically(t *testing.T) {
+	directory := t.TempDir()
+	writeTerminalSessionFile(t, directory, `prompt: candidate
+default: aina
+characters:
+  - id: aina
+`)
+	skillsRoot := filepath.Join(t.TempDir(), "skills")
+	writeReloadSkill(t, skillsRoot, "Teach the old way.")
+
+	session, err := newInteractiveTerminalSession(
+		terminalchat.NewCandidateSource(directory),
+		"codex",
+		func(terminalchat.Candidate) (terminalchat.Processor, error) {
+			registry, err := agentskills.Load(skillsRoot)
+			if err != nil {
+				return nil, err
+			}
+			return &recordingTerminalProcessor{prompt: registry.AlwaysActivePrompt()}, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("newInteractiveTerminalSession() error = %v", err)
+	}
+
+	invalidSkill := "---\nname: teacher\ndescription: Teaching guidance\nunknown: field\n---\nTeach the broken way."
+	if err := os.WriteFile(filepath.Join(skillsRoot, "teacher", "SKILL.md"), []byte(invalidSkill), 0o600); err != nil {
+		t.Fatalf("write invalid skill: %v", err)
+	}
+	if _, err := session.Reload(t.Context()); err == nil {
+		t.Fatal("Reload() error = nil, want invalid skill failure")
+	}
+	result, err := session.ProcessTurn(t.Context(), chat.InboundMessage{Text: "still old"})
+	if err != nil {
+		t.Fatalf("ProcessTurn() after failed reload error = %v", err)
+	}
+	if !strings.Contains(result.Text, "Teach the old way.") {
+		t.Fatalf("reply after failed reload = %q, want old skill", result.Text)
+	}
+
+	writeReloadSkill(t, skillsRoot, "Teach the new way.")
+	if _, err := session.Reload(t.Context()); err != nil {
+		t.Fatalf("Reload(valid) error = %v", err)
+	}
+	result, err = session.ProcessTurn(t.Context(), chat.InboundMessage{Text: "now new"})
+	if err != nil {
+		t.Fatalf("ProcessTurn() after reload error = %v", err)
+	}
+	if !strings.Contains(result.Text, "Teach the new way.") {
+		t.Fatalf("reply after valid reload = %q, want new skill", result.Text)
+	}
+}
+
 func TestInteractiveTerminalSessionCharacterFactoryFailureIsAtomic(t *testing.T) {
 	directory := t.TempDir()
 	writeTerminalSessionFile(t, directory, `prompt: candidate
@@ -225,5 +279,17 @@ func writeTerminalSessionFile(t *testing.T, directory, content string) {
 	const filename = "candidate.yaml"
 	if err := os.WriteFile(filepath.Join(directory, filename), []byte(content), 0o600); err != nil {
 		t.Fatalf("write %s: %v", filename, err)
+	}
+}
+
+func writeReloadSkill(t *testing.T, root, instructions string) {
+	t.Helper()
+	directory := filepath.Join(root, "teacher")
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		t.Fatalf("create skill directory: %v", err)
+	}
+	contents := "---\nname: teacher\ndescription: Teaching guidance\nmetadata:\n  activation: always\n---\n" + instructions
+	if err := os.WriteFile(filepath.Join(directory, "SKILL.md"), []byte(contents), 0o600); err != nil {
+		t.Fatalf("write reload skill: %v", err)
 	}
 }

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -34,6 +34,7 @@ COPY --from=builder /pai-terminal-nudge /pai-terminal-nudge
 COPY --from=builder /pai-seed /pai-seed
 COPY --from=builder /pai-validate-production-secrets /pai-validate-production-secrets
 COPY oss /oss
+COPY skills /skills
 COPY migrations /migrations
 COPY --from=codex-cli /codex /usr/local/bin/codex
 RUN codex --version

--- a/docs/agent-skills.md
+++ b/docs/agent-skills.md
@@ -17,7 +17,7 @@ At startup, pai-bot validates each `SKILL.md` and loads only its `name` and `des
 
 The configured directory is an operator-controlled trust boundary. Pai-bot does not download skills or execute bundled scripts. The experimental `allowed-tools` field is parsed for format compatibility but does not grant tools or override pai-bot's runtime policy.
 
-Set `metadata.activation: always` for trusted skills that must be added to every model-facing system prompt. This works with managed Codex and providers without native tool continuation. Other skills retain metadata-first, tool-driven activation.
+Set `metadata.activation: always` for trusted skills that must be added to every model-facing system prompt. This works with managed Codex and providers without native tool continuation. Other skills automatically use metadata-first, tool-driven activation when a native provider is available.
 
 In `just chat-codex`, `/reload` re-parses `LEARN_SKILLS_PATH` and starts a fresh memory session. An invalid skill rejects the reload and preserves the active session. The long-running server loads skills at startup and currently requires a restart to refresh them.
 

--- a/docs/agent-skills.md
+++ b/docs/agent-skills.md
@@ -1,0 +1,24 @@
+# Agent Skills
+
+Pai-bot can load trusted, local [Agent Skills](https://agentskills.io/specification) bundles for native tool-capable teaching turns.
+
+Pai-bot loads built-in system skills from `./skills` by default. Set `LEARN_SKILLS_PATH` only to override that trusted directory. It contains one child directory per skill:
+
+```text
+skills/
+└── maths-coach/
+    ├── SKILL.md
+    ├── references/
+    ├── scripts/
+    └── assets/
+```
+
+At startup, pai-bot validates each `SKILL.md` and loads only its `name` and `description` into the tutor prompt. When a learner request matches, the model uses `load_skill` to load the complete Markdown instructions. It can then use `read_skill_resource` for referenced UTF-8 text files. Reads are limited to the selected skill directory and files up to 1 MiB.
+
+The configured directory is an operator-controlled trust boundary. Pai-bot does not download skills or execute bundled scripts. The experimental `allowed-tools` field is parsed for format compatibility but does not grant tools or override pai-bot's runtime policy.
+
+Set `metadata.activation: always` for trusted skills that must be added to every model-facing system prompt. This works with managed Codex and providers without native tool continuation. Other skills retain metadata-first, tool-driven activation.
+
+In `just chat-codex`, `/reload` re-parses `LEARN_SKILLS_PATH` and starts a fresh memory session. An invalid skill rejects the reload and preserves the active session. The long-running server loads skills at startup and currently requires a restart to refresh them.
+
+Invalid system skills fail startup so pai-bot never silently runs without its configured behavior.

--- a/internal/agent/curriculum_tool.go
+++ b/internal/agent/curriculum_tool.go
@@ -61,8 +61,9 @@ func (t curriculumLookupTool) Execute(_ context.Context, call llm.ToolCall) (llm
 }
 
 func (e *Engine) teachingTools() []agentcore.Tool {
-	if e.curriculumLoader == nil || e.curriculumRuntime != nil {
-		return nil
+	tools := e.skills.Tools()
+	if e.curriculumLoader != nil && e.curriculumRuntime == nil {
+		tools = append(tools, curriculumLookupTool{loader: e.curriculumLoader})
 	}
-	return []agentcore.Tool{curriculumLookupTool{loader: e.curriculumLoader}}
+	return tools
 }

--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -15,6 +15,7 @@ import (
 
 	"time"
 
+	"github.com/p-n-ai/pai-bot/internal/agentskills"
 	"github.com/p-n-ai/pai-bot/internal/ai"
 	"github.com/p-n-ai/pai-bot/internal/chat"
 	"github.com/p-n-ai/pai-bot/internal/curriculum"
@@ -79,6 +80,7 @@ type EngineConfig struct {
 	FocusedPageEnabled    func(chat.InboundMessage) bool
 	TurnDeliverer         TurnDeliverer
 	TutorPromptExtension  string
+	Skills                *agentskills.Registry
 }
 
 // Engine is the core conversation processor.
@@ -114,6 +116,7 @@ type Engine struct {
 	turnLocks             keyedTurnLocks
 	turnDeliverer         TurnDeliverer
 	tutorPromptExtension  string
+	skills                *agentskills.Registry
 }
 
 // NewEngine creates a new agent engine.
@@ -205,6 +208,7 @@ func NewEngine(cfg EngineConfig) *Engine {
 		focusedPageEnabled:    focusedPageEnabled,
 		turnDeliverer:         cfg.TurnDeliverer,
 		tutorPromptExtension:  strings.TrimSpace(cfg.TutorPromptExtension),
+		skills:                cfg.Skills,
 	}
 }
 

--- a/internal/agent/focused_page_tool.go
+++ b/internal/agent/focused_page_tool.go
@@ -21,6 +21,8 @@ import (
 const createFocusedPageToolName = "create_focused_page"
 
 func (e *Engine) completeTeachingTurn(ctx context.Context, turn *agentTurn, messages []ai.Message, model string) (teachingCompletion, *focusedpage.Artifact, error) {
+	nativeSkillTools := e.skills.HasOnDemandSkills() && e.aiRouter.HasNativeProvider()
+	useAgentCore := e.featureFlags().Enabled(featureflags.AgentCore) || nativeSkillTools
 	focusedConfigured := e.focusedPages != nil && e.focusedPageEnabled(chat.InboundMessage{
 		Channel: turn.Channel,
 		UserID:  turn.UserID,
@@ -29,7 +31,7 @@ func (e *Engine) completeTeachingTurn(ctx context.Context, turn *agentTurn, mess
 		completion, err := e.completeTextTeachingTurn(ctx, messages, model)
 		return completion, nil, err
 	}
-	if !focusedConfigured && !e.featureFlags().Enabled(featureflags.AgentCore) {
+	if !focusedConfigured && !useAgentCore {
 		completion, err := e.completeTextTeachingTurn(ctx, messages, model)
 		return completion, nil, err
 	}
@@ -54,7 +56,7 @@ func (e *Engine) completeTeachingTurn(ctx context.Context, turn *agentTurn, mess
 		},
 	}
 	tools := []agentcore.Tool{tool}
-	if e.featureFlags().Enabled(featureflags.AgentCore) {
+	if useAgentCore {
 		tools = append(e.teachingTools(), tools...)
 	}
 	completion, err := e.completeNativeTeachingTurnWithTools(ctx, turn, model, tools)

--- a/internal/agent/native_teaching.go
+++ b/internal/agent/native_teaching.go
@@ -29,6 +29,7 @@ func (e *Engine) completeNativeTeachingTurnWithTools(ctx context.Context, turn *
 	if err != nil {
 		return teachingCompletion{}, err
 	}
+	e.addSkillCatalog(&nativeContext)
 	model := ai.NewNativeModel(e.aiRouter, ai.NativeModelConfig{Task: ai.TaskTeaching, Model: modelID})
 	result, err := agentcore.Run(ctx, model, nativeContext, tools, agentcore.Config{
 		MaxModelCalls:  agentcore.DefaultMaxModelCalls,
@@ -64,4 +65,10 @@ func (e *Engine) completeNativeTeachingTurnWithTools(ctx context.Context, turn *
 		completion.Model = result.Final.Model
 	}
 	return completion, nil
+}
+
+func (e *Engine) addSkillCatalog(nativeContext *llm.Context) {
+	if catalog := e.skills.CatalogPrompt(); catalog != "" {
+		nativeContext.SystemPrompt += "\n\n" + catalog
+	}
 }

--- a/internal/agent/prompt_builder.go
+++ b/internal/agent/prompt_builder.go
@@ -22,11 +22,23 @@ func (e *Engine) buildPromptMessagesFromTurn(turn *agentTurn) []ai.Message {
 	compiler := promptCompiler{engine: e}
 	messages, manifest, err := compiler.compile(turn)
 	if err == nil {
+		e.addAlwaysActiveSkills(messages)
 		turn.Prompt = manifest
 		return messages
 	}
 
-	return []ai.Message{{Role: "system", Content: e.buildSystemPromptFromTurn(turn)}, {Role: "user", Content: turn.UserContent}}
+	messages = []ai.Message{{Role: "system", Content: e.buildSystemPromptFromTurn(turn)}, {Role: "user", Content: turn.UserContent}}
+	e.addAlwaysActiveSkills(messages)
+	return messages
+}
+
+func (e *Engine) addAlwaysActiveSkills(messages []ai.Message) {
+	if len(messages) == 0 || messages[0].Role != "system" {
+		return
+	}
+	if instructions := e.skills.AlwaysActivePrompt(); instructions != "" {
+		messages[0].Content += "\n\n" + instructions
+	}
 }
 
 type promptCompiler struct {

--- a/internal/agent/skills_test.go
+++ b/internal/agent/skills_test.go
@@ -4,14 +4,36 @@
 package agent
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/p-n-ai/pai-bot/internal/agentskills"
+	"github.com/p-n-ai/pai-bot/internal/ai"
 	"github.com/p-n-ai/pai-bot/internal/llm"
 )
+
+type skillsNativeProvider struct {
+	response llm.AssistantMessage
+}
+
+func (p *skillsNativeProvider) CompleteNative(context.Context, string, llm.Context, *llm.StreamOptions) (llm.AssistantMessage, error) {
+	return p.response, nil
+}
+
+func (*skillsNativeProvider) Complete(context.Context, ai.CompletionRequest) (ai.CompletionResponse, error) {
+	return ai.CompletionResponse{}, errors.New("legacy completion should not run")
+}
+
+func (*skillsNativeProvider) StreamComplete(context.Context, ai.CompletionRequest) (<-chan ai.StreamChunk, error) {
+	return nil, errors.New("legacy stream should not run")
+}
+
+func (*skillsNativeProvider) Models() []ai.ModelInfo            { return nil }
+func (*skillsNativeProvider) HealthCheck(context.Context) error { return nil }
 
 func TestEngineAdvertisesAndRegistersConfiguredSkills(t *testing.T) {
 	root := t.TempDir()
@@ -37,6 +59,36 @@ func TestEngineAdvertisesAndRegistersConfiguredSkills(t *testing.T) {
 	tools := engine.teachingTools()
 	if len(tools) != 2 || tools[0].Definition().Name != "load_skill" || tools[1].Definition().Name != "read_skill_resource" {
 		t.Fatalf("teaching tools = %#v", tools)
+	}
+}
+
+func TestOnDemandSkillsEnableNativeTeachingWithoutFeatureFlag(t *testing.T) {
+	root := t.TempDir()
+	skillRoot := filepath.Join(root, "study-planner")
+	if err := os.MkdirAll(skillRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	contents := "---\nname: study-planner\ndescription: Build a study plan.\n---\nPlan one week."
+	if err := os.WriteFile(filepath.Join(skillRoot, "SKILL.md"), []byte(contents), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	registry, err := agentskills.Load(root)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	router := ai.NewRouter()
+	router.Register("native", &skillsNativeProvider{response: llm.AssistantMessage{
+		Content: []llm.AssistantContent{llm.TextContent{Text: "native response"}},
+	}})
+	engine := NewEngine(EngineConfig{AIRouter: router, Skills: registry})
+	turn := &agentTurn{UserContent: "Plan my week", Conversation: &Conversation{}}
+
+	completion, _, err := engine.completeTeachingTurn(t.Context(), turn, engine.buildPromptMessagesFromTurn(turn), "")
+	if err != nil {
+		t.Fatalf("completeTeachingTurn() error = %v", err)
+	}
+	if completion.Content != "native response" {
+		t.Fatalf("completion = %q, want native response", completion.Content)
 	}
 }
 

--- a/internal/agent/skills_test.go
+++ b/internal/agent/skills_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/p-n-ai/pai-bot/internal/agentskills"
+	"github.com/p-n-ai/pai-bot/internal/llm"
+)
+
+func TestEngineAdvertisesAndRegistersConfiguredSkills(t *testing.T) {
+	root := t.TempDir()
+	skillRoot := filepath.Join(root, "study-planner")
+	if err := os.MkdirAll(skillRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	contents := "---\nname: study-planner\ndescription: Build a study plan when a learner asks for one.\n---\nPlan one week at a time."
+	if err := os.WriteFile(filepath.Join(skillRoot, "SKILL.md"), []byte(contents), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	registry, err := agentskills.Load(root)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	engine := NewEngine(EngineConfig{Skills: registry})
+	context := llm.Context{SystemPrompt: "Tutor policy"}
+
+	engine.addSkillCatalog(&context)
+	if !strings.Contains(context.SystemPrompt, "study-planner: Build a study plan") || strings.Contains(context.SystemPrompt, "Plan one week") {
+		t.Fatalf("system prompt = %q", context.SystemPrompt)
+	}
+	tools := engine.teachingTools()
+	if len(tools) != 2 || tools[0].Definition().Name != "load_skill" || tools[1].Definition().Name != "read_skill_resource" {
+		t.Fatalf("teaching tools = %#v", tools)
+	}
+}
+
+func TestEngineOmitsSkillsWhenNotConfigured(t *testing.T) {
+	engine := NewEngine(EngineConfig{})
+	context := llm.Context{SystemPrompt: "Tutor policy"}
+	engine.addSkillCatalog(&context)
+	if context.SystemPrompt != "Tutor policy" || len(engine.teachingTools()) != 0 {
+		t.Fatalf("unconfigured skills changed runtime: context=%q tools=%d", context.SystemPrompt, len(engine.teachingTools()))
+	}
+}
+
+func TestEngineAddsAlwaysActiveSkillToLegacyPrompt(t *testing.T) {
+	root := t.TempDir()
+	skillRoot := filepath.Join(root, "teacher")
+	if err := os.MkdirAll(skillRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	contents := "---\nname: teacher\ndescription: Teach as a learning buddy.\nmetadata:\n  activation: always\n---\nTeach one useful move at a time."
+	if err := os.WriteFile(filepath.Join(skillRoot, "SKILL.md"), []byte(contents), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	registry, err := agentskills.Load(root)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	engine := NewEngine(EngineConfig{Skills: registry})
+	turn := &agentTurn{UserContent: "Help me", Conversation: &Conversation{}}
+
+	messages := engine.buildPromptMessagesFromTurn(turn)
+	if len(messages) == 0 || !strings.Contains(messages[0].Content, "ACTIVE SKILL: teacher") || !strings.Contains(messages[0].Content, "Teach one useful move") {
+		t.Fatalf("system prompt = %#v", messages)
+	}
+}

--- a/internal/agentskills/registry.go
+++ b/internal/agentskills/registry.go
@@ -1,0 +1,277 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package agentskills loads and exposes Agent Skills specification bundles.
+package agentskills
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	skillFilename = "SKILL.md"
+	maxSkillBytes = 1 << 20
+)
+
+var validName = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
+
+// Skill is one parsed Agent Skills bundle.
+type Skill struct {
+	Name          string
+	Description   string
+	License       string
+	Compatibility string
+	Metadata      map[string]string
+	AllowedTools  string
+	instructions  string
+	document      string
+	root          string
+}
+
+type frontmatter struct {
+	Name          string            `yaml:"name"`
+	Description   string            `yaml:"description"`
+	License       string            `yaml:"license"`
+	Compatibility string            `yaml:"compatibility"`
+	Metadata      map[string]string `yaml:"metadata"`
+	AllowedTools  string            `yaml:"allowed-tools"`
+}
+
+// Registry is an immutable collection of validated skills indexed by name.
+type Registry struct {
+	skills map[string]Skill
+	names  []string
+}
+
+// LoadOptional loads a configured skills root or disables skills for an empty path.
+func LoadOptional(root string) (*Registry, error) {
+	if strings.TrimSpace(root) == "" {
+		return nil, nil
+	}
+	return Load(root)
+}
+
+// Load discovers immediate child directories containing SKILL.md files.
+func Load(root string) (*Registry, error) {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return nil, errors.New("skills root is required")
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("resolve skills root: %w", err)
+	}
+	entries, err := os.ReadDir(absRoot)
+	if err != nil {
+		return nil, fmt.Errorf("read skills root: %w", err)
+	}
+
+	registry := &Registry{skills: make(map[string]Skill)}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		skillPath := filepath.Join(absRoot, entry.Name(), skillFilename)
+		if _, err := os.Stat(skillPath); errors.Is(err, os.ErrNotExist) {
+			continue
+		} else if err != nil {
+			return nil, fmt.Errorf("inspect %s: %w", skillPath, err)
+		}
+		skill, err := parse(skillPath, entry.Name())
+		if err != nil {
+			return nil, err
+		}
+		if _, exists := registry.skills[skill.Name]; exists {
+			return nil, fmt.Errorf("duplicate skill %q", skill.Name)
+		}
+		registry.skills[skill.Name] = skill
+		registry.names = append(registry.names, skill.Name)
+	}
+	sort.Strings(registry.names)
+	return registry, nil
+}
+
+func parse(path, directoryName string) (Skill, error) {
+	contents, err := readBoundedFile(path)
+	if err != nil {
+		return Skill{}, fmt.Errorf("read skill %s: %w", directoryName, err)
+	}
+	header, body, err := splitDocument(contents)
+	if err != nil {
+		return Skill{}, fmt.Errorf("parse skill %s: %w", directoryName, err)
+	}
+	var metadata frontmatter
+	decoder := yaml.NewDecoder(strings.NewReader(header))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&metadata); err != nil {
+		return Skill{}, fmt.Errorf("parse skill %s frontmatter: %w", directoryName, err)
+	}
+	if err := validate(metadata, directoryName); err != nil {
+		return Skill{}, fmt.Errorf("validate skill %s: %w", directoryName, err)
+	}
+	return Skill{
+		Name:          metadata.Name,
+		Description:   metadata.Description,
+		License:       metadata.License,
+		Compatibility: metadata.Compatibility,
+		Metadata:      metadata.Metadata,
+		AllowedTools:  metadata.AllowedTools,
+		instructions:  strings.TrimSpace(body),
+		document:      strings.TrimSpace(contents),
+		root:          filepath.Dir(path),
+	}, nil
+}
+
+func splitDocument(contents string) (string, string, error) {
+	if !strings.HasPrefix(contents, "---\n") {
+		return "", "", errors.New("SKILL.md must start with YAML frontmatter")
+	}
+	remainder := strings.TrimPrefix(contents, "---\n")
+	end := strings.Index(remainder, "\n---\n")
+	if end < 0 {
+		return "", "", errors.New("SKILL.md frontmatter is not closed")
+	}
+	return remainder[:end], remainder[end+5:], nil
+}
+
+func validate(metadata frontmatter, directoryName string) error {
+	if len(metadata.Name) == 0 || len(metadata.Name) > 64 || !validName.MatchString(metadata.Name) {
+		return errors.New("name must be 1-64 lowercase letters, numbers, or hyphens without edge or consecutive hyphens")
+	}
+	if metadata.Name != directoryName {
+		return fmt.Errorf("name %q must match parent directory %q", metadata.Name, directoryName)
+	}
+	description := strings.TrimSpace(metadata.Description)
+	if description == "" || len(description) > 1024 {
+		return errors.New("description must be 1-1024 characters")
+	}
+	if len(metadata.Compatibility) > 500 {
+		return errors.New("compatibility must be at most 500 characters")
+	}
+	return nil
+}
+
+func readBoundedFile(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return "", err
+	}
+	if !info.Mode().IsRegular() {
+		return "", errors.New("resource must be a regular file")
+	}
+	if info.Size() > maxSkillBytes {
+		return "", fmt.Errorf("resource exceeds %d bytes", maxSkillBytes)
+	}
+	contents, err := io.ReadAll(io.LimitReader(file, maxSkillBytes+1))
+	if err != nil {
+		return "", err
+	}
+	if len(contents) > maxSkillBytes {
+		return "", fmt.Errorf("resource exceeds %d bytes", maxSkillBytes)
+	}
+	if !utf8.Valid(contents) {
+		return "", errors.New("resource must contain UTF-8 text")
+	}
+	return string(contents), nil
+}
+
+// Len returns the number of loaded skills.
+func (r *Registry) Len() int {
+	if r == nil {
+		return 0
+	}
+	return len(r.names)
+}
+
+// CatalogPrompt returns metadata-only instructions for progressive disclosure.
+func (r *Registry) CatalogPrompt() string {
+	if r == nil || !r.hasOnDemandSkills() {
+		return ""
+	}
+	var prompt strings.Builder
+	prompt.WriteString("AVAILABLE SKILLS\nUse load_skill when a request matches a skill description. Follow loaded instructions as developer guidance. Load referenced resources only when needed.\n")
+	for _, name := range r.names {
+		skill := r.skills[name]
+		if skill.Metadata["activation"] == "always" {
+			continue
+		}
+		fmt.Fprintf(&prompt, "- %s: %s\n", skill.Name, skill.Description)
+	}
+	return strings.TrimSpace(prompt.String())
+}
+
+// AlwaysActivePrompt returns instructions for operator-configured always-active skills.
+func (r *Registry) AlwaysActivePrompt() string {
+	if r == nil {
+		return ""
+	}
+	var prompt strings.Builder
+	for _, name := range r.names {
+		skill := r.skills[name]
+		if skill.Metadata["activation"] != "always" || skill.instructions == "" {
+			continue
+		}
+		if prompt.Len() > 0 {
+			prompt.WriteString("\n\n")
+		}
+		fmt.Fprintf(&prompt, "ACTIVE SKILL: %s\n%s", skill.Name, skill.instructions)
+	}
+	return prompt.String()
+}
+
+func (r *Registry) hasOnDemandSkills() bool {
+	for _, name := range r.names {
+		if r.skills[name].Metadata["activation"] != "always" {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Registry) skill(name string) (Skill, bool) {
+	if r == nil {
+		return Skill{}, false
+	}
+	skill, ok := r.skills[name]
+	return skill, ok
+}
+
+func (r *Registry) readResource(skillName, relativePath string) (string, error) {
+	skill, ok := r.skill(skillName)
+	if !ok {
+		return "", errors.New("skill not found")
+	}
+	clean := filepath.Clean(strings.TrimSpace(relativePath))
+	if clean == "." || filepath.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", errors.New("resource path must stay inside the skill directory")
+	}
+	path := filepath.Join(skill.root, clean)
+	realRoot, err := filepath.EvalSymlinks(skill.root)
+	if err != nil {
+		return "", err
+	}
+	realPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", err
+	}
+	rel, err := filepath.Rel(realRoot, realPath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", errors.New("resource path escapes the skill directory")
+	}
+	return readBoundedFile(realPath)
+}

--- a/internal/agentskills/registry.go
+++ b/internal/agentskills/registry.go
@@ -133,15 +133,19 @@ func parse(path, directoryName string) (Skill, error) {
 }
 
 func splitDocument(contents string) (string, string, error) {
+	contents = strings.ReplaceAll(contents, "\r\n", "\n")
 	if !strings.HasPrefix(contents, "---\n") {
 		return "", "", errors.New("SKILL.md must start with YAML frontmatter")
 	}
 	remainder := strings.TrimPrefix(contents, "---\n")
 	end := strings.Index(remainder, "\n---\n")
-	if end < 0 {
-		return "", "", errors.New("SKILL.md frontmatter is not closed")
+	if end >= 0 {
+		return remainder[:end], remainder[end+5:], nil
 	}
-	return remainder[:end], remainder[end+5:], nil
+	if header, ok := strings.CutSuffix(remainder, "\n---"); ok {
+		return header, "", nil
+	}
+	return "", "", errors.New("SKILL.md frontmatter is not closed")
 }
 
 func validate(metadata frontmatter, directoryName string) error {
@@ -166,7 +170,7 @@ func readBoundedFile(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 	info, err := file.Stat()
 	if err != nil {
 		return "", err
@@ -241,6 +245,11 @@ func (r *Registry) hasOnDemandSkills() bool {
 		}
 	}
 	return false
+}
+
+// HasOnDemandSkills reports whether model-selected skill tools are needed.
+func (r *Registry) HasOnDemandSkills() bool {
+	return r != nil && r.hasOnDemandSkills()
 }
 
 func (r *Registry) skill(name string) (Skill, bool) {

--- a/internal/agentskills/registry_test.go
+++ b/internal/agentskills/registry_test.go
@@ -82,6 +82,25 @@ func TestLoadRejectsInvalidSkills(t *testing.T) {
 	}
 }
 
+func TestLoadAcceptsPortableFrontmatterDelimiters(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+	}{
+		{name: "closing delimiter at EOF", contents: "---\nname: portable\ndescription: Portable skill.\n---"},
+		{name: "CRLF line endings", contents: "---\r\nname: portable\r\ndescription: Portable skill.\r\n---\r\nInstructions.\r\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeFixture(t, filepath.Join(root, "portable", skillFilename), tt.contents)
+			if _, err := Load(root); err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+		})
+	}
+}
+
 func TestReadResourceRejectsEscapes(t *testing.T) {
 	root := t.TempDir()
 	skillRoot := filepath.Join(root, "safe-skill")

--- a/internal/agentskills/registry_test.go
+++ b/internal/agentskills/registry_test.go
@@ -1,0 +1,188 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package agentskills
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/p-n-ai/pai-bot/internal/llm"
+)
+
+func TestLoadAndProgressivelyReadSkill(t *testing.T) {
+	root := t.TempDir()
+	skillRoot := filepath.Join(root, "math-coach")
+	writeFixture(t, filepath.Join(skillRoot, skillFilename), `---
+name: math-coach
+description: Coach learners through maths problems. Use for maths tutoring.
+license: Apache-2.0
+compatibility: Requires the curriculum lookup tool
+metadata:
+  author: pai
+  version: "1.0"
+allowed-tools: lookup_curriculum_topic
+---
+# Maths coach
+
+Ask one question at a time.
+`)
+	writeFixture(t, filepath.Join(skillRoot, "references", "fractions.md"), "Use visual fractions.")
+
+	registry, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if registry.Len() != 1 {
+		t.Fatalf("Len() = %d, want 1", registry.Len())
+	}
+	catalog := registry.CatalogPrompt()
+	if !strings.Contains(catalog, "math-coach: Coach learners") || strings.Contains(catalog, "Ask one question") {
+		t.Fatalf("CatalogPrompt() = %q", catalog)
+	}
+
+	tools := registry.Tools()
+	loaded, err := tools[0].Execute(context.Background(), llm.ToolCall{Arguments: map[string]any{"name": "math-coach"}})
+	loadedText := textResult(t, loaded)
+	if err != nil || loaded.IsError || !strings.Contains(loadedText, "name: math-coach") || !strings.Contains(loadedText, "Ask one question at a time.") {
+		t.Fatalf("load skill = %#v, %v", loaded, err)
+	}
+	resource, err := tools[1].Execute(context.Background(), llm.ToolCall{Arguments: map[string]any{
+		"skill": "math-coach",
+		"path":  "references/fractions.md",
+	}})
+	if err != nil || resource.IsError || textResult(t, resource) != "Use visual fractions." {
+		t.Fatalf("read resource = %#v, %v", resource, err)
+	}
+}
+
+func TestLoadRejectsInvalidSkills(t *testing.T) {
+	tests := []struct {
+		name      string
+		directory string
+		contents  string
+		want      string
+	}{
+		{name: "missing frontmatter", directory: "broken", contents: "# Broken", want: "must start with YAML frontmatter"},
+		{name: "directory mismatch", directory: "math", contents: "---\nname: science\ndescription: Teach science.\n---\nBody", want: "must match parent directory"},
+		{name: "unknown field", directory: "math", contents: "---\nname: math\ndescription: Teach math.\nextra: nope\n---\nBody", want: "field extra not found"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeFixture(t, filepath.Join(root, tt.directory, skillFilename), tt.contents)
+			_, err := Load(root)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Load() error = %v, want containing %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestReadResourceRejectsEscapes(t *testing.T) {
+	root := t.TempDir()
+	skillRoot := filepath.Join(root, "safe-skill")
+	writeFixture(t, filepath.Join(skillRoot, skillFilename), "---\nname: safe-skill\ndescription: Read safe local resources.\n---\nDo it.")
+	outside := filepath.Join(root, "secret.txt")
+	writeFixture(t, outside, "secret")
+
+	registry, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	for _, path := range []string{"../secret.txt", outside} {
+		if _, err := registry.readResource("safe-skill", path); err == nil {
+			t.Fatalf("readResource(%q) unexpectedly succeeded", path)
+		}
+	}
+	link := filepath.Join(skillRoot, "linked.txt")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+	if _, err := registry.readResource("safe-skill", "linked.txt"); err == nil {
+		t.Fatal("readResource() followed a symlink outside the skill")
+	}
+}
+
+func TestLoadOptionalDisablesSkillsAndRejectsBadConfiguredPath(t *testing.T) {
+	registry, err := LoadOptional("  ")
+	if err != nil || registry != nil {
+		t.Fatalf("LoadOptional(empty) = %#v, %v", registry, err)
+	}
+	if _, err := LoadOptional(filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Fatal("LoadOptional(missing) unexpectedly succeeded")
+	}
+}
+
+func TestAlwaysActiveSkillIsInjectedInsteadOfExposedAsTool(t *testing.T) {
+	root := t.TempDir()
+	writeFixture(t, filepath.Join(root, "teacher", skillFilename), `---
+name: teacher
+description: Teach as a capable and approachable learning buddy.
+metadata:
+  activation: always
+---
+Teach one useful move at a time.
+`)
+	registry, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if got := registry.AlwaysActivePrompt(); !strings.Contains(got, "ACTIVE SKILL: teacher") || !strings.Contains(got, "Teach one useful move") {
+		t.Fatalf("AlwaysActivePrompt() = %q", got)
+	}
+	if catalog := registry.CatalogPrompt(); catalog != "" {
+		t.Fatalf("CatalogPrompt() = %q, want empty", catalog)
+	}
+	if tools := registry.Tools(); len(tools) != 0 {
+		t.Fatalf("Tools() count = %d, want 0", len(tools))
+	}
+}
+
+func TestReadResourceRejectsUnsupportedContent(t *testing.T) {
+	root := t.TempDir()
+	skillRoot := filepath.Join(root, "bounded-skill")
+	writeFixture(t, filepath.Join(skillRoot, skillFilename), "---\nname: bounded-skill\ndescription: Read bounded text resources.\n---\nDo it.")
+	registry, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	invalidUTF8 := filepath.Join(skillRoot, "invalid.txt")
+	if err := os.WriteFile(invalidUTF8, []byte{0xff}, 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if _, err := registry.readResource("bounded-skill", "invalid.txt"); err == nil || !strings.Contains(err.Error(), "UTF-8") {
+		t.Fatalf("read invalid UTF-8 error = %v", err)
+	}
+
+	oversized := filepath.Join(skillRoot, "oversized.txt")
+	if err := os.WriteFile(oversized, make([]byte, maxSkillBytes+1), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if _, err := registry.readResource("bounded-skill", "oversized.txt"); err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("read oversized error = %v", err)
+	}
+}
+
+func writeFixture(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+}
+
+func textResult(t *testing.T, result llm.ToolResultMessage) string {
+	t.Helper()
+	content, ok := result.Content[0].(llm.TextContent)
+	if !ok {
+		t.Fatalf("tool content = %#v", result.Content)
+	}
+	return content.Text
+}

--- a/internal/agentskills/tools.go
+++ b/internal/agentskills/tools.go
@@ -1,0 +1,73 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package agentskills
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/p-n-ai/pai-bot/internal/agentcore"
+	"github.com/p-n-ai/pai-bot/internal/llm"
+)
+
+const (
+	loadSkillToolName    = "load_skill"
+	readResourceToolName = "read_skill_resource"
+)
+
+// Tools returns the read-only tools used to progressively load skill content.
+func (r *Registry) Tools() []agentcore.Tool {
+	if r == nil || !r.hasOnDemandSkills() {
+		return nil
+	}
+	return []agentcore.Tool{loadSkillTool{registry: r}, readResourceTool{registry: r}}
+}
+
+type loadSkillTool struct{ registry *Registry }
+
+func (loadSkillTool) Definition() llm.Tool {
+	return llm.Tool{
+		Name:        loadSkillToolName,
+		Description: "Load the full instructions for one available skill before applying it.",
+		Parameters:  json.RawMessage(`{"type":"object","properties":{"name":{"type":"string","minLength":1}},"required":["name"],"additionalProperties":false}`),
+	}
+}
+
+func (t loadSkillTool) Execute(_ context.Context, call llm.ToolCall) (llm.ToolResultMessage, error) {
+	name, _ := call.Arguments["name"].(string)
+	skill, ok := t.registry.skill(name)
+	if !ok {
+		return skillToolResult("skill not found", true), nil
+	}
+	return skillToolResult(skill.document, false), nil
+}
+
+type readResourceTool struct{ registry *Registry }
+
+func (readResourceTool) Definition() llm.Tool {
+	return llm.Tool{
+		Name:        readResourceToolName,
+		Description: "Read one file referenced by a loaded skill. Paths are relative to that skill directory.",
+		Parameters:  json.RawMessage(`{"type":"object","properties":{"skill":{"type":"string","minLength":1},"path":{"type":"string","minLength":1}},"required":["skill","path"],"additionalProperties":false}`),
+	}
+}
+
+func (t readResourceTool) Execute(_ context.Context, call llm.ToolCall) (llm.ToolResultMessage, error) {
+	skill, _ := call.Arguments["skill"].(string)
+	path, _ := call.Arguments["path"].(string)
+	contents, err := t.registry.readResource(skill, path)
+	if err != nil {
+		return skillToolResult("skill resource unavailable", true), nil
+	}
+	return skillToolResult(contents, false), nil
+}
+
+func skillToolResult(content string, isError bool) llm.ToolResultMessage {
+	return llm.ToolResultMessage{
+		Content:   []llm.UserContent{llm.TextContent{Text: content}},
+		IsError:   isError,
+		Timestamp: time.Now(),
+	}
+}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -52,6 +52,7 @@ type Config struct {
 	Embed          EmbedConfig
 	Retrieval      RetrievalConfig
 	CurriculumPath string
+	SkillsPath     string
 }
 
 // SecurityConfig holds process-level cryptographic roots with distinct purposes.
@@ -403,6 +404,7 @@ func Load() (*Config, error) {
 		},
 		FeatureFlags:   parsedFeatureFlags,
 		CurriculumPath: envStr("LEARN_CURRICULUM_PATH", "./oss"),
+		SkillsPath:     envStr("LEARN_SKILLS_PATH", "./skills"),
 	}
 
 	return cfg, nil

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -80,6 +80,7 @@ func clearEnv(t *testing.T) {
 		"LEARN_LOG_LEVEL",
 		"LEARN_LOG_FORMAT",
 		"LEARN_CURRICULUM_PATH",
+		"LEARN_SKILLS_PATH",
 		"LEARN_DEV_MODE",
 		"PAI_FEATURES",
 		"LEARN_AI_PERSONALIZED_NUDGES_ENABLED",
@@ -145,6 +146,9 @@ func TestLoad_Defaults(t *testing.T) {
 	if cfg.CurriculumPath != "./oss" {
 		t.Errorf("CurriculumPath = %q, want ./oss", cfg.CurriculumPath)
 	}
+	if cfg.SkillsPath != "./skills" {
+		t.Errorf("SkillsPath = %q, want ./skills", cfg.SkillsPath)
+	}
 	if !cfg.Runtime.AIPersonalizedNudgesEnabled {
 		t.Error("Runtime.AIPersonalizedNudgesEnabled should default to true")
 	}
@@ -201,6 +205,7 @@ func TestLoad_FromEnv(t *testing.T) {
 	t.Setenv("PAI_AUTH_BOOTSTRAP_ADMIN_PASSWORD", "secret-bootstrap")
 	t.Setenv("LEARN_TENANT_MODE", "multi")
 	t.Setenv("LEARN_CURRICULUM_PATH", "/tmp/oss")
+	t.Setenv("LEARN_SKILLS_PATH", "/tmp/skills")
 	t.Setenv("LEARN_AI_PERSONALIZED_NUDGES_ENABLED", "false")
 	t.Setenv("PAI_FEATURES", "turn_hooks")
 
@@ -315,6 +320,9 @@ func TestLoad_FromEnv(t *testing.T) {
 	}
 	if cfg.CurriculumPath != "/tmp/oss" {
 		t.Errorf("CurriculumPath = %q, want /tmp/oss", cfg.CurriculumPath)
+	}
+	if cfg.SkillsPath != "/tmp/skills" {
+		t.Errorf("SkillsPath = %q, want /tmp/skills", cfg.SkillsPath)
 	}
 	if cfg.Runtime.AIPersonalizedNudgesEnabled {
 		t.Error("Runtime.AIPersonalizedNudgesEnabled should be false when configured")

--- a/skills/buddy/SKILL.md
+++ b/skills/buddy/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: buddy
+description: Be an approachable study buddy for K-12 learners. Use for every learner-facing conversation.
+compatibility: Pai-bot tutor runtime
+metadata:
+  activation: always
+---
+
+# Buddy
+
+- Be warm, natural, and never shame mistakes.
+- Match the learner's energy and requested brevity.
+- Avoid generic praise, filler, and artificial intimacy.

--- a/skills/teacher/SKILL.md
+++ b/skills/teacher/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: teacher
+description: Teach K-12 learners clearly and adaptively. Use for every learner-facing teaching conversation.
+compatibility: Pai-bot tutor runtime
+metadata:
+  activation: always
+---
+
+# Teacher
+
+- Match the learner's level and language.
+- Teach one clear step at a time; ask at most one question.
+- Correct kindly and stay grounded in available evidence.


### PR DESCRIPTION
## Summary

- load and validate Agent Skills-compatible `SKILL.md` bundles from the built-in `./skills` directory
- support metadata-first activation, safe resource reads, and always-active skills for managed Codex
- add compact teacher and buddy system skills with local `/reload` support
- package system skills in the production image and document configuration

## Testing

- `go test ./internal/agentskills ./internal/agent ./internal/platform/config ./cmd/server ./cmd/terminal-chat`
- local managed-Codex smoke test for teacher and buddy behavior
- local `/reload` verification for invalid and restored skill files
- `git diff --check`
