### PR TITLE
publish nightly GitHub prereleases from candidate metadata

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read
-      contents: read
+      contents: write
       id-token: write
       packages: write
     steps:
@@ -48,6 +48,16 @@ jobs:
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Restore completed candidate metadata
+        if: steps.artifact.outputs.exists == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+        run: >-
+          gh run download "$GITHUB_RUN_ID"
+          --name "nightly-candidate-$SHA"
+          --dir .
 
       - name: Configure AWS credentials
         if: steps.artifact.outputs.exists != 'true'
@@ -225,3 +235,44 @@ jobs:
           path: candidate.json
           if-no-files-found: error
           retention-days: 30
+
+      - name: Publish nightly GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          if [ ! -s candidate.json ]; then
+            echo "candidate.json is missing or empty" >&2
+            exit 1
+          fi
+          jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg sha "$SHA" \
+            '.repository == $repository and .sha == $sha' \
+            candidate.json >/dev/null
+
+          tag="nightly-$SHA"
+          tag_sha=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$tag" --jq .object.sha 2>/dev/null) || tag_sha=""
+          if [ -n "$tag_sha" ] && [ "$tag_sha" != "$SHA" ]; then
+            echo "tag $tag points to $tag_sha, expected $SHA" >&2
+            exit 1
+          fi
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "GitHub Release $tag already exists"
+            exit 0
+          fi
+
+          release_args=(
+            "$tag"
+            candidate.json
+            --prerelease
+            --latest=false
+            --generate-notes
+            --title "Nightly ${SHA:0:12}"
+          )
+          if [ -n "$tag_sha" ]; then
+            release_args+=(--verify-tag)
+          else
+            release_args+=(--target "$SHA")
+          fi
+          gh release create "${release_args[@]}"

--- a/README.md
+++ b/README.md
@@ -251,7 +251,8 @@ Read these guides before deployment:
 - [Runtime AI settings and secret rotation](docs/operations/runtime-ai-settings.md)
 - [Conversation identity migration](docs/operations/conversation-identity-migration.md)
 
-A merge to `main` creates a release candidate after CI passes. It does not deploy production.
+A push to `main` publishes a SHA-addressed nightly prerelease after CI passes.
+It does not deploy production; stable promotion remains manual.
 A feature is shipped only when it is included in a release tag.
 
 ## About Pandai

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,9 +1,9 @@
-# Nightly candidates and stable releases
+# Nightly and stable releases
 
 P&AI separates building a release from deploying it. A successful `CI` run for
-a push to `main` produces a digest-pinned nightly candidate, but it never
-deploys production. A maintainer must explicitly promote one successful
-candidate through the `Stable release` workflow.
+a push to `main` produces a digest-pinned candidate and publishes a SHA-addressed
+GitHub prerelease, but it never deploys production. A maintainer must explicitly
+promote one successful candidate through the `Stable release` workflow.
 
 This runbook is for maintainers who create candidates, promote releases, or
 diagnose release failures.
@@ -15,9 +15,11 @@ The release workflows enforce these invariants:
 - Pull requests and `main` must pass the aggregate `Required CI gate`.
 - Only a successful `CI` push run on `main` can produce a nightly candidate.
 - A candidate records immutable app, admin, and PostgreSQL image digests.
+- Every candidate publishes one `nightly-<40-character-sha>` GitHub prerelease.
+- The prerelease includes `candidate.json` and never replaces a previous tag.
 - Stable promotion downloads an existing candidate and never rebuilds it.
-- Production receives the candidate commit and image digests before a semantic
-  tag or GitHub Release is published.
+- Production receives the candidate commit and image digests before a stable
+  semantic tag or GitHub Release is published.
 - Production deployment is manual. A merge to `main` does not deploy.
 - A failed deployment does not publish a new semantic tag or GitHub Release.
 
@@ -29,6 +31,7 @@ pull request
   -> merge to main
   -> successful main CI
   -> Nightly candidate artifact
+  -> SHA-addressed nightly GitHub prerelease
   -> manual Stable release
   -> production deployment
   -> vMAJOR.MINOR.PATCH tag and GitHub Release
@@ -77,7 +80,7 @@ See [Runtime AI settings](operations/runtime-ai-settings.md) for the production
 AI and secret-rotation contract. The exact values consumed during deployment
 are defined in [the deploy workflow](../.github/workflows/deploy.yml).
 
-## Create a nightly candidate
+## Create a nightly release
 
 No operator action is normally required. The `Nightly candidate` workflow
 starts after `CI` completes successfully for a push to `main`.
@@ -91,6 +94,8 @@ The workflow:
 5. Resolves all three registry digests.
 6. Uploads `candidate.json` as
    `nightly-candidate-<40-character-sha>` with 30-day retention.
+7. Publishes `nightly-<40-character-sha>` as a GitHub prerelease with
+   `candidate.json` attached.
 
 Registry inspection is fail-closed. Only a confirmed `manifest unknown` or
 not-found response marks an app/admin image as missing. Authentication,
@@ -159,7 +164,9 @@ run IDs, artifact name, source CI run, SHA, registry paths, and digest formats.
 
 Rerunning the same Nightly workflow is safe:
 
-- If its complete candidate artifact already exists, the rerun is a no-op.
+- If its complete candidate artifact already exists, candidate construction is
+  a no-op and its metadata is restored for publication.
+- If its GitHub prerelease already exists, publication is a no-op.
 - If no artifact exists, app and admin images are checked independently.
 - Confirmed-missing images are built; existing images are reused.
 - Multiple matching candidate artifacts fail as ambiguous.

--- a/internal/releaseworkflow/workflows_test.go
+++ b/internal/releaseworkflow/workflows_test.go
@@ -294,6 +294,14 @@ func TestNightlyCandidateContracts(t *testing.T) {
 	if _, ok := on["workflow_run"]; !ok || len(on) != 1 {
 		t.Fatalf("nightly triggers = %#v, want only workflow_run", on)
 	}
+	candidate, err := workflowJob(document, "candidate")
+	if err != nil {
+		t.Fatal(err)
+	}
+	permissions, ok := stringMap(candidate["permissions"])
+	if !ok || permissions["contents"] != "write" {
+		t.Fatalf("nightly contents permission = %v, want write", permissions["contents"])
+	}
 	requirePinnedActions(t, document)
 	requireContains(t, source,
 		"github.event.workflow_run.conclusion == 'success'",
@@ -302,6 +310,7 @@ func TestNightlyCandidateContracts(t *testing.T) {
 		"github.event.workflow_run.head_sha",
 		"Reuse completed candidate artifact",
 		"this rerun is a no-op",
+		"Restore completed candidate metadata",
 		"Reuse existing SHA-addressed application images",
 		`docker buildx imagetools inspect "$1"`,
 		"steps.existing.outputs.app_exists != 'true'",
@@ -313,9 +322,97 @@ func TestNightlyCandidateContracts(t *testing.T) {
 		"postgres_image:",
 		"nightly-candidate-${{ github.event.workflow_run.head_sha }}",
 		"retention-days: 30",
+		"Publish nightly GitHub Release",
+		`tag="nightly-$SHA"`,
+		"--prerelease",
+		"--latest=false",
+		"--target \"$SHA\"",
 	)
 	if strings.Contains(source, "environment: production") {
 		t.Fatal("nightly workflow must not deploy to production")
+	}
+}
+
+func TestNightlyGitHubReleaseIsImmutableAndRetrySafe(t *testing.T) {
+	_, document := repositoryWorkflow(t, ".github/workflows/nightly.yml")
+	publish := workflowStepRun(t, document, "candidate", "Publish nightly GitHub Release")
+
+	workDir := t.TempDir()
+	bin := filepath.Join(workDir, "bin")
+	if err := os.Mkdir(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(workDir, "gh.log")
+	writeExecutable(t, filepath.Join(bin, "gh"), `#!/bin/bash
+echo "$*" >> "$FAKE_GH_LOG"
+if [ "$1" = "api" ] && [[ "$2" == */git/ref/tags/* ]]; then
+  if [ -n "${FAKE_TAG_SHA:-}" ]; then
+    echo "$FAKE_TAG_SHA"
+    exit 0
+  fi
+  exit 1
+fi
+if [ "$1" = "release" ] && [ "$2" = "view" ]; then
+  if [ "${FAKE_RELEASE_EXISTS:-false}" = "true" ]; then
+    exit 0
+  fi
+  exit 1
+fi
+exit 0
+`)
+
+	sha := strings.Repeat("a", 40)
+	manifest := fmt.Sprintf(`{"repository":"p-n-ai/pai-bot","sha":"%s"}`, sha)
+	if err := os.WriteFile(filepath.Join(workDir, "candidate.json"), []byte(manifest), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	commonEnvironment := []string{
+		"PATH=" + bin + ":" + os.Getenv("PATH"),
+		"FAKE_GH_LOG=" + logPath,
+		"GITHUB_REPOSITORY=p-n-ai/pai-bot",
+		"SHA=" + sha,
+	}
+	if err := runBash(
+		t,
+		"cd \"$TEST_WORKDIR\"\n"+publish,
+		append(commonEnvironment, "TEST_WORKDIR="+workDir)...,
+	); err != nil {
+		t.Fatal(err)
+	}
+	log := string(mustReadFile(t, logPath))
+	requireContains(t, log,
+		"api repos/p-n-ai/pai-bot/git/ref/tags/nightly-"+sha+" --jq .object.sha",
+		"release create nightly-"+sha+" candidate.json --prerelease --latest=false --generate-notes --title Nightly "+sha[:12]+" --target "+sha,
+	)
+
+	if err := os.WriteFile(logPath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := runBash(
+		t,
+		"cd \"$TEST_WORKDIR\"\n"+publish,
+		append(commonEnvironment,
+			"TEST_WORKDIR="+workDir,
+			"FAKE_TAG_SHA="+sha,
+			"FAKE_RELEASE_EXISTS=true",
+		)...,
+	); err != nil {
+		t.Fatal(err)
+	}
+	log = string(mustReadFile(t, logPath))
+	if strings.Contains(log, "release create") {
+		t.Fatal("retry attempted to recreate an existing nightly release")
+	}
+
+	if err := runBash(
+		t,
+		"cd \"$TEST_WORKDIR\"\n"+publish,
+		append(commonEnvironment,
+			"TEST_WORKDIR="+workDir,
+			"FAKE_TAG_SHA="+strings.Repeat("b", 40),
+		)...,
+	); err == nil {
+		t.Fatal("nightly publication accepted an existing tag for another commit")
 	}
 }
 

--- a/scripts/test_ci_config.py
+++ b/scripts/test_ci_config.py
@@ -71,6 +71,11 @@ class CIWorkflowTests(unittest.TestCase):
             "github.event.workflow_run.head_branch == 'main'",
             nightly,
         )
+        self.assertIn("      contents: write", nightly)
+        self.assertIn("      - name: Publish nightly GitHub Release", nightly)
+        self.assertIn('tag="nightly-$SHA"', nightly)
+        self.assertIn("--prerelease", nightly)
+        self.assertIn("--latest=false", nightly)
         for job in (
             "changes",
             "config",


### PR DESCRIPTION
## Summary

Successful pushes to `main` now publish SHA-addressed GitHub prereleases from the existing nightly candidate metadata. Completed candidate artifacts are restored on reruns, publication is retry-safe, and stable promotion remains manual. Documentation and workflow contract tests have been updated accordingly.

## Risk

- API contract: unchanged; this adds GitHub release publication without changing application APIs.
- Database migrations: none.
- Release and deployment: nightly only; the workflow now requires `contents: write` and publishes a prerelease after candidate creation. Production deployment remains manual.
- Rollback: disable or revert the nightly workflow publication changes; existing candidate artifacts and stable release promotion remain unaffected.

## Verification

- Added Go coverage for immutable, retry-safe nightly release publication.
- Added workflow contract assertions for permissions, candidate restoration, prerelease flags, and SHA-addressed tags.
- Updated CI configuration checks for nightly release publication.
- Updated `README.md` and `docs/releases.md` to document the new nightly prerelease flow.