### PR TITLE
fix(auth): enforce minimum password length

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: millionco/react-doctor@v2
+        with:
+          directory: admin-spa
 
   postgres-image:
     name: Publish PostgreSQL candidate

--- a/admin-spa/src/components/auth/invite-activation-form.test.tsx
+++ b/admin-spa/src/components/auth/invite-activation-form.test.tsx
@@ -112,10 +112,7 @@ describe('InviteActivationForm', () => {
 
   it('rejects a password shorter than 12 characters', async () => {
     render(
-      <InviteActivationForm
-        onAuthenticated={vi.fn()}
-        token='invite-token'
-      />,
+      <InviteActivationForm onAuthenticated={vi.fn()} token='invite-token' />,
     )
 
     fireEvent.change(screen.getByLabelText('Full name'), {

--- a/admin-spa/src/components/auth/invite-activation-form.test.tsx
+++ b/admin-spa/src/components/auth/invite-activation-form.test.tsx
@@ -106,7 +106,29 @@ describe('InviteActivationForm', () => {
       screen.getByText('Go straight to the right admin view.'),
     ).toBeInTheDocument()
     expect(screen.getByLabelText('Password')).toHaveAccessibleDescription(
-      'Use a strong password for future sign-ins.',
+      'Use at least 12 characters for future sign-ins.',
     )
+  })
+
+  it('rejects a password shorter than 12 characters', async () => {
+    render(
+      <InviteActivationForm
+        onAuthenticated={vi.fn()}
+        token='invite-token'
+      />,
+    )
+
+    fireEvent.change(screen.getByLabelText('Full name'), {
+      target: { value: 'Parent One' },
+    })
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'short-pass' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Accept invite' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Password must be at least 12 characters.',
+    )
+    expect(acceptInvite).not.toHaveBeenCalled()
   })
 })

--- a/admin-spa/src/components/auth/invite-activation-form.tsx
+++ b/admin-spa/src/components/auth/invite-activation-form.tsx
@@ -18,6 +18,8 @@ interface InviteActivationFormProps {
   onAuthenticated: (session: AuthSession) => void
 }
 
+const minimumPasswordLength = 12
+
 export function InviteActivationForm({
   onAuthenticated,
   token,
@@ -202,6 +204,11 @@ function useInviteActivationSubmit({
         return
       }
 
+      if (Array.from(password).length < minimumPasswordLength) {
+        setError('Password must be at least 12 characters.')
+        return
+      }
+
       beginSubmit()
 
       acceptInvite({
@@ -271,7 +278,7 @@ function InviteActivationFields({
           className='m-0 text-sm text-muted-foreground'
           id={passwordDescriptionID}
         >
-          Use a strong password for future sign-ins.
+          Use at least 12 characters for future sign-ins.
         </p>
         <Input
           aria-describedby={passwordDescriptionID}

--- a/internal/auth/google_integration_test.go
+++ b/internal/auth/google_integration_test.go
@@ -31,7 +31,7 @@ func TestPostgresService_GoogleLoginAutoLinksSingleVerifiedEmail(t *testing.T) {
 	svc := newPostgresService(pool, 7*24*time.Hour, func() time.Time { return now })
 
 	tenantID := loadDefaultTenantID(t, ctx, pool)
-	userID := seedPasswordUser(t, ctx, pool, tenantID, "teacher@gmail.com", RoleTeacher, "secret-123")
+	userID := seedPasswordUser(t, ctx, pool, tenantID, "teacher@gmail.com", RoleTeacher, "secret-12345")
 	google := newGoogleOIDCTestServer(t)
 	defer google.Close()
 
@@ -92,7 +92,7 @@ func TestPostgresService_GoogleLinkAllowsDifferentEmail(t *testing.T) {
 	svc := newPostgresService(pool, 7*24*time.Hour, func() time.Time { return now })
 
 	tenantID := loadDefaultTenantID(t, ctx, pool)
-	userID := seedPasswordUser(t, ctx, pool, tenantID, "teacher@yahoo.com", RoleTeacher, "secret-123")
+	userID := seedPasswordUser(t, ctx, pool, tenantID, "teacher@yahoo.com", RoleTeacher, "secret-12345")
 	google := newGoogleOIDCTestServer(t)
 	defer google.Close()
 
@@ -165,7 +165,7 @@ func TestPostgresService_GoogleLinkReplacesExistingGoogleIdentity(t *testing.T) 
 	svc := newPostgresService(pool, 7*24*time.Hour, func() time.Time { return now })
 
 	tenantID := loadDefaultTenantID(t, ctx, pool)
-	userID := seedPasswordUser(t, ctx, pool, tenantID, "teacher@yahoo.com", RoleTeacher, "secret-123")
+	userID := seedPasswordUser(t, ctx, pool, tenantID, "teacher@yahoo.com", RoleTeacher, "secret-12345")
 	google := newGoogleOIDCTestServer(t)
 	defer google.Close()
 
@@ -310,8 +310,8 @@ func TestPostgresService_GoogleLoginReturnsTenantChoicesWhenEmailMatchesMultiple
 
 	defaultTenantID := loadDefaultTenantID(t, ctx, pool)
 	secondTenantID := seedTenant(t, ctx, pool, "school-b", "School B")
-	seedPasswordUser(t, ctx, pool, defaultTenantID, "shared@gmail.com", RoleTeacher, "secret-123")
-	seedPasswordUser(t, ctx, pool, secondTenantID, "shared@gmail.com", RoleTeacher, "secret-123")
+	seedPasswordUser(t, ctx, pool, defaultTenantID, "shared@gmail.com", RoleTeacher, "secret-12345")
+	seedPasswordUser(t, ctx, pool, secondTenantID, "shared@gmail.com", RoleTeacher, "secret-12345")
 
 	svc.ConfigureGoogleOAuth(GoogleOAuthProviderConfig{
 		ClientID:              "google-client",

--- a/internal/auth/password.go
+++ b/internal/auth/password.go
@@ -12,7 +12,12 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
-var ErrEmptyPassword = errors.New("password is required")
+const MinimumPasswordLength = 12
+
+var (
+	ErrEmptyPassword = errors.New("password is required")
+	ErrWeakPassword  = errors.New("password must be at least 12 characters")
+)
 
 // NormalizeIdentifier trims whitespace and lowercases login identifiers such as email.
 func NormalizeIdentifier(identifier string) string {
@@ -21,8 +26,8 @@ func NormalizeIdentifier(identifier string) string {
 
 // HashPassword hashes a plaintext password with bcrypt.
 func HashPassword(password string) (string, error) {
-	if strings.TrimSpace(password) == "" {
-		return "", ErrEmptyPassword
+	if err := ValidatePassword(password); err != nil {
+		return "", err
 	}
 
 	hashed, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
@@ -30,6 +35,17 @@ func HashPassword(password string) (string, error) {
 		return "", err
 	}
 	return string(hashed), nil
+}
+
+// ValidatePassword enforces the durable password-account policy.
+func ValidatePassword(password string) error {
+	if strings.TrimSpace(password) == "" {
+		return ErrEmptyPassword
+	}
+	if len([]rune(password)) < MinimumPasswordLength {
+		return ErrWeakPassword
+	}
+	return nil
 }
 
 // ComparePassword verifies a plaintext password against a bcrypt hash.

--- a/internal/auth/password_test.go
+++ b/internal/auth/password_test.go
@@ -3,7 +3,11 @@
 
 package auth
 
-import "testing"
+import (
+	"testing"
+
+	"golang.org/x/crypto/bcrypt"
+)
 
 func TestNormalizeIdentifier(t *testing.T) {
 	tests := []struct {
@@ -46,9 +50,22 @@ func TestHashPasswordRejectsEmpty(t *testing.T) {
 	}
 }
 
-func TestHashPasswordRejectsWeakPassword(t *testing.T) {
-	if _, err := HashPassword("short"); err != ErrWeakPassword {
-		t.Fatalf("HashPassword() error = %v, want %v", err, ErrWeakPassword)
+func TestValidatePasswordBoundary(t *testing.T) {
+	if err := ValidatePassword("12345678901"); err != ErrWeakPassword {
+		t.Fatalf("ValidatePassword(11 characters) error = %v, want %v", err, ErrWeakPassword)
+	}
+	if err := ValidatePassword("123456789012"); err != nil {
+		t.Fatalf("ValidatePassword(12 characters) error = %v", err)
+	}
+}
+
+func TestComparePasswordAcceptsLegacyShortPassword(t *testing.T) {
+	hash, err := bcrypt.GenerateFromPassword([]byte("legacy-123"), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("GenerateFromPassword() error = %v", err)
+	}
+	if err := ComparePassword(string(hash), "legacy-123"); err != nil {
+		t.Fatalf("ComparePassword() error = %v", err)
 	}
 }
 

--- a/internal/auth/password_test.go
+++ b/internal/auth/password_test.go
@@ -46,6 +46,12 @@ func TestHashPasswordRejectsEmpty(t *testing.T) {
 	}
 }
 
+func TestHashPasswordRejectsWeakPassword(t *testing.T) {
+	if _, err := HashPassword("short"); err != ErrWeakPassword {
+		t.Fatalf("HashPassword() error = %v, want %v", err, ErrWeakPassword)
+	}
+}
+
 func TestHashOpaqueToken(t *testing.T) {
 	const token = "invite-token-123"
 

--- a/internal/auth/postgres.go
+++ b/internal/auth/postgres.go
@@ -341,7 +341,7 @@ func (s *PostgresService) AcceptInvite(ctx context.Context, req AcceptInviteRequ
 
 	passwordHash, err := HashPassword(req.Password)
 	if err != nil {
-		if errors.Is(err, ErrEmptyPassword) {
+		if errors.Is(err, ErrEmptyPassword) || errors.Is(err, ErrWeakPassword) {
 			return Session{}, ErrInvalidInvite
 		}
 		return Session{}, fmt.Errorf("hash password: %w", err)

--- a/internal/auth/postgres_integration_test.go
+++ b/internal/auth/postgres_integration_test.go
@@ -33,7 +33,7 @@ func TestPostgresService_AcceptInviteLoginSessionAndLogout(t *testing.T) {
 	pair, err := svc.AcceptInvite(ctx, AcceptInviteRequest{
 		Token:    "invite-token",
 		Name:     "Teacher One",
-		Password: "secret-123",
+		Password: "secret-12345",
 	})
 	if err != nil {
 		t.Fatalf("AcceptInvite() error = %v", err)
@@ -50,7 +50,7 @@ func TestPostgresService_AcceptInviteLoginSessionAndLogout(t *testing.T) {
 	loginPair, err := svc.Login(ctx, LoginRequest{
 		TenantID: tenantID,
 		Email:    "teacher@example.com",
-		Password: "secret-123",
+		Password: "secret-12345",
 	})
 	if err != nil {
 		t.Fatalf("Login() error = %v", err)
@@ -85,7 +85,7 @@ func TestPostgresService_LoginRejectsInvalidPassword(t *testing.T) {
 	svc := newPostgresService(pool, 7*24*time.Hour, func() time.Time { return now })
 
 	tenantID := loadDefaultTenantID(t, ctx, pool)
-	userID := seedPasswordUser(t, ctx, pool, tenantID, "parent@example.com", RoleParent, "secret-123")
+	userID := seedPasswordUser(t, ctx, pool, tenantID, "parent@example.com", RoleParent, "secret-12345")
 
 	_, err := svc.Login(ctx, LoginRequest{
 		TenantID: tenantID,
@@ -106,11 +106,11 @@ func TestPostgresService_AuthenticatePasswordDoesNotCreateBrowserSession(t *test
 	svc := newPostgresService(pool, 7*24*time.Hour, func() time.Time { return now })
 
 	tenantID := loadDefaultTenantID(t, ctx, pool)
-	userID := seedPasswordUser(t, ctx, pool, tenantID, "student@example.com", RoleStudent, "secret-123")
+	userID := seedPasswordUser(t, ctx, pool, tenantID, "student@example.com", RoleStudent, "secret-12345")
 	user, err := svc.AuthenticatePassword(ctx, LoginRequest{
 		TenantID: tenantID,
 		Email:    "student@example.com",
-		Password: "secret-123",
+		Password: "secret-12345",
 	})
 	if err != nil {
 		t.Fatalf("AuthenticatePassword() error = %v", err)
@@ -274,7 +274,7 @@ func TestPostgresService_ReissueInviteRotatesToken(t *testing.T) {
 	if _, err := svc.AcceptInvite(ctx, AcceptInviteRequest{
 		Token:    firstInvite.Token,
 		Name:     "Teacher New",
-		Password: "secret-123",
+		Password: "secret-12345",
 	}); err != ErrInvalidInvite {
 		t.Fatalf("AcceptInvite(old token) error = %v, want ErrInvalidInvite", err)
 	}
@@ -289,12 +289,12 @@ func TestPostgresService_LoginReturnsTenantChoicesWhenEmailExistsAcrossTenants(t
 	defaultTenantID := loadDefaultTenantID(t, ctx, pool)
 	secondTenantID := seedTenant(t, ctx, pool, "school-b", "School B")
 
-	seedPasswordUser(t, ctx, pool, defaultTenantID, "shared@example.com", RoleTeacher, "secret-123")
-	seedPasswordUser(t, ctx, pool, secondTenantID, "shared@example.com", RoleTeacher, "secret-123")
+	seedPasswordUser(t, ctx, pool, defaultTenantID, "shared@example.com", RoleTeacher, "secret-12345")
+	seedPasswordUser(t, ctx, pool, secondTenantID, "shared@example.com", RoleTeacher, "secret-12345")
 
 	pair, err := svc.Login(ctx, LoginRequest{
 		Email:    "shared@example.com",
-		Password: "secret-123",
+		Password: "secret-12345",
 	})
 	if err != nil {
 		t.Fatalf("Login() error = %v", err)
@@ -309,7 +309,7 @@ func TestPostgresService_LoginReturnsTenantChoicesWhenEmailExistsAcrossTenants(t
 	pair, err = svc.Login(ctx, LoginRequest{
 		TenantID: secondTenantID,
 		Email:    "shared@example.com",
-		Password: "secret-123",
+		Password: "secret-12345",
 	})
 	if err != nil {
 		t.Fatalf("Login(with tenant) error = %v", err)
@@ -328,19 +328,19 @@ func TestPostgresService_SwitchTenantReissuesSessionWithoutLogout(t *testing.T) 
 	defaultTenantID := loadDefaultTenantID(t, ctx, pool)
 	secondTenantID := seedTenant(t, ctx, pool, "school-b", "School B")
 
-	seedPasswordUser(t, ctx, pool, defaultTenantID, "shared@example.com", RoleTeacher, "secret-123")
-	secondUserID := seedPasswordUser(t, ctx, pool, secondTenantID, "shared@example.com", RoleTeacher, "secret-123")
+	seedPasswordUser(t, ctx, pool, defaultTenantID, "shared@example.com", RoleTeacher, "secret-12345")
+	secondUserID := seedPasswordUser(t, ctx, pool, secondTenantID, "shared@example.com", RoleTeacher, "secret-12345")
 
 	loginPair, err := svc.Login(ctx, LoginRequest{
 		TenantID: defaultTenantID,
 		Email:    "shared@example.com",
-		Password: "secret-123",
+		Password: "secret-12345",
 	})
 	if err != nil {
 		t.Fatalf("Login() error = %v", err)
 	}
 
-	switchedPair, err := svc.SwitchTenant(ctx, loginPair.Token, secondTenantID, "secret-123")
+	switchedPair, err := svc.SwitchTenant(ctx, loginPair.Token, secondTenantID, "secret-12345")
 	if err != nil {
 		t.Fatalf("SwitchTenant() error = %v", err)
 	}
@@ -367,19 +367,19 @@ func TestPostgresService_SwitchTenantRequiresTargetTenantPassword(t *testing.T) 
 	defaultTenantID := loadDefaultTenantID(t, ctx, pool)
 	secondTenantID := seedTenant(t, ctx, pool, "school-b", "School B")
 
-	seedPasswordUser(t, ctx, pool, defaultTenantID, "shared@example.com", RoleTeacher, "secret-123")
+	seedPasswordUser(t, ctx, pool, defaultTenantID, "shared@example.com", RoleTeacher, "secret-12345")
 	seedPasswordUser(t, ctx, pool, secondTenantID, "shared@example.com", RoleTeacher, "different-secret")
 
 	loginPair, err := svc.Login(ctx, LoginRequest{
 		TenantID: defaultTenantID,
 		Email:    "shared@example.com",
-		Password: "secret-123",
+		Password: "secret-12345",
 	})
 	if err != nil {
 		t.Fatalf("Login() error = %v", err)
 	}
 
-	_, err = svc.SwitchTenant(ctx, loginPair.Token, secondTenantID, "secret-123")
+	_, err = svc.SwitchTenant(ctx, loginPair.Token, secondTenantID, "secret-12345")
 	if err != ErrInvalidCredentials {
 		t.Fatalf("SwitchTenant() error = %v, want ErrInvalidCredentials", err)
 	}
@@ -434,11 +434,11 @@ func TestPostgresService_PlatformAdminLoginWithoutTenant(t *testing.T) {
 	now := time.Date(2026, 3, 18, 10, 0, 0, 0, time.UTC)
 	svc := newPostgresService(pool, 7*24*time.Hour, func() time.Time { return now })
 
-	userID := seedGlobalPasswordUser(t, ctx, pool, "platform-admin@example.com", RolePlatformAdmin, "secret-123")
+	userID := seedGlobalPasswordUser(t, ctx, pool, "platform-admin@example.com", RolePlatformAdmin, "secret-12345")
 
 	pair, err := svc.Login(ctx, LoginRequest{
 		Email:    "platform-admin@example.com",
-		Password: "secret-123",
+		Password: "secret-12345",
 	})
 	if err != nil {
 		t.Fatalf("Login() error = %v", err)
@@ -470,12 +470,12 @@ func TestPostgresService_SessionRefreshesOnlyNearExpiry(t *testing.T) {
 	svc := newPostgresService(pool, 7*24*time.Hour, func() time.Time { return now })
 
 	tenantID := loadDefaultTenantID(t, ctx, pool)
-	seedPasswordUser(t, ctx, pool, tenantID, "teacher@example.com", RoleTeacher, "secret-123")
+	seedPasswordUser(t, ctx, pool, tenantID, "teacher@example.com", RoleTeacher, "secret-12345")
 
 	farSession, err := svc.Login(ctx, LoginRequest{
 		TenantID: tenantID,
 		Email:    "teacher@example.com",
-		Password: "secret-123",
+		Password: "secret-12345",
 	})
 	if err != nil {
 		t.Fatalf("Login(far) error = %v", err)
@@ -495,7 +495,7 @@ func TestPostgresService_SessionRefreshesOnlyNearExpiry(t *testing.T) {
 	nearSession, err := svc.Login(ctx, LoginRequest{
 		TenantID: tenantID,
 		Email:    "teacher@example.com",
-		Password: "secret-123",
+		Password: "secret-12345",
 	})
 	if err != nil {
 		t.Fatalf("Login(near) error = %v", err)

--- a/internal/chat/embed/chat.html
+++ b/internal/chat/embed/chat.html
@@ -125,7 +125,7 @@
       <p>Create a free account to keep your learning history and continue on any device.</p>
       <div class="upgrade-field"><label for="upgradeName">Name</label><input autocomplete="name" type="text" id="upgradeName" name="name" placeholder="Your name"></div>
       <div class="upgrade-field"><label for="upgradeEmail">Email</label><input autocomplete="email" type="email" id="upgradeEmail" name="email" placeholder="you@example.com"></div>
-      <div class="upgrade-field"><label for="upgradePassword">Password</label><input autocomplete="new-password" type="password" id="upgradePassword" name="password" placeholder="At least 8 characters"></div>
+      <div class="upgrade-field"><label for="upgradePassword">Password</label><input autocomplete="new-password" type="password" id="upgradePassword" name="password" placeholder="At least 12 characters"></div>
       <p aria-live="polite" class="upgrade-error" id="upgradeError"></p>
       <button class="upgrade-submit" id="upgradeSubmit" type="submit">Create Account</button>
     </form>
@@ -164,33 +164,33 @@
     en: {
       tutor: 'P&AI Tutor', guest: 'Guest', signUp: 'Sign Up', logIn: 'Log In', account: 'Account',
       saveProgress: 'Save your progress', saveDescription: 'Create a free account to keep your learning history and continue on any device.',
-      name: 'Name', email: 'Email', password: 'Password', yourName: 'Your name', passwordHint: 'At least 8 characters',
+      name: 'Name', email: 'Email', password: 'Password', yourName: 'Your name', passwordHint: 'At least 12 characters',
       createAccount: 'Create Account', welcome: 'Welcome back', loginDescription: 'Log in to continue your learning journey.',
       yourPassword: 'Your password', reconnecting: 'Reconnecting...', ask: 'Ask a question... (type / for commands)', send: 'Send',
       logout: 'Log out', closeAccount: 'Close account dialog', loggingIn: 'Logging in...', creating: 'Creating...', validEmail: 'Valid email is required',
-      passwordRequired: 'Password is required', nameRequired: 'Name is required', passwordLength: 'Password must be at least 8 characters',
+      passwordRequired: 'Password is required', nameRequired: 'Name is required', passwordLength: 'Password must be at least 12 characters',
       invalidLogin: 'Invalid email or password', networkError: 'Network error. Please try again.', connectError: 'Unable to connect. Please try again later.',
       accountCreated: 'Account created!', progressSaved: 'Your progress is now saved. You can log in anytime with your email and password.', genericError: 'Something went wrong'
     },
     ms: {
       tutor: 'Tutor P&AI', guest: 'Tetamu', signUp: 'Daftar', logIn: 'Log Masuk', account: 'Akaun',
       saveProgress: 'Simpan kemajuan anda', saveDescription: 'Cipta akaun percuma untuk menyimpan sejarah pembelajaran dan meneruskan pada mana-mana peranti.',
-      name: 'Nama', email: 'E-mel', password: 'Kata laluan', yourName: 'Nama anda', passwordHint: 'Sekurang-kurangnya 8 aksara',
+      name: 'Nama', email: 'E-mel', password: 'Kata laluan', yourName: 'Nama anda', passwordHint: 'Sekurang-kurangnya 12 aksara',
       createAccount: 'Cipta Akaun', welcome: 'Selamat kembali', loginDescription: 'Log masuk untuk meneruskan pembelajaran anda.',
       yourPassword: 'Kata laluan anda', reconnecting: 'Menyambung semula...', ask: 'Tanya soalan... (taip / untuk arahan)', send: 'Hantar',
       logout: 'Log keluar', closeAccount: 'Tutup dialog akaun', loggingIn: 'Sedang log masuk...', creating: 'Sedang mencipta...', validEmail: 'E-mel yang sah diperlukan',
-      passwordRequired: 'Kata laluan diperlukan', nameRequired: 'Nama diperlukan', passwordLength: 'Kata laluan mesti sekurang-kurangnya 8 aksara',
+      passwordRequired: 'Kata laluan diperlukan', nameRequired: 'Nama diperlukan', passwordLength: 'Kata laluan mesti sekurang-kurangnya 12 aksara',
       invalidLogin: 'E-mel atau kata laluan tidak sah', networkError: 'Ralat rangkaian. Sila cuba lagi.', connectError: 'Tidak dapat menyambung. Sila cuba lagi kemudian.',
       accountCreated: 'Akaun berjaya dicipta!', progressSaved: 'Kemajuan anda kini disimpan. Anda boleh log masuk pada bila-bila masa dengan e-mel dan kata laluan.', genericError: 'Sesuatu telah berlaku'
     },
     zh: {
       tutor: 'P&AI 导师', guest: '访客', signUp: '注册', logIn: '登录', account: '账户',
       saveProgress: '保存学习进度', saveDescription: '创建免费账户，以保存学习记录并在任何设备上继续学习。',
-      name: '姓名', email: '电子邮箱', password: '密码', yourName: '你的姓名', passwordHint: '至少 8 个字符',
+      name: '姓名', email: '电子邮箱', password: '密码', yourName: '你的姓名', passwordHint: '至少 12 个字符',
       createAccount: '创建账户', welcome: '欢迎回来', loginDescription: '登录以继续你的学习旅程。',
       yourPassword: '你的密码', reconnecting: '正在重新连接...', ask: '输入问题...（输入 / 查看指令）', send: '发送',
       logout: '退出登录', closeAccount: '关闭账户对话框', loggingIn: '正在登录...', creating: '正在创建...', validEmail: '请输入有效的电子邮箱',
-      passwordRequired: '请输入密码', nameRequired: '请输入姓名', passwordLength: '密码必须至少包含 8 个字符',
+      passwordRequired: '请输入密码', nameRequired: '请输入姓名', passwordLength: '密码必须至少包含 12 个字符',
       invalidLogin: '电子邮箱或密码无效', networkError: '网络错误，请重试。', connectError: '无法连接，请稍后重试。',
       accountCreated: '账户已创建！', progressSaved: '你的学习进度已保存。你可以随时使用电子邮箱和密码登录。', genericError: '出现错误'
     }
@@ -538,7 +538,7 @@
 
       if (!name) { upgradeErrorEl.textContent = copy.nameRequired; return; }
       if (!email || email.indexOf('@') === -1) { upgradeErrorEl.textContent = copy.validEmail; return; }
-      if (pw.length < 8) { upgradeErrorEl.textContent = copy.passwordLength; return; }
+      if (Array.from(pw).length < 12) { upgradeErrorEl.textContent = copy.passwordLength; return; }
 
       upgradeSubmitEl.disabled = true;
       upgradeSubmitEl.textContent = copy.creating;

--- a/internal/chat/embed_handler_test.go
+++ b/internal/chat/embed_handler_test.go
@@ -86,6 +86,8 @@ func TestHandleChatPage_ValidTenant(t *testing.T) {
 		`role="dialog"`,
 		`aria-modal="true"`,
 		`label for="upgradeEmail"`,
+		"At least 12 characters",
+		"Array.from(pw).length < 12",
 		"panelSignupEl.innerHTML",
 		"window.crypto.getRandomValues(bytes)",
 	} {

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/p-n-ai/pai-bot/internal/auth"
 	"github.com/p-n-ai/pai-bot/internal/platform/featureflags"
 )
 
@@ -668,8 +669,8 @@ func ValidateRuntimeSettingsKeys(active, auth string, previous []string) error {
 
 // ValidateProductionSecrets rejects deployment credentials that are missing,
 // public defaults, or invalid runtime-settings encryption roots.
-func ValidateProductionSecrets(auth, active string, previous []string, bootstrapAdminPassword string) error {
-	if auth == "" || auth == DefaultAuthSecret {
+func ValidateProductionSecrets(authSecret, active string, previous []string, bootstrapAdminPassword string) error {
+	if authSecret == "" || authSecret == DefaultAuthSecret {
 		return fmt.Errorf("PAI_AUTH_SECRET must be a private value")
 	}
 	if active == "" {
@@ -678,7 +679,10 @@ func ValidateProductionSecrets(auth, active string, previous []string, bootstrap
 	if bootstrapAdminPassword == "" || bootstrapAdminPassword == "demo-password" {
 		return fmt.Errorf("PAI_AUTH_BOOTSTRAP_ADMIN_PASSWORD must be a private value")
 	}
-	return ValidateRuntimeSettingsKeys(active, auth, previous)
+	if err := auth.ValidatePassword(bootstrapAdminPassword); err != nil {
+		return fmt.Errorf("PAI_AUTH_BOOTSTRAP_ADMIN_PASSWORD does not meet the password policy: %w", err)
+	}
+	return ValidateRuntimeSettingsKeys(active, authSecret, previous)
 }
 
 // ValidateProductionSecretEnvironment parses and validates only the secrets

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -788,6 +788,7 @@ func TestValidateProductionSecretsRejectsUnsafeDeploymentValues(t *testing.T) {
 		{name: "previous reuses auth", auth: validAuth, active: validActive, previous: []string{validAuth}, bootstrap: validBootstrap},
 		{name: "missing bootstrap", auth: validAuth, active: validActive},
 		{name: "default bootstrap", auth: validAuth, active: validActive, bootstrap: "demo-password"},
+		{name: "short bootstrap", auth: validAuth, active: validActive, bootstrap: "private-123"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/server/embed.go
+++ b/internal/server/embed.go
@@ -235,8 +235,8 @@ func handleEmbedUpgradeGuest(store chat.EmbedConfigStore, guests EmbedGuestServi
 		if !decodeEmbedJSON(w, r, &request) {
 			return
 		}
-		if strings.TrimSpace(request.Name) == "" || !strings.Contains(request.Email, "@") || len(strings.TrimSpace(request.Password)) < 8 {
-			http.Error(w, "name, valid email, and password of at least 8 characters are required", http.StatusBadRequest)
+		if strings.TrimSpace(request.Name) == "" || !strings.Contains(request.Email, "@") || auth.ValidatePassword(request.Password) != nil {
+			http.Error(w, "name, valid email, and password of at least 12 characters are required", http.StatusBadRequest)
 			return
 		}
 		token, err := guests.UpgradeGuest(r.Context(), claims.Subject, claims.TenantID, claims.ParentOrigin, request.Name, request.Email, request.Password)

--- a/internal/server/embed.go
+++ b/internal/server/embed.go
@@ -235,7 +235,7 @@ func handleEmbedUpgradeGuest(store chat.EmbedConfigStore, guests EmbedGuestServi
 		if !decodeEmbedJSON(w, r, &request) {
 			return
 		}
-		if strings.TrimSpace(request.Name) == "" || !strings.Contains(request.Email, "@") || auth.ValidatePassword(request.Password) != nil {
+		if strings.TrimSpace(request.Name) == "" || !strings.Contains(request.Email, "@") || auth.ValidatePassword(strings.TrimSpace(request.Password)) != nil {
 			http.Error(w, "name, valid email, and password of at least 12 characters are required", http.StatusBadRequest)
 			return
 		}

--- a/internal/server/embed_test.go
+++ b/internal/server/embed_test.go
@@ -71,7 +71,8 @@ func (s *embedConfigStoreStub) FindTenantBySlugAndOrigin(_ context.Context, slug
 }
 
 type embedGuestsStub struct {
-	parentOrigin string
+	parentOrigin  string
+	upgradeCalled bool
 }
 
 func (s *embedGuestsStub) IssueGuestToken(_ context.Context, tenantID, origin, fingerprint string) (string, string, error) {
@@ -81,6 +82,7 @@ func (s *embedGuestsStub) IssueGuestToken(_ context.Context, tenantID, origin, f
 
 func (s *embedGuestsStub) UpgradeGuest(_ context.Context, userID, tenantID, parentOrigin, name, email, password string) (string, error) {
 	s.parentOrigin = parentOrigin
+	s.upgradeCalled = true
 	return "student-token", nil
 }
 
@@ -281,6 +283,39 @@ func TestEmbedGuestAuthBindsValidatedParentOrigin(t *testing.T) {
 	handler.ServeHTTP(response, request)
 	if response.Code != http.StatusRequestEntityTooLarge {
 		t.Fatalf("oversized body status = %d, want 413", response.Code)
+	}
+}
+
+func TestEmbedGuestUpgradeRejectsPasswordThatBecomesShortAfterTrimming(t *testing.T) {
+	const secret = "embed-upgrade-secret"
+	store := &embedConfigStoreStub{
+		configs: map[string]chat.EmbedConfig{},
+		tenantByOrigin: map[string]string{
+			"https://school.example": "tenant-a",
+		},
+	}
+	guests := &embedGuestsStub{}
+	handler := NewTopMux(TopMuxOptions{
+		EmbedConfigStore:  store,
+		EmbedGuestService: guests,
+		JWTSecret:         secret,
+		AccessTokenTTL:    time.Hour,
+	})
+	token := issueEmbedTestToken(t, secret, auth.RoleGuest, "tenant-a", "https://school.example")
+	request := httptest.NewRequest(http.MethodPost, "https://api.example/api/embed/auth/upgrade", strings.NewReader(
+		`{"name":"Student","email":"student@example.com","password":" 12345678901"}`,
+	))
+	request.Header.Set("Authorization", "Bearer "+token)
+	request.Header.Set("Origin", "https://api.example")
+	response := httptest.NewRecorder()
+
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", response.Code, response.Body.String())
+	}
+	if guests.upgradeCalled {
+		t.Fatal("UpgradeGuest() was called for a password that becomes too short after trimming")
 	}
 }
 

--- a/scripts/test_ci_config.py
+++ b/scripts/test_ci_config.py
@@ -342,6 +342,8 @@ class CIWorkflowTests(unittest.TestCase):
 
         self.assertIn("needs.changes.outputs.admin_spa == 'true'", doctor)
         self.assertIn("uses: millionco/react-doctor@v2", doctor)
+        self.assertIn("fetch-depth: 0", doctor)
+        self.assertIn("directory: admin-spa", doctor)
         self.assertIn("      - react-doctor\n", gate)
         self.assertFalse((ROOT / ".github/workflows/react-doctor.yml").exists())
 


### PR DESCRIPTION
## summary

- enforce a 12-character minimum wherever account passwords are hashed
- apply the same policy to invitations and embedded-chat guest upgrades
- return existing boundary-safe errors for weak invitation passwords
- reject weak bootstrap administrator passwords during production preflight
- keep embed request validation consistent with guest password normalization
- scope react doctor to the admin spa project

## risk

- passwords shorter than 12 characters are rejected
- existing password hashes and sessions are unchanged
- production bootstrap passwords must meet the same policy before startup
- rollback: revert this pull request

## verification

- `go test ./internal/auth ./internal/platform/config -count=1`: pass
- `go test ./internal/server -count=1`: pass with local listener access
- `go test ./cmd/validate-production-secrets -count=1`: pass
- `go vet ./internal/auth ./internal/platform/config ./internal/server`: pass
- `python3 -m unittest scripts.test_ci_config`: 17 tests passed
- GitHub required CI gate: pass
- react doctor: 100/100
