### PR TITLE
fix(ai): bound image input processing

### DIFF
--- a/internal/ai/image_input.go
+++ b/internal/ai/image_input.go
@@ -67,13 +67,23 @@ func parseDataURLImage(raw string) (normalizedImageInput, error) {
 	if !isSupportedImageMIMEType(parsedMediaType) {
 		return normalizedImageInput{}, fmt.Errorf("unsupported image MIME type %q", parsedMediaType)
 	}
-	if base64.StdEncoding.DecodedLen(len(payload)) > maxImageInputBytes {
+	decodedLen := base64.StdEncoding.DecodedLen(len(payload))
+	if strings.HasSuffix(payload, "=") {
+		decodedLen--
+	}
+	if strings.HasSuffix(payload, "==") {
+		decodedLen--
+	}
+	if decodedLen > maxImageInputBytes {
 		return normalizedImageInput{}, fmt.Errorf("image data exceeds %d bytes", maxImageInputBytes)
 	}
 
 	data, err := base64.StdEncoding.DecodeString(payload)
 	if err != nil {
 		return normalizedImageInput{}, fmt.Errorf("decode image data URL: %w", err)
+	}
+	if len(data) > maxImageInputBytes {
+		return normalizedImageInput{}, fmt.Errorf("image data exceeds %d bytes", maxImageInputBytes)
 	}
 
 	return normalizedImageInput{

--- a/internal/ai/image_input.go
+++ b/internal/ai/image_input.go
@@ -21,6 +21,8 @@ var supportedImageMIMETypes = map[string]struct{}{
 	"image/gif":  {},
 }
 
+const maxImageInputBytes = 8 << 20
+
 type normalizedImageInput struct {
 	MIMEType string
 	Data     []byte
@@ -65,6 +67,9 @@ func parseDataURLImage(raw string) (normalizedImageInput, error) {
 	if !isSupportedImageMIMEType(parsedMediaType) {
 		return normalizedImageInput{}, fmt.Errorf("unsupported image MIME type %q", parsedMediaType)
 	}
+	if base64.StdEncoding.DecodedLen(len(payload)) > maxImageInputBytes {
+		return normalizedImageInput{}, fmt.Errorf("image data exceeds %d bytes", maxImageInputBytes)
+	}
 
 	data, err := base64.StdEncoding.DecodeString(payload)
 	if err != nil {
@@ -93,9 +98,15 @@ func fetchImageBytes(ctx context.Context, client *http.Client, rawURL string) (n
 		return normalizedImageInput{}, fmt.Errorf("fetch image %q: status %d", rawURL, resp.StatusCode)
 	}
 
-	data, err := io.ReadAll(resp.Body)
+	if resp.ContentLength > maxImageInputBytes {
+		return normalizedImageInput{}, fmt.Errorf("image %q exceeds %d bytes", rawURL, maxImageInputBytes)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxImageInputBytes+1))
 	if err != nil {
 		return normalizedImageInput{}, fmt.Errorf("read image %q: %w", rawURL, err)
+	}
+	if len(data) > maxImageInputBytes {
+		return normalizedImageInput{}, fmt.Errorf("image %q exceeds %d bytes", rawURL, maxImageInputBytes)
 	}
 	mimeType := normalizeImageMIMEType(resp.Header.Get("Content-Type"), data)
 	if !isSupportedImageMIMEType(mimeType) {

--- a/internal/ai/image_input_test.go
+++ b/internal/ai/image_input_test.go
@@ -16,3 +16,16 @@ func TestNormalizeImageInputRejectsOversizedDataURL(t *testing.T) {
 		t.Fatalf("normalizeImageInput() error = %v, want oversized image rejection", err)
 	}
 }
+
+func TestNormalizeImageInputAcceptsExactLimitDataURL(t *testing.T) {
+	data := make([]byte, maxImageInputBytes)
+	payload := base64.StdEncoding.EncodeToString(data)
+
+	image, err := normalizeImageInput("data:image/png;base64," + payload)
+	if err != nil {
+		t.Fatalf("normalizeImageInput() error = %v, want exact-limit image accepted", err)
+	}
+	if len(image.Data) != maxImageInputBytes {
+		t.Fatalf("len(image.Data) = %d, want %d", len(image.Data), maxImageInputBytes)
+	}
+}

--- a/internal/ai/image_input_test.go
+++ b/internal/ai/image_input_test.go
@@ -1,0 +1,18 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ai
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeImageInputRejectsOversizedDataURL(t *testing.T) {
+	payload := strings.Repeat("A", base64.StdEncoding.EncodedLen(maxImageInputBytes+1))
+	_, err := normalizeImageInput("data:image/png;base64," + payload)
+	if err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("normalizeImageInput() error = %v, want oversized image rejection", err)
+	}
+}

--- a/internal/chat/telegram.go
+++ b/internal/chat/telegram.go
@@ -19,16 +19,21 @@ import (
 	"time"
 )
 
-const telegramMaxMessageLen = 4096
+const (
+	telegramMaxMessageLen          = 4096
+	telegramMaxImageBytes    int64 = 8 << 20
+	telegramImageConcurrency       = 4
+)
 
 // TelegramChannel implements the Channel interface for Telegram Bot API.
 type TelegramChannel struct {
-	token    string
-	baseURL  string
-	client   *http.Client
-	offset   int
-	stop     chan struct{}
-	stopOnce sync.Once
+	token      string
+	baseURL    string
+	client     *http.Client
+	offset     int
+	stop       chan struct{}
+	stopOnce   sync.Once
+	imageSlots chan struct{}
 
 	devMode     bool
 	lifecycleMu sync.Mutex
@@ -46,7 +51,8 @@ func NewTelegramChannel(token string) (*TelegramChannel, error) {
 		client: &http.Client{
 			Timeout: 60 * time.Second,
 		},
-		stop: make(chan struct{}),
+		stop:       make(chan struct{}),
+		imageSlots: make(chan struct{}, telegramImageConcurrency),
 	}, nil
 }
 
@@ -228,20 +234,32 @@ func (t *TelegramChannel) pollLoop(ctx context.Context, handler func(InboundMess
 				if !ok {
 					continue
 				}
-				if msg.HasImage && msg.ImageFileID != "" {
-					dataURL, err := t.getImageDataURL(ctx, msg.ImageFileID)
-					if err != nil {
-						slog.Warn("failed to fetch telegram image", "error", err)
-					} else {
-						msg.ImageDataURL = dataURL
-					}
-				}
 				if msg.CallbackQueryID != "" {
 					if err := t.answerCallbackQuery(ctx, msg.CallbackQueryID); err != nil {
 						slog.Warn("failed to answer callback query", "error", err)
 					}
 				}
 
+				if msg.HasImage && msg.ImageFileID != "" {
+					select {
+					case t.imageSlots <- struct{}{}:
+					case <-ctx.Done():
+						return
+					case <-t.stop:
+						return
+					}
+					go func() {
+						defer func() { <-t.imageSlots }()
+						dataURL, err := t.getImageDataURL(ctx, msg.ImageFileID)
+						if err != nil {
+							slog.Warn("failed to fetch telegram image", "error", err)
+						} else {
+							msg.ImageDataURL = dataURL
+						}
+						handler(msg)
+					}()
+					continue
+				}
 				go handler(msg)
 			}
 		}
@@ -525,13 +543,19 @@ func (t *TelegramChannel) getImageDataURL(ctx context.Context, fileID string) (s
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
 		return "", fmt.Errorf("telegram file download error %d: %s", resp.StatusCode, string(body))
 	}
 
-	content, err := io.ReadAll(resp.Body)
+	if resp.ContentLength > telegramMaxImageBytes {
+		return "", fmt.Errorf("telegram image exceeds %d bytes", telegramMaxImageBytes)
+	}
+	content, err := io.ReadAll(io.LimitReader(resp.Body, telegramMaxImageBytes+1))
 	if err != nil {
 		return "", fmt.Errorf("read telegram file: %w", err)
+	}
+	if int64(len(content)) > telegramMaxImageBytes {
+		return "", fmt.Errorf("telegram image exceeds %d bytes", telegramMaxImageBytes)
 	}
 	if len(content) == 0 {
 		return "", fmt.Errorf("telegram file is empty")

--- a/internal/chat/telegram.go
+++ b/internal/chat/telegram.go
@@ -249,8 +249,8 @@ func (t *TelegramChannel) pollLoop(ctx context.Context, handler func(InboundMess
 						return
 					}
 					go func() {
-						defer func() { <-t.imageSlots }()
 						dataURL, err := t.getImageDataURL(ctx, msg.ImageFileID)
+						<-t.imageSlots
 						if err != nil {
 							slog.Warn("failed to fetch telegram image", "error", err)
 						} else {

--- a/internal/chat/telegram_transport_test.go
+++ b/internal/chat/telegram_transport_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 type telegramRoundTripperFunc func(*http.Request) (*http.Response, error)
@@ -45,6 +46,92 @@ func TestTelegramImageDownloadRejectsOversizedContentLength(t *testing.T) {
 
 	if _, err := channel.getImageDataURL(context.Background(), "file-id"); err == nil || !strings.Contains(err.Error(), "exceeds") {
 		t.Fatalf("getImageDataURL() error = %v, want oversized image rejection", err)
+	}
+}
+
+func TestTelegramImageSlotsDoNotLimitHandlerExecution(t *testing.T) {
+	var sentUpdates atomic.Bool
+	channel, err := NewTelegramChannel("test-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	channel.baseURL = "https://api.telegram.test/bottest-token"
+	channel.client = &http.Client{Transport: telegramRoundTripperFunc(func(request *http.Request) (*http.Response, error) {
+		switch {
+		case strings.HasSuffix(request.URL.Path, "/getUpdates"):
+			if sentUpdates.Swap(true) {
+				<-request.Context().Done()
+				return nil, request.Context().Err()
+			}
+			updates := make([]tgUpdate, 0, telegramImageConcurrency+2)
+			for i := 1; i <= telegramImageConcurrency+1; i++ {
+				updates = append(updates, tgUpdate{
+					UpdateID: i,
+					Message: &tgMessage{
+						MessageID: i,
+						Photo:     []tgPhoto{{FileID: "image"}},
+						Chat:      tgChat{ID: 123},
+						From:      tgUser{ID: 456},
+					},
+				})
+			}
+			updates = append(updates, tgUpdate{
+				UpdateID: telegramImageConcurrency + 2,
+				Message: &tgMessage{
+					MessageID: telegramImageConcurrency + 2,
+					Text:      "after images",
+					Chat:      tgChat{ID: 123},
+					From:      tgUser{ID: 456},
+				},
+			})
+			body, marshalErr := json.Marshal(map[string]any{"ok": true, "result": updates})
+			if marshalErr != nil {
+				return nil, marshalErr
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(string(body))),
+				Header:     make(http.Header),
+			}, nil
+		case strings.HasSuffix(request.URL.Path, "/getFile"):
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"ok":true,"result":{"file_path":"photos/image.jpg"}}`)),
+				Header:     make(http.Header),
+			}, nil
+		default:
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("image")),
+				Header:     http.Header{"Content-Type": []string{"image/jpeg"}},
+			}, nil
+		}
+	})}
+
+	handlerRelease := make(chan struct{})
+	textHandled := make(chan struct{})
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	if err := channel.Start(ctx, func(message InboundMessage) {
+		if message.HasImage {
+			<-handlerRelease
+			return
+		}
+		close(textHandled)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-textHandled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("text message was blocked by running image handlers")
+	}
+
+	close(handlerRelease)
+	cancel()
+	if err := channel.Stop(); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/chat/telegram_transport_test.go
+++ b/internal/chat/telegram_transport_test.go
@@ -22,6 +22,32 @@ func (f telegramRoundTripperFunc) RoundTrip(request *http.Request) (*http.Respon
 	return f(request)
 }
 
+func TestTelegramImageDownloadRejectsOversizedContentLength(t *testing.T) {
+	channel := &TelegramChannel{
+		token:   "test-token",
+		baseURL: "https://api.telegram.test/bottest-token",
+		client: &http.Client{Transport: telegramRoundTripperFunc(func(request *http.Request) (*http.Response, error) {
+			if strings.Contains(request.URL.Path, "/getFile") {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"ok":true,"result":{"file_path":"photos/large.jpg"}}`)),
+					Header:     make(http.Header),
+				}, nil
+			}
+			return &http.Response{
+				StatusCode:    http.StatusOK,
+				Body:          io.NopCloser(strings.NewReader("not-read")),
+				Header:        http.Header{"Content-Type": []string{"image/jpeg"}},
+				ContentLength: telegramMaxImageBytes + 1,
+			}, nil
+		})},
+	}
+
+	if _, err := channel.getImageDataURL(context.Background(), "file-id"); err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("getImageDataURL() error = %v, want oversized image rejection", err)
+	}
+}
+
 func TestTelegramChannelTransportErrorDoesNotExposeToken(t *testing.T) {
 	channel, err := NewTelegramChannel("secret-test-token")
 	if err != nil {


### PR DESCRIPTION
## summary

- reject data-url and downloaded images larger than 8 mib
- limit telegram image downloads and error bodies
- limit telegram image fetch concurrency to four

## risk

- images larger than 8 mib are rejected
- api contract: unchanged
- database migrations: none
- rollback: revert this pull request

## verification

- `./scripts/agent-check changed`: pass
- `internal/ai` and `internal/chat` package tests: pass
- GitHub required CI gate: pass
