### PR TITLE
fix(admin): restore nightly CI checks

### DIFF
--- a/admin-spa/e2e/admin-auth.spec.ts
+++ b/admin-spa/e2e/admin-auth.spec.ts
@@ -9,7 +9,7 @@ const protectedRoutes = [
   { path: '/dashboard', heading: 'Today' },
   { path: '/dashboard/classes', heading: 'Classes' },
   { path: '/settings/users', heading: 'Staff access' },
-  { path: '/export', heading: 'Data export' },
+  { path: '/export', heading: 'Download records' },
 ] as const
 
 test.describe('admin public auth flows', () => {

--- a/admin-spa/e2e/admin-auth.spec.ts
+++ b/admin-spa/e2e/admin-auth.spec.ts
@@ -8,7 +8,7 @@ const hasBackendAuth = Boolean(adminEmail && adminPassword)
 const protectedRoutes = [
   { path: '/dashboard', heading: 'Today' },
   { path: '/dashboard/classes', heading: 'Classes' },
-  { path: '/settings/users', heading: 'User and invite management' },
+  { path: '/settings/users', heading: 'Staff access' },
   { path: '/export', heading: 'Data export' },
 ] as const
 

--- a/admin-spa/src/components/ai-usage/ai-usage-budget-page.tsx
+++ b/admin-spa/src/components/ai-usage/ai-usage-budget-page.tsx
@@ -201,15 +201,12 @@ function getBudgetSnapshot(
     return { status: 'empty' }
   }
 
-  const reportedRemaining = readNonNegativeNumber(
-    usage.budget_remaining_tokens,
-  )
+  const reportedRemaining = readNonNegativeNumber(usage.budget_remaining_tokens)
   const remaining =
     reportedRemaining === null ? null : Math.min(limit, reportedRemaining)
   const recordedUsed = readNonNegativeNumber(usage.budget_used_tokens)
   const used =
-    recordedUsed ??
-    (remaining === null ? null : Math.max(0, limit - remaining))
+    recordedUsed ?? (remaining === null ? null : Math.max(0, limit - remaining))
 
   return {
     limit,
@@ -224,6 +221,8 @@ function getBudgetSnapshot(
   }
 }
 
-function readNonNegativeNumber(value: number | null | undefined): number | null {
+function readNonNegativeNumber(
+  value: number | null | undefined,
+): number | null {
   return typeof value === 'number' ? Math.max(0, value) : null
 }

--- a/admin-spa/src/components/settings/embed-config-panel.tsx
+++ b/admin-spa/src/components/settings/embed-config-panel.tsx
@@ -455,10 +455,7 @@ function EmbedSetupGuide({
           : 3
   const steps = [
     ['Add host origin', 'Enter the site URL.'],
-    [
-      'Configure appearance',
-      'Set color, language, and position.',
-    ],
+    ['Configure appearance', 'Set color, language, and position.'],
     ['Enable the widget', 'Turn it on and save.'],
     ['Install the snippet', 'Copy it into your site.'],
     ['Verify chat', 'Send a test message.'],
@@ -486,7 +483,7 @@ function EmbedSetupGuide({
           return (
             <li
               aria-current={current ? 'step' : undefined}
-              className='relative grid grid-cols-[2.5rem_minmax(0,1fr)] gap-3 pb-7 last:pb-0 lg:block lg:pb-0 lg:pe-5'
+              className='relative grid grid-cols-[2.5rem_minmax(0,1fr)] gap-3 pb-7 last:pb-0 lg:block lg:pe-5 lg:pb-0'
               key={title}
             >
               {index < steps.length - 1 && (
@@ -688,7 +685,7 @@ function PublishedState({ config }: { config: EmbedConfig }) {
         </p>
         <p className='m-0 text-xs text-[var(--admin-muted)]'>{detail}</p>
       </div>
-      <p className='ms-auto m-0 text-[0.6875rem] font-semibold tracking-[0.12em] text-[var(--admin-muted)] uppercase'>
+      <p className='m-0 ms-auto text-[0.6875rem] font-semibold tracking-[0.12em] text-[var(--admin-muted)] uppercase'>
         Saved state
       </p>
     </div>

--- a/admin-spa/src/components/shared/admin-sidebar.tsx
+++ b/admin-spa/src/components/shared/admin-sidebar.tsx
@@ -78,7 +78,7 @@ export function AdminSidebar() {
           {isMobile && (
             <Button
               aria-label='Close navigation'
-              className='size-11 shrink-0 text-[var(--admin-nav-muted)] hover:bg-white/8 hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-current focus-visible:ring-0'
+              className='size-11 shrink-0 text-[var(--admin-nav-muted)] hover:bg-white/8 hover:text-white focus-visible:ring-0 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-current'
               onClick={handleCloseNavigation}
               size='icon'
               type='button'
@@ -129,7 +129,7 @@ export function AdminSidebar() {
           </div>
           <Button
             aria-label='Log out'
-            className='size-11 text-[var(--admin-nav-muted)] hover:bg-white/8 hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-current focus-visible:ring-0'
+            className='size-11 text-[var(--admin-nav-muted)] hover:bg-white/8 hover:text-white focus-visible:ring-0 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-current'
             onClick={handleLogout}
             size='icon-sm'
             type='button'
@@ -159,7 +159,7 @@ function AdminNavigationLink({
     <SidebarMenuItem>
       <SidebarMenuButton
         asChild
-        className='relative h-11 gap-3 rounded-xl px-3 text-[var(--admin-nav-muted)] transition-[background-color,color,box-shadow,transform] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:bg-white/7 hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-current focus-visible:ring-0 active:scale-[0.96] motion-reduce:transform-none motion-reduce:transition-none data-active:bg-[var(--admin-accent)] data-active:font-semibold data-active:text-[var(--admin-ink)]'
+        className='relative h-11 gap-3 rounded-xl px-3 text-[var(--admin-nav-muted)] transition-[background-color,color,box-shadow,transform] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:bg-white/7 hover:text-white focus-visible:ring-0 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-current active:scale-[0.96] motion-reduce:transform-none motion-reduce:transition-none data-active:bg-[var(--admin-accent)] data-active:font-semibold data-active:text-[var(--admin-ink)]'
         isActive={isActive}
       >
         <Link

--- a/admin-spa/src/components/shared/admin-topbar.tsx
+++ b/admin-spa/src/components/shared/admin-topbar.tsx
@@ -18,7 +18,7 @@ export function AdminTopbar() {
       <div className='flex min-w-0 items-center gap-2 sm:gap-3'>
         <SidebarTrigger
           aria-label='Open navigation'
-          className='size-11 shrink-0 text-[var(--admin-ink-soft)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-current focus-visible:ring-0 md:hidden'
+          className='size-11 shrink-0 text-[var(--admin-ink-soft)] focus-visible:ring-0 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-current md:hidden'
         />
         <div className='min-w-0 leading-tight'>
           <p className='truncate text-[10px] font-semibold tracking-[0.12em] text-[var(--admin-muted)] uppercase sm:text-[11px]'>

--- a/admin-spa/src/components/shared/stat-item.tsx
+++ b/admin-spa/src/components/shared/stat-item.tsx
@@ -10,7 +10,7 @@ export function StatItem({
   return (
     <div className='flex min-h-22 flex-col justify-start gap-2.5 rounded-xl bg-[var(--admin-surface-muted)] p-4'>
       <span className='text-[var(--admin-muted)]'>{label}</span>
-      <strong className='text-[1.75rem] leading-none tracking-[-0.03em] tabular-nums text-[var(--admin-ink)]'>
+      <strong className='text-[1.75rem] leading-none tracking-[-0.03em] text-[var(--admin-ink)] tabular-nums'>
         {value}
       </strong>
       {note ? (

--- a/admin-spa/src/components/ui/button.tsx
+++ b/admin-spa/src/components/ui/button.tsx
@@ -6,7 +6,7 @@ import type { VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-full border border-transparent bg-clip-padding text-sm font-semibold whitespace-nowrap transition-[background-color,border-color,color,box-shadow,transform] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] outline-none select-none motion-reduce:transform-none motion-reduce:transition-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:scale-[0.96] disabled:pointer-events-none disabled:opacity-50 disabled:active:scale-100 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-full border border-transparent bg-clip-padding text-sm font-semibold whitespace-nowrap transition-[background-color,border-color,color,box-shadow,transform] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:scale-[0.96] disabled:pointer-events-none disabled:opacity-50 disabled:active:scale-100 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 motion-reduce:transform-none motion-reduce:transition-none dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/admin-spa/src/components/ui/card.tsx
+++ b/admin-spa/src/components/ui/card.tsx
@@ -12,7 +12,7 @@ function Card({
       data-slot='card'
       data-size={size}
       className={cn(
-        'group/card flex flex-col gap-4 overflow-hidden rounded-2xl bg-[var(--admin-surface,var(--card))] py-5 text-sm text-card-foreground ring-1 ring-[var(--admin-line,var(--border))] shadow-[0_12px_36px_oklch(0.25_0.015_150/0.04)] has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-2xl *:[img:last-child]:rounded-b-2xl',
+        'group/card flex flex-col gap-4 overflow-hidden rounded-2xl bg-[var(--admin-surface,var(--card))] py-5 text-sm text-card-foreground shadow-[0_12px_36px_oklch(0.25_0.015_150/0.04)] ring-1 ring-[var(--admin-line,var(--border))] has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-2xl *:[img:last-child]:rounded-b-2xl',
         className,
       )}
       {...props}

--- a/admin-spa/src/routes/_authenticated.tsx
+++ b/admin-spa/src/routes/_authenticated.tsx
@@ -14,9 +14,9 @@ export const Route = createFileRoute('/_authenticated')({
 
 function AuthenticatedLayout() {
   return (
-    <SidebarProvider className='admin-workspace min-h-svh w-full bg-[var(--admin-canvas)] text-[var(--admin-ink)] [--sidebar:var(--admin-ink)] [--sidebar-foreground:var(--admin-nav-text)]'>
+    <SidebarProvider className='admin-workspace min-h-svh w-full bg-[var(--admin-canvas)] text-[var(--admin-ink)] [--sidebar-foreground:var(--admin-nav-text)] [--sidebar:var(--admin-ink)]'>
       <a
-        className='fixed top-3 left-3 z-50 -translate-y-20 rounded-full bg-[var(--admin-ink)] px-4 py-3 text-sm font-semibold text-[var(--admin-surface)] shadow-lg transition-transform duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none focus:translate-y-0 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-current'
+        className='fixed top-3 left-3 z-50 -translate-y-20 rounded-full bg-[var(--admin-ink)] px-4 py-3 text-sm font-semibold text-[var(--admin-surface)] shadow-lg transition-transform duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] focus:translate-y-0 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-current motion-reduce:transition-none'
         href='#admin-content'
       >
         Skip to content


### PR DESCRIPTION
## Summary

- normalize merged Admin SPA formatting and Tailwind class order
- align the authenticated users-route assertion with the current Staff access heading

## Testing

- `cd admin-spa && pnpm check`
- local Playwright launch blocked because the matching browser binary is not installed; GitHub backend E2E will verify the authenticated route

## Release and deployment

- nightly only; this restores the required main CI gate for candidate creation