### PR TITLE
fix(terraform): keep private SSH keys out of state

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -16,18 +16,24 @@ server over SSH. This keeps the server portable to any VPS.
 
 ```bash
 cd terraform
+ssh-keygen -t ed25519 -f ~/.ssh/pai-bot-deploy
 terraform init
-terraform plan -var='ssh_cidr_blocks=["YOUR_IP/32"]'
-terraform apply -var='ssh_cidr_blocks=["YOUR_IP/32"]'
+terraform plan \\
+  -var='ssh_cidr_blocks=["YOUR_IP/32"]' \\
+  -var="ssh_public_key=$(cat ~/.ssh/pai-bot-deploy.pub)"
+terraform apply \\
+  -var='ssh_cidr_blocks=["YOUR_IP/32"]' \\
+  -var="ssh_public_key=$(cat ~/.ssh/pai-bot-deploy.pub)"
 ```
 
-**Important:** `ssh_cidr_blocks` has no default — you must set it to restrict SSH access.
+Both `ssh_cidr_blocks` and `ssh_public_key` are required. Generate and store
+the private key outside Terraform; only the public key enters Terraform state.
 
 ## First-Time Server Setup
 
 ```bash
 # SSH in (command from terraform output)
-ssh -i terraform/pai-bot-key.pem ubuntu@<PUBLIC_IP>
+ssh -i ~/.ssh/pai-bot-deploy ubuntu@<PUBLIC_IP>
 
 # Create app directory (done by user-data, but verify)
 ls /opt/pai-bot
@@ -48,7 +54,7 @@ Configure deploy-only values as repository secrets or in the GitHub
 
 - `DEPLOY_HOST` — public IP from terraform output
 - `DEPLOY_USER` — `ubuntu`
-- `DEPLOY_KEY` — contents of `terraform/pai-bot-key.pem`
+- `DEPLOY_KEY` — contents of the externally managed `~/.ssh/pai-bot-deploy`
 - `DEPLOY_DIR` — `/opt/pai-bot`
 
 Configure the production runtime values consumed by

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -9,10 +9,10 @@ server over SSH. This keeps the server portable to any VPS.
 
 ## Prerequisites
 
-- [Terraform](https://developer.hashicorp.com/terraform/install) >= 1.5
+- [Terraform](https://developer.hashicorp.com/terraform/install) >= 1.7
 - AWS CLI configured with access to ap-southeast-5
 
-## Deploy Infrastructure
+## New Deployment
 
 ```bash
 cd terraform
@@ -28,6 +28,57 @@ terraform apply \\
 
 Both `ssh_cidr_blocks` and `ssh_public_key` are required. Generate and store
 the private key outside Terraform; only the public key enters Terraform state.
+
+## Existing Deployment Migration
+
+Do not generate a replacement key before this migration. Reuse the private key
+that matches the public key on the running server.
+
+```bash
+cd terraform
+install -m 0600 pai-bot-key.pem ~/.ssh/pai-bot-deploy
+ssh-keygen -y -f ~/.ssh/pai-bot-deploy > ~/.ssh/pai-bot-deploy.pub
+ssh -i ~/.ssh/pai-bot-deploy ubuntu@<PUBLIC_IP>
+terraform init -upgrade
+terraform plan \
+  -var='ssh_cidr_blocks=["YOUR_IP/32"]' \
+  -var="ssh_public_key=$(cat ~/.ssh/pai-bot-deploy.pub)"
+```
+
+Check the plan before you apply it. It must not replace the EC2 instance. If it
+replaces the AWS key pair, proceed only when the successful SSH check proves
+that the supplied private key already opens the server. The two `removed`
+blocks remove the generated key resources from Terraform state without
+deleting the existing private-key file.
+
+Apply the same variables only after the plan is safe:
+
+```bash
+terraform apply \
+  -var='ssh_cidr_blocks=["YOUR_IP/32"]' \
+  -var="ssh_public_key=$(cat ~/.ssh/pai-bot-deploy.pub)"
+```
+
+Keep the old key until the copied key works in a separate SSH session. Old
+Terraform state versions can still contain the private key. Protect that state
+history, and rotate the key after this migration.
+
+## Rotate an Existing Key
+
+AWS key-pair replacement does not change `authorized_keys` on a running EC2
+instance. Add and test the new public key before you change Terraform.
+
+```bash
+ssh-keygen -t ed25519 -f ~/.ssh/pai-bot-next
+cat ~/.ssh/pai-bot-next.pub | \
+  ssh -i ~/.ssh/pai-bot-deploy ubuntu@<PUBLIC_IP> \
+  'umask 077; mkdir -p ~/.ssh; cat >> ~/.ssh/authorized_keys'
+ssh -i ~/.ssh/pai-bot-next ubuntu@<PUBLIC_IP>
+```
+
+Keep that second SSH session open. Then run `terraform plan` with the new
+public key and `-var='ssh_private_key_path=~/.ssh/pai-bot-next'`. Update the
+`DEPLOY_KEY` secret before you remove the old key.
 
 ## First-Time Server Setup
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -7,7 +7,7 @@
 # Usage:
 #   cd terraform
 #   terraform init
-#   terraform plan -var="ssh_cidr_blocks=[\"YOUR_IP/32\"]"
+#   terraform plan -var="ssh_cidr_blocks=[\"YOUR_IP/32\"]" -var="ssh_public_key=$(cat ~/.ssh/pai-bot-deploy.pub)"
 #   terraform apply
 
 terraform {
@@ -17,10 +17,6 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
-    tls = {
-      source  = "hashicorp/tls"
-      version = "~> 4.0"
-    }
   }
 }
 
@@ -29,23 +25,10 @@ provider "aws" {
 }
 
 # --- SSH Key Pair ---
-# NOTE: This is convenient for bootstrapping but places the private key in
-# Terraform state. For production, consider importing an externally managed
-# key pair instead.
-
-resource "tls_private_key" "deploy" {
-  algorithm = "ED25519"
-}
 
 resource "aws_key_pair" "deploy" {
   key_name   = "${var.project}-key"
-  public_key = tls_private_key.deploy.public_key_openssh
-}
-
-resource "local_file" "private_key" {
-  content         = tls_private_key.deploy.private_key_openssh
-  filename        = "${path.module}/${var.project}-key.pem"
-  file_permission = "0600"
+  public_key = trimspace(var.ssh_public_key)
 }
 
 # --- Security Group ---

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -11,7 +11,7 @@
 #   terraform apply
 
 terraform {
-  required_version = ">= 1.5"
+  required_version = ">= 1.7"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
@@ -25,6 +25,22 @@ provider "aws" {
 }
 
 # --- SSH Key Pair ---
+
+removed {
+  from = tls_private_key.deploy
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = local_file.private_key
+
+  lifecycle {
+    destroy = false
+  }
+}
 
 resource "aws_key_pair" "deploy" {
   key_name   = "${var.project}-key"

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -10,7 +10,7 @@ output "public_ip" {
 
 output "ssh_command" {
   description = "SSH command to connect"
-  value       = "ssh -i terraform/${var.project}-key.pem ubuntu@${aws_instance.app.public_ip}"
+  value       = "ssh ubuntu@${aws_instance.app.public_ip}"
 }
 
 output "health_check_url" {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -10,7 +10,7 @@ output "public_ip" {
 
 output "ssh_command" {
   description = "SSH command to connect"
-  value       = "ssh ubuntu@${aws_instance.app.public_ip}"
+  value       = "ssh -i ${var.ssh_private_key_path} ubuntu@${aws_instance.app.public_ip}"
 }
 
 output "health_check_url" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -37,6 +37,17 @@ variable "ssh_public_key" {
   }
 }
 
+variable "ssh_private_key_path" {
+  description = "Local private key path used in the SSH command output"
+  type        = string
+  default     = "~/.ssh/pai-bot-deploy"
+
+  validation {
+    condition     = trimspace(var.ssh_private_key_path) != ""
+    error_message = "ssh_private_key_path must not be empty."
+  }
+}
+
 variable "app_dir" {
   description = "Application directory on the server"
   type        = string

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -27,6 +27,16 @@ variable "ssh_cidr_blocks" {
   type        = list(string)
 }
 
+variable "ssh_public_key" {
+  description = "Externally generated OpenSSH public key used for server access"
+  type        = string
+
+  validation {
+    condition     = can(regex("^(ssh-ed25519|ssh-rsa|ecdsa-sha2-nistp(256|384|521)) ", trimspace(var.ssh_public_key)))
+    error_message = "ssh_public_key must be a valid OpenSSH public key."
+  }
+}
+
 variable "app_dir" {
   description = "Application directory on the server"
   type        = string


### PR DESCRIPTION
## summary

- require an external OpenSSH public key for the deployment key pair
- remove generated private keys from future terraform state
- preserve legacy key resources during state migration with `destroy = false`
- include the selected private key in the `ssh_command` output
- document safe migration and key rotation

## migration safety

- reuse the key that already opens each existing server
- copy that key before terraform removes its legacy state entries
- reject any plan that replaces the ec2 instance
- install and test a new key before changing `ssh_public_key`
- protect historical terraform state that contains the old private key

## risk

- application behavior: unchanged
- database behavior: unchanged
- existing deployments require the documented state migration
- rollback: restore the previous configuration and state only with operator review

## verification

- `terraform fmt -check -diff`: pass
- `terraform init -backend=false -input=false`: pass
- `terraform validate`: pass
- `git diff --check`: pass
- GitHub required CI gate: pass
