### PR TITLE
feat(chat): persist inbound deliveries before processing

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -45,6 +45,22 @@ func focusedPageChannelEnabled(devMode bool, msg chat.InboundMessage) bool {
 	return msg.Channel == "telegram" || (devMode && msg.Channel == "websocket")
 }
 
+type chatIngressProcessor struct {
+	gateway *chat.Gateway
+	router  *server.TenantTurnRouter
+}
+
+func (p chatIngressProcessor) ProcessTurn(ctx context.Context, msg chat.InboundMessage) (agent.TurnResult, error) {
+	if err := p.gateway.SendTyping(ctx, msg.Channel, msg.DestinationID()); err != nil {
+		slog.Warn("failed to send typing indicator", "error", err)
+	}
+	return p.router.ProcessTurn(ctx, msg)
+}
+
+func (p chatIngressProcessor) DeliverTurn(ctx context.Context, msg chat.InboundMessage, result agent.TurnResult) error {
+	return p.router.DeliverTurn(ctx, msg, result)
+}
+
 type runtimeSettingsUpdater interface {
 	Update(
 		context.Context,
@@ -499,30 +515,21 @@ func run(ctx context.Context, cfg *config.Config) (runErr error) {
 			// when we add user enumeration from the database.
 			go scheduler.Start(ctx, []string{})
 
-			// Start long-polling with message handler.
-			// Shared inbound message handler for all channels.
-			processInbound := func(processCtx context.Context, msg chat.InboundMessage) {
-				// Show typing indicator while processing.
-				if err := gw.SendTyping(processCtx, msg.Channel, msg.DestinationID()); err != nil {
-					slog.Warn("failed to send typing indicator", "error", err)
-				}
-
-				_, err := turnRouter.ProcessAndDeliver(processCtx, msg)
-				if err != nil {
-					slog.Error("process or deliver turn failed", "error", err, "user_id", msg.UserID)
-				}
-			}
-			chatIngress, err := server.NewChatIngress(256, processInbound)
+			chatIngress, err := server.NewPostgresChatIngress(
+				store.TenantID(),
+				db.Pool,
+				chatIngressProcessor{gateway: gw, router: turnRouter},
+			)
 			if err != nil {
 				return nil, nil, fmt.Errorf("initialize chat ingress: %w", err)
 			}
-			handleInbound := func(msg chat.InboundMessage) {
-				if err := chatIngress.Enqueue(ctx, msg); err != nil && ctx.Err() == nil {
-					slog.Warn("failed to enqueue inbound chat message", "channel", msg.Channel, "error", err)
+			acceptInbound := func(msg chat.InboundMessage) {
+				if err := chatIngress.Accept(ctx, msg); err != nil && ctx.Err() == nil {
+					slog.Warn("failed to accept inbound chat message", "channel", msg.Channel, "error", err)
 				}
 			}
 
-			chatWebhooks := gw.Webhooks(handleInbound)
+			chatWebhooks := gw.Webhooks(acceptInbound)
 
 			authService := auth.NewPostgresService(
 				db.Pool,
@@ -601,7 +608,7 @@ func run(ctx context.Context, cfg *config.Config) (runErr error) {
 				EmbedTokenTTL:         defaultEmbedTokenTTL,
 				WACloudChannel:        waCloudChannel,
 				ChatWebhooks:          chatWebhooks,
-				InboundHandler:        handleInbound,
+				InboundHandler:        acceptInbound,
 				AuthService:           authService,
 				JWTSecret:             cfg.Auth.JWTSecret,
 				AccessTokenTTL:        defaultAccessTokenTTL,
@@ -619,7 +626,7 @@ func run(ctx context.Context, cfg *config.Config) (runErr error) {
 					defer close(ingressDone)
 					chatIngress.Run(ingressCtx)
 				}()
-				if err := gw.StartAll(ctx, handleInbound); err != nil {
+				if err := gw.StartAll(ctx, acceptInbound); err != nil {
 					cancelIngress()
 					<-ingressDone
 					return err

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -528,8 +528,11 @@ func run(ctx context.Context, cfg *config.Config) (runErr error) {
 					slog.Warn("failed to accept inbound chat message", "channel", msg.Channel, "error", err)
 				}
 			}
+			acceptWebhook := func(requestCtx context.Context, msg chat.InboundMessage) error {
+				return chatIngress.Accept(requestCtx, msg)
+			}
 
-			chatWebhooks := gw.Webhooks(acceptInbound)
+			chatWebhooks := gw.Webhooks(acceptWebhook)
 
 			authService := auth.NewPostgresService(
 				db.Pool,
@@ -606,9 +609,7 @@ func run(ctx context.Context, cfg *config.Config) (runErr error) {
 				EmbedAuthenticator:    authService,
 				EmbedBaseURL:          cfg.Embed.BaseURL,
 				EmbedTokenTTL:         defaultEmbedTokenTTL,
-				WACloudChannel:        waCloudChannel,
 				ChatWebhooks:          chatWebhooks,
-				InboundHandler:        acceptInbound,
 				AuthService:           authService,
 				JWTSecret:             cfg.Auth.JWTSecret,
 				AccessTokenTTL:        defaultAccessTokenTTL,

--- a/internal/chat/discord_test.go
+++ b/internal/chat/discord_test.go
@@ -5,6 +5,7 @@ package chat
 
 import (
 	"bytes"
+	"context"
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/hex"
@@ -37,8 +38,9 @@ func TestDiscordChannelWebhookRespondsToSignedPing(t *testing.T) {
 	request.Header.Set("X-Signature-Ed25519", hex.EncodeToString(ed25519.Sign(privateKey, append([]byte(timestamp), body...))))
 	recorder := httptest.NewRecorder()
 
-	channel.WebhookHandler(func(InboundMessage) {
+	channel.WebhookHandler(func(context.Context, InboundMessage) error {
 		t.Fatal("Discord ping must not dispatch a tutor message")
+		return nil
 	}).ServeHTTP(recorder, request)
 
 	if recorder.Code != http.StatusOK {
@@ -80,8 +82,9 @@ func TestDiscordChannelWebhookRejectsBotTokenForwarding(t *testing.T) {
 	request.Header.Set("X-Discord-Gateway-Token", "discord-bot-token")
 	recorder := httptest.NewRecorder()
 
-	channel.WebhookHandler(func(InboundMessage) {
+	channel.WebhookHandler(func(context.Context, InboundMessage) error {
 		t.Fatal("bot-token forwarding must not dispatch")
+		return nil
 	}).ServeHTTP(recorder, request)
 
 	if recorder.Code != http.StatusUnauthorized {
@@ -107,8 +110,9 @@ func TestDiscordChannelWebhookRejectsInvalidInteractionSignature(t *testing.T) {
 	request.Header.Set("X-Signature-Ed25519", hex.EncodeToString(make([]byte, ed25519.SignatureSize)))
 	recorder := httptest.NewRecorder()
 
-	channel.WebhookHandler(func(InboundMessage) {
+	channel.WebhookHandler(func(context.Context, InboundMessage) error {
 		t.Fatal("invalid interaction must not dispatch")
+		return nil
 	}).ServeHTTP(recorder, request)
 
 	if recorder.Code != http.StatusUnauthorized {

--- a/internal/chat/discord_webhook.go
+++ b/internal/chat/discord_webhook.go
@@ -14,7 +14,7 @@ import (
 const maxDiscordWebhookBody = 1 << 20
 
 // WebhookHandler verifies and handles Discord interactions.
-func (d *DiscordChannel) WebhookHandler(_ func(InboundMessage)) http.Handler {
+func (d *DiscordChannel) WebhookHandler(_ InboundWebhookHandler) http.Handler {
 	return http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		if request.Method != http.MethodPost {
 			http.Error(response, "method not allowed", http.StatusMethodNotAllowed)

--- a/internal/chat/embed/chat.html
+++ b/internal/chat/embed/chat.html
@@ -672,13 +672,24 @@
     }
   });
 
+  function newDeliveryID() {
+    if (window.crypto && typeof window.crypto.randomUUID === 'function') {
+      return window.crypto.randomUUID();
+    }
+    var bytes = new Uint8Array(16);
+    window.crypto.getRandomValues(bytes);
+    return Array.prototype.map.call(bytes, function(value) {
+      return value.toString(16).padStart(2, '0');
+    }).join('');
+  }
+
   function sendMessage() {
     var text = inputEl.value.trim();
     if (!text) return;
     inputEl.value = '';
     addMessage(text, 'user');
 
-    var msg = JSON.stringify({ type: 'message', text: text });
+    var msg = JSON.stringify({ type: 'message', delivery_id: newDeliveryID(), text: text });
     if (connected && ws && ws.readyState === WebSocket.OPEN) {
       ws.send(msg);
     } else {

--- a/internal/chat/fuzz_test.go
+++ b/internal/chat/fuzz_test.go
@@ -43,12 +43,13 @@ func FuzzSlackWebhook(f *testing.F) {
 		request := httptest.NewRequest(http.MethodPost, "/webhook/slack", bytes.NewReader(body))
 		signSlackTestRequest(request, body, "fuzz-signing-secret", now)
 		recorder := httptest.NewRecorder()
-		channel.WebhookHandler(func(message InboundMessage) {
+		channel.WebhookHandler(func(_ context.Context, message InboundMessage) error {
 			if message.Channel != "slack" ||
 				message.UserID == "" ||
 				!strings.HasPrefix(message.ThreadID, "slack:") {
 				t.Fatalf("invalid normalized Slack message: %#v", message)
 			}
+			return nil
 		}).ServeHTTP(recorder, request)
 
 		if recorder.Code != http.StatusOK && recorder.Code != http.StatusBadRequest {
@@ -95,8 +96,9 @@ func FuzzDiscordInteractionWebhook(f *testing.F) {
 		request.Header.Set("X-Signature-Timestamp", timestamp)
 		request.Header.Set("X-Signature-Ed25519", hex.EncodeToString(ed25519.Sign(privateKey, signed)))
 		recorder := httptest.NewRecorder()
-		channel.WebhookHandler(func(message InboundMessage) {
+		channel.WebhookHandler(func(_ context.Context, message InboundMessage) error {
 			t.Fatalf("interaction webhook dispatched an inbound message: %#v", message)
+			return nil
 		}).ServeHTTP(recorder, request)
 
 		if recorder.Code != http.StatusOK && recorder.Code != http.StatusBadRequest {
@@ -134,12 +136,13 @@ func FuzzTeamsWebhook(f *testing.F) {
 		request := httptest.NewRequest(http.MethodPost, "/webhook/teams", bytes.NewReader(body))
 		request.Header.Set("Authorization", "Bearer fuzz-token")
 		recorder := httptest.NewRecorder()
-		channel.WebhookHandler(func(message InboundMessage) {
+		channel.WebhookHandler(func(_ context.Context, message InboundMessage) error {
 			if message.Channel != "teams" ||
 				message.UserID == "" ||
 				!strings.HasPrefix(message.ThreadID, "teams:") {
 				t.Fatalf("invalid normalized Teams message: %#v", message)
 			}
+			return nil
 		}).ServeHTTP(recorder, request)
 
 		if recorder.Code != http.StatusOK && recorder.Code != http.StatusBadRequest {

--- a/internal/chat/gateway.go
+++ b/internal/chat/gateway.go
@@ -77,10 +77,14 @@ type Channel interface {
 	Stop() error
 }
 
+// InboundWebhookHandler durably accepts one normalized webhook message.
+// Returning an error tells the adapter to request a provider retry.
+type InboundWebhookHandler func(context.Context, InboundMessage) error
+
 // WebhookChannel receives inbound messages through an HTTP webhook.
 type WebhookChannel interface {
 	Channel
-	WebhookHandler(handler func(InboundMessage)) http.Handler
+	WebhookHandler(handler InboundWebhookHandler) http.Handler
 }
 
 // Gateway routes messages to/from registered channels.
@@ -157,7 +161,7 @@ func (g *Gateway) SendTyping(ctx context.Context, channel, destination string) e
 }
 
 // Webhook returns the inbound HTTP handler for a registered webhook channel.
-func (g *Gateway) Webhook(name string, handler func(InboundMessage)) (http.Handler, error) {
+func (g *Gateway) Webhook(name string, handler InboundWebhookHandler) (http.Handler, error) {
 	channel, ok := g.Channel(name)
 	if !ok {
 		return nil, fmt.Errorf("unknown channel: %s", name)
@@ -170,7 +174,7 @@ func (g *Gateway) Webhook(name string, handler func(InboundMessage)) (http.Handl
 }
 
 // Webhooks returns every registered HTTP ingress adapter by its channel name.
-func (g *Gateway) Webhooks(handler func(InboundMessage)) map[string]http.Handler {
+func (g *Gateway) Webhooks(handler InboundWebhookHandler) map[string]http.Handler {
 	webhooks := make(map[string]http.Handler)
 	for _, entry := range g.channelEntries() {
 		channel, ok := entry.channel.(WebhookChannel)

--- a/internal/chat/gateway_test.go
+++ b/internal/chat/gateway_test.go
@@ -31,7 +31,7 @@ type recordingWebhookChannel struct {
 	handler http.Handler
 }
 
-func (c *recordingWebhookChannel) WebhookHandler(func(chat.InboundMessage)) http.Handler {
+func (c *recordingWebhookChannel) WebhookHandler(chat.InboundWebhookHandler) http.Handler {
 	return c.handler
 }
 
@@ -135,7 +135,7 @@ func TestGatewayDiscoversFutureWebhookAdapters(t *testing.T) {
 	gw.Register("future-chat", &recordingWebhookChannel{handler: expected})
 	gw.Register("polling-only", &recordingChannel{})
 
-	webhooks := gw.Webhooks(func(chat.InboundMessage) {})
+	webhooks := gw.Webhooks(func(context.Context, chat.InboundMessage) error { return nil })
 	if len(webhooks) != 1 || webhooks["future-chat"] == nil {
 		t.Fatalf("Webhooks() = %#v, want future-chat only", webhooks)
 	}

--- a/internal/chat/slack.go
+++ b/internal/chat/slack.go
@@ -100,7 +100,7 @@ func (s *SlackChannel) Start(context.Context, func(InboundMessage)) error { retu
 func (s *SlackChannel) Stop() error { return nil }
 
 // WebhookHandler verifies and normalizes Slack Events API requests.
-func (s *SlackChannel) WebhookHandler(handler func(InboundMessage)) http.Handler {
+func (s *SlackChannel) WebhookHandler(handler InboundWebhookHandler) http.Handler {
 	return http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		if request.Method != http.MethodPost {
 			http.Error(response, "method not allowed", http.StatusMethodNotAllowed)
@@ -137,8 +137,7 @@ func (s *SlackChannel) WebhookHandler(handler func(InboundMessage)) http.Handler
 			response.WriteHeader(http.StatusOK)
 			return
 		}
-		response.WriteHeader(http.StatusOK)
-		handler(InboundMessage{
+		message := InboundMessage{
 			Channel:    "slack",
 			UserID:     envelope.Event.User,
 			ExternalID: envelope.Event.User,
@@ -146,7 +145,14 @@ func (s *SlackChannel) WebhookHandler(handler func(InboundMessage)) http.Handler
 			MessageID:  envelope.Event.TS,
 			DeliveryID: envelope.EventID,
 			Text:       envelope.Event.Text,
-		})
+		}
+		if handler != nil {
+			if err := handler(request.Context(), message); err != nil {
+				http.Error(response, "temporarily unavailable", http.StatusServiceUnavailable)
+				return
+			}
+		}
+		response.WriteHeader(http.StatusOK)
 	})
 }
 

--- a/internal/chat/slack_test.go
+++ b/internal/chat/slack_test.go
@@ -5,14 +5,17 @@ package chat
 
 import (
 	"bytes"
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 )
@@ -41,8 +44,9 @@ func TestSlackChannelWebhookNormalizesSignedMessage(t *testing.T) {
 	recorder := httptest.NewRecorder()
 
 	var got InboundMessage
-	channel.WebhookHandler(func(message InboundMessage) {
+	channel.WebhookHandler(func(_ context.Context, message InboundMessage) error {
 		got = message
+		return nil
 	}).ServeHTTP(recorder, request)
 
 	if recorder.Code != http.StatusOK {
@@ -93,7 +97,10 @@ func TestSlackChannelWebhookPreservesThreadRoute(t *testing.T) {
 	recorder := httptest.NewRecorder()
 
 	var got InboundMessage
-	channel.WebhookHandler(func(message InboundMessage) { got = message }).ServeHTTP(recorder, request)
+	channel.WebhookHandler(func(_ context.Context, message InboundMessage) error {
+		got = message
+		return nil
+	}).ServeHTTP(recorder, request)
 
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
@@ -115,8 +122,9 @@ func TestSlackChannelWebhookAnswersSignedURLVerification(t *testing.T) {
 	request := httptest.NewRequest(http.MethodPost, "/webhook/slack", bytes.NewReader(body))
 	signSlackTestRequest(request, body, "signing-secret", now)
 	recorder := httptest.NewRecorder()
-	channel.WebhookHandler(func(InboundMessage) {
+	channel.WebhookHandler(func(context.Context, InboundMessage) error {
 		t.Fatal("URL verification must not dispatch an inbound message")
+		return nil
 	}).ServeHTTP(recorder, request)
 
 	if recorder.Code != http.StatusOK {
@@ -137,8 +145,9 @@ func TestSlackChannelWebhookRejectsInvalidSignature(t *testing.T) {
 	request.Header.Set("X-Slack-Signature", "v0=bad")
 	recorder := httptest.NewRecorder()
 
-	channel.WebhookHandler(func(InboundMessage) {
+	channel.WebhookHandler(func(context.Context, InboundMessage) error {
 		t.Fatal("invalid request must not dispatch an inbound message")
+		return nil
 	}).ServeHTTP(recorder, request)
 
 	if recorder.Code != http.StatusUnauthorized {
@@ -158,8 +167,9 @@ func TestSlackChannelWebhookRejectsStaleSignature(t *testing.T) {
 	signSlackTestRequest(request, body, "signing-secret", now.Add(-6*time.Minute))
 	recorder := httptest.NewRecorder()
 
-	channel.WebhookHandler(func(InboundMessage) {
+	channel.WebhookHandler(func(context.Context, InboundMessage) error {
 		t.Fatal("stale request must not dispatch")
+		return nil
 	}).ServeHTTP(recorder, request)
 
 	if recorder.Code != http.StatusUnauthorized {
@@ -183,12 +193,84 @@ func TestSlackChannelWebhookIgnoresBotMessage(t *testing.T) {
 	signSlackTestRequest(request, body, "signing-secret", now)
 	recorder := httptest.NewRecorder()
 
-	channel.WebhookHandler(func(InboundMessage) {
+	channel.WebhookHandler(func(context.Context, InboundMessage) error {
 		t.Fatal("bot message must not dispatch")
+		return nil
 	}).ServeHTTP(recorder, request)
 
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+}
+
+func TestSlackWebhookAcknowledgesOnlyAfterInboundAccepted(t *testing.T) {
+	now := time.Unix(1_725_000_000, 0)
+	channel, err := NewSlackChannel("xoxb-test", "signing-secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	channel.now = func() time.Time { return now }
+	body := []byte(`{
+		"type":"event_callback","event_id":"EvPersist",
+		"event":{"type":"message","user":"U1","channel":"C1","text":"hello","ts":"1.0"}
+	}`)
+	request := httptest.NewRequest(http.MethodPost, "/webhook/slack", bytes.NewReader(body))
+	signSlackTestRequest(request, body, "signing-secret", now)
+	recorder := httptest.NewRecorder()
+	accepted := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		channel.WebhookHandler(func(context.Context, InboundMessage) error {
+			close(accepted)
+			<-release
+			return nil
+		}).ServeHTTP(recorder, request)
+		close(done)
+	}()
+	select {
+	case <-accepted:
+	case <-time.After(time.Second):
+		t.Fatal("inbound acceptor was not called")
+	}
+	select {
+	case <-done:
+		t.Fatal("webhook acknowledged before inbound acceptance completed")
+	case <-time.After(25 * time.Millisecond):
+	}
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("webhook did not finish after inbound acceptance")
+	}
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+}
+
+func TestSlackWebhookReturnsRetryableStatusWhenInboundPersistenceFails(t *testing.T) {
+	now := time.Unix(1_725_000_000, 0)
+	channel, err := NewSlackChannel("xoxb-test", "signing-secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	channel.now = func() time.Time { return now }
+	body := []byte(`{
+		"type":"event_callback","event_id":"EvFail",
+		"event":{"type":"message","user":"U1","channel":"C1","text":"hello","ts":"1.0"}
+	}`)
+	request := httptest.NewRequest(http.MethodPost, "/webhook/slack", bytes.NewReader(body))
+	signSlackTestRequest(request, body, "signing-secret", now)
+	recorder := httptest.NewRecorder()
+	channel.WebhookHandler(func(context.Context, InboundMessage) error {
+		return errors.New("private database failure")
+	}).ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusServiceUnavailable)
+	}
+	if strings.Contains(recorder.Body.String(), "database") {
+		t.Fatalf("response exposed persistence error: %q", recorder.Body.String())
 	}
 }
 

--- a/internal/chat/teams.go
+++ b/internal/chat/teams.go
@@ -233,7 +233,7 @@ func newTeamsHTTPClient() *http.Client {
 }
 
 // WebhookHandler authenticates and normalizes Bot Framework message activities.
-func (t *TeamsChannel) WebhookHandler(handler func(InboundMessage)) http.Handler {
+func (t *TeamsChannel) WebhookHandler(handler InboundWebhookHandler) http.Handler {
 	return http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		if request.Method != http.MethodPost {
 			http.Error(response, "method not allowed", http.StatusMethodNotAllowed)
@@ -278,7 +278,10 @@ func (t *TeamsChannel) WebhookHandler(handler func(InboundMessage)) http.Handler
 			return
 		}
 		if handler != nil {
-			handler(message)
+			if err := handler(request.Context(), message); err != nil {
+				http.Error(response, "temporarily unavailable", http.StatusServiceUnavailable)
+				return
+			}
 		}
 		response.WriteHeader(http.StatusOK)
 	})

--- a/internal/chat/teams_test.go
+++ b/internal/chat/teams_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -55,7 +56,10 @@ func TestTeamsChannelWebhookNormalizesAuthenticatedMessageActivity(t *testing.T)
 	recorder := httptest.NewRecorder()
 
 	var got InboundMessage
-	channel.WebhookHandler(func(message InboundMessage) { got = message }).ServeHTTP(recorder, request)
+	channel.WebhookHandler(func(_ context.Context, message InboundMessage) error {
+		got = message
+		return nil
+	}).ServeHTTP(recorder, request)
 
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
@@ -98,8 +102,9 @@ func TestTeamsChannelWebhookRejectsUnauthenticatedActivity(t *testing.T) {
 	request := httptest.NewRequest(http.MethodPost, "/webhook/teams", bytes.NewReader([]byte(`{"type":"message"}`)))
 	recorder := httptest.NewRecorder()
 
-	channel.WebhookHandler(func(InboundMessage) {
+	channel.WebhookHandler(func(context.Context, InboundMessage) error {
 		t.Fatal("unauthenticated activity must not dispatch")
+		return nil
 	}).ServeHTTP(recorder, request)
 
 	if recorder.Code != http.StatusUnauthorized {
@@ -132,12 +137,44 @@ func TestTeamsChannelWebhookRejectsUnendorsedActivityAsForbidden(t *testing.T) {
 	request.Header.Set("Authorization", "Bearer valid-token")
 	recorder := httptest.NewRecorder()
 
-	channel.WebhookHandler(func(InboundMessage) {
+	channel.WebhookHandler(func(context.Context, InboundMessage) error {
 		t.Fatal("unendorsed activity must not dispatch")
+		return nil
 	}).ServeHTTP(recorder, request)
 
 	if recorder.Code != http.StatusForbidden {
 		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusForbidden)
+	}
+}
+
+func TestTeamsWebhookReturnsRetryableStatusWhenInboundPersistenceFails(t *testing.T) {
+	channel, err := NewTeamsChannel(TeamsConfig{
+		TokenValidator: teamsTokenValidatorFunc(func(context.Context, string, TeamsAuthenticationContext) error {
+			return nil
+		}),
+		TokenProvider: teamsTokenProviderFunc(func(context.Context) (string, error) {
+			return "connector-token", nil
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := []byte(`{
+		"type":"message","id":"message-fail","text":"hello",
+		"from":{"id":"user-1"},"conversation":{"id":"conversation-1"},
+		"channelId":"msteams","serviceUrl":"https://smba.trafficmanager.net/teams/"
+	}`)
+	request := httptest.NewRequest(http.MethodPost, "/webhook/teams", bytes.NewReader(body))
+	request.Header.Set("Authorization", "Bearer valid-token")
+	recorder := httptest.NewRecorder()
+	channel.WebhookHandler(func(context.Context, InboundMessage) error {
+		return errors.New("private database failure")
+	}).ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusServiceUnavailable)
+	}
+	if strings.Contains(recorder.Body.String(), "database") {
+		t.Fatalf("response exposed persistence error: %q", recorder.Body.String())
 	}
 }
 

--- a/internal/chat/websocket.go
+++ b/internal/chat/websocket.go
@@ -5,7 +5,6 @@ package chat
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -26,19 +25,6 @@ type wsInboundMsg struct {
 	UserID     string `json:"user_id,omitempty"`
 	DeliveryID string `json:"delivery_id,omitempty"`
 	Text       string `json:"text,omitempty"`
-}
-
-func webSocketDeliveryID(channel, userID, externalID string, msg wsInboundMsg) string {
-	if deliveryID := strings.TrimSpace(msg.DeliveryID); deliveryID != "" {
-		return deliveryID
-	}
-	digest := sha256.Sum256([]byte(strings.Join([]string{
-		channel,
-		userID,
-		externalID,
-		msg.Text,
-	}, "\x00")))
-	return fmt.Sprintf("websocket:v1:%x", digest)
 }
 
 // wsOutboundMsg is the JSON envelope the server sends over the WebSocket.
@@ -367,7 +353,7 @@ func (ws *WSChannel) readLoop(ctx context.Context, conn *websocket.Conn, userID 
 				InternalUserID:  claims.Subject,
 				IdentityChannel: claims.Channel,
 				ExternalID:      externalID,
-				DeliveryID:      webSocketDeliveryID(channel, userID, externalID, msg),
+				DeliveryID:      strings.TrimSpace(msg.DeliveryID),
 				Text:            msg.Text,
 			})
 		}

--- a/internal/chat/websocket_test.go
+++ b/internal/chat/websocket_test.go
@@ -110,7 +110,7 @@ func TestWSChannel_ConnectAuthAndMessage(t *testing.T) {
 	}
 }
 
-func TestWSChannel_DerivesStableDeliveryIDAcrossReconnect(t *testing.T) {
+func TestWSChannelLeavesLegacyDeliveryIDEmptyAcrossReconnect(t *testing.T) {
 	ws := NewWSChannel()
 	received := make(chan InboundMessage, 2)
 	_ = ws.Start(context.Background(), func(msg InboundMessage) {
@@ -139,11 +139,8 @@ func TestWSChannel_DerivesStableDeliveryIDAcrossReconnect(t *testing.T) {
 
 	first := send()
 	replay := send()
-	if first.DeliveryID == "" {
-		t.Fatal("derived delivery ID is empty")
-	}
-	if replay.DeliveryID != first.DeliveryID {
-		t.Fatalf("delivery IDs = %q and %q, want stable replay identity", first.DeliveryID, replay.DeliveryID)
+	if first.DeliveryID != "" || replay.DeliveryID != "" {
+		t.Fatalf("legacy delivery IDs = %q and %q, want empty IDs for ingress assignment", first.DeliveryID, replay.DeliveryID)
 	}
 }
 
@@ -608,8 +605,8 @@ func TestWSChannel_EmbedSubprotocolAuth(t *testing.T) {
 	if received[0].IdentityChannel != "embed" || received[0].ExternalID != "guest-external-id" {
 		t.Errorf("authenticated identity = %q/%q", received[0].IdentityChannel, received[0].ExternalID)
 	}
-	if received[0].DeliveryID == "" {
-		t.Error("expected a server-derived delivery ID")
+	if received[0].DeliveryID != "" {
+		t.Errorf("delivery ID = %q, want empty legacy ID for ingress assignment", received[0].DeliveryID)
 	}
 	if received[0].Text != "hello from embed" {
 		t.Errorf("expected text 'hello from embed', got %q", received[0].Text)

--- a/internal/chat/whatsapp.go
+++ b/internal/chat/whatsapp.go
@@ -95,7 +95,7 @@ func (w *WhatsAppChannel) Stop() error {
 
 // WebhookHandler returns an http.Handler for the WhatsApp webhook endpoint.
 // GET requests handle verification; POST requests handle inbound messages.
-func (w *WhatsAppChannel) WebhookHandler(handler func(InboundMessage)) http.Handler {
+func (w *WhatsAppChannel) WebhookHandler(handler InboundWebhookHandler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:
@@ -124,7 +124,7 @@ func (w *WhatsAppChannel) handleVerification(rw http.ResponseWriter, r *http.Req
 }
 
 // handleInbound parses an inbound WhatsApp webhook payload and dispatches messages.
-func (w *WhatsAppChannel) handleInbound(rw http.ResponseWriter, r *http.Request, handler func(InboundMessage)) {
+func (w *WhatsAppChannel) handleInbound(rw http.ResponseWriter, r *http.Request, handler InboundWebhookHandler) {
 	body, err := io.ReadAll(http.MaxBytesReader(rw, r.Body, maxWhatsAppWebhookBodyBytes))
 	if err != nil {
 		slog.Error("whatsapp webhook: read body failed", "error", err)
@@ -147,9 +147,6 @@ func (w *WhatsAppChannel) handleInbound(rw http.ResponseWriter, r *http.Request,
 		http.Error(rw, "bad request", http.StatusBadRequest)
 		return
 	}
-
-	// Always respond 200 to avoid retries.
-	rw.WriteHeader(http.StatusOK)
 
 	for _, entry := range payload.Entry {
 		for _, change := range entry.Changes {
@@ -181,11 +178,15 @@ func (w *WhatsAppChannel) handleInbound(rw http.ResponseWriter, r *http.Request,
 					inbound.FirstName = contact.Profile.Name
 				}
 				if handler != nil {
-					handler(inbound)
+					if err := handler(r.Context(), inbound); err != nil {
+						http.Error(rw, "temporarily unavailable", http.StatusServiceUnavailable)
+						return
+					}
 				}
 			}
 		}
 	}
+	rw.WriteHeader(http.StatusOK)
 }
 
 func (w *WhatsAppChannel) validInboundSignature(header string, body []byte) bool {

--- a/internal/chat/whatsapp_test.go
+++ b/internal/chat/whatsapp_test.go
@@ -203,7 +203,7 @@ func TestWhatsAppWebhookVerification(t *testing.T) {
 		verifyToken: "my-verify-token",
 	}
 
-	handler := ch.WebhookHandler(func(InboundMessage) {})
+	handler := ch.WebhookHandler(func(context.Context, InboundMessage) error { return nil })
 
 	req := httptest.NewRequest(http.MethodGet,
 		"/webhook?hub.mode=subscribe&hub.verify_token=my-verify-token&hub.challenge=challenge-123",
@@ -224,7 +224,7 @@ func TestWhatsAppWebhookVerification_BadToken(t *testing.T) {
 		verifyToken: "my-verify-token",
 	}
 
-	handler := ch.WebhookHandler(func(InboundMessage) {})
+	handler := ch.WebhookHandler(func(context.Context, InboundMessage) error { return nil })
 
 	req := httptest.NewRequest(http.MethodGet,
 		"/webhook?hub.mode=subscribe&hub.verify_token=wrong-token&hub.challenge=challenge-123",
@@ -245,8 +245,9 @@ func TestWhatsAppWebhookInboundMessage(t *testing.T) {
 	}
 
 	var got InboundMessage
-	handler := ch.WebhookHandler(func(msg InboundMessage) {
+	handler := ch.WebhookHandler(func(_ context.Context, msg InboundMessage) error {
 		got = msg
+		return nil
 	})
 
 	payload := `{
@@ -299,7 +300,7 @@ func TestWhatsAppWebhookInboundMessage(t *testing.T) {
 
 func TestWhatsAppWebhookRejectsOversizedPayload(t *testing.T) {
 	ch := &WhatsAppChannel{phoneID: "phone-123"}
-	handler := ch.WebhookHandler(func(InboundMessage) {})
+	handler := ch.WebhookHandler(func(context.Context, InboundMessage) error { return nil })
 
 	req := httptest.NewRequest(http.MethodPost, "/webhook", strings.NewReader(strings.Repeat(" ", (1<<20)+1)))
 	w := httptest.NewRecorder()
@@ -313,7 +314,10 @@ func TestWhatsAppWebhookRejectsOversizedPayload(t *testing.T) {
 func TestWhatsAppWebhookRejectsUnsignedPayload(t *testing.T) {
 	ch := &WhatsAppChannel{phoneID: "phone-123", appSecret: whatsappTestAppSecret}
 	called := false
-	handler := ch.WebhookHandler(func(InboundMessage) { called = true })
+	handler := ch.WebhookHandler(func(context.Context, InboundMessage) error {
+		called = true
+		return nil
+	})
 
 	req := httptest.NewRequest(http.MethodPost, "/webhook", strings.NewReader(`{"entry":[]}`))
 	w := httptest.NewRecorder()
@@ -330,7 +334,10 @@ func TestWhatsAppWebhookRejectsUnsignedPayload(t *testing.T) {
 func TestWhatsAppWebhookRejectsInvalidSignature(t *testing.T) {
 	ch := &WhatsAppChannel{phoneID: "phone-123", appSecret: whatsappTestAppSecret}
 	called := false
-	handler := ch.WebhookHandler(func(InboundMessage) { called = true })
+	handler := ch.WebhookHandler(func(context.Context, InboundMessage) error {
+		called = true
+		return nil
+	})
 
 	req := httptest.NewRequest(http.MethodPost, "/webhook", strings.NewReader(`{"entry":[]}`))
 	req.Header.Set("X-Hub-Signature-256", "sha256="+strings.Repeat("0", sha256.Size*2))
@@ -379,6 +386,27 @@ func TestWhatsAppWebhookAllowsNilHandler(t *testing.T) {
 	}
 }
 
+func TestWhatsAppWebhookReturnsRetryableStatusWhenInboundPersistenceFails(t *testing.T) {
+	channel := &WhatsAppChannel{phoneID: "phone-123", appSecret: whatsappTestAppSecret}
+	payload := `{
+		"entry":[{"changes":[{"value":{
+			"metadata":{"phone_number_id":"phone-123"},
+			"messages":[{"from":"60123456789","id":"wamid.fail","type":"text","text":{"body":"hello"}}]
+		}}]}]
+	}`
+	request := newSignedWhatsAppRequest(payload)
+	recorder := httptest.NewRecorder()
+	channel.WebhookHandler(func(context.Context, InboundMessage) error {
+		return errors.New("private database failure")
+	}).ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusServiceUnavailable)
+	}
+	if strings.Contains(recorder.Body.String(), "database") {
+		t.Fatalf("response exposed persistence error: %q", recorder.Body.String())
+	}
+}
+
 func TestWhatsAppWebhookIgnoresStatusUpdates(t *testing.T) {
 	ch := &WhatsAppChannel{
 		verifyToken: "tok",
@@ -387,8 +415,9 @@ func TestWhatsAppWebhookIgnoresStatusUpdates(t *testing.T) {
 	}
 
 	called := false
-	handler := ch.WebhookHandler(func(msg InboundMessage) {
+	handler := ch.WebhookHandler(func(_ context.Context, msg InboundMessage) error {
 		called = true
+		return nil
 	})
 
 	// Status update (delivery receipt), not a message.

--- a/internal/server/chat_ingress.go
+++ b/internal/server/chat_ingress.go
@@ -5,74 +5,133 @@ package server
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/p-n-ai/pai-bot/internal/agent"
 	"github.com/p-n-ai/pai-bot/internal/chat"
 )
 
-const chatIngressDedupeTTL = 10 * time.Minute
+const (
+	chatIngressLeaseDuration   = 30 * time.Second
+	chatIngressPollInterval    = time.Second
+	chatIngressBaseBackoff     = time.Second
+	chatIngressMaxBackoff      = 5 * time.Minute
+	chatIngressRecordRetention = 24 * time.Hour
+	chatIngressCleanupInterval = 10 * time.Minute
+	chatIngressBatchSize       = 1000
+	chatIngressWorkerCount     = 16
+)
 
-// ChatIngress serializes inbound adapter deliveries and suppresses webhook
-// retries without conflating delivery IDs from different channels.
-type ChatIngress struct {
-	queue       chan chat.InboundMessage
-	slots       chan struct{}
-	process     func(context.Context, chat.InboundMessage)
-	workerCount int
-	maxSeen     int
+const chatIngressInterruptedResponse = "I hit a technical issue while processing that message. Please try again."
+
+type InboundTurnProcessor interface {
+	ProcessTurn(context.Context, chat.InboundMessage) (agent.TurnResult, error)
+	DeliverTurn(context.Context, chat.InboundMessage, agent.TurnResult) error
 }
 
-func NewChatIngress(
-	capacity int,
-	process func(context.Context, chat.InboundMessage),
+type chatIngressConfig struct {
+	LeaseDuration time.Duration
+	PollInterval  time.Duration
+	BaseBackoff   time.Duration
+	MaxBackoff    time.Duration
+	WorkerCount   int
+	Now           func() time.Time
+}
+
+func defaultChatIngressConfig() chatIngressConfig {
+	return chatIngressConfig{
+		LeaseDuration: chatIngressLeaseDuration,
+		PollInterval:  chatIngressPollInterval,
+		BaseBackoff:   chatIngressBaseBackoff,
+		MaxBackoff:    chatIngressMaxBackoff,
+		WorkerCount:   chatIngressWorkerCount,
+		Now:           time.Now,
+	}
+}
+
+type ChatIngress struct {
+	defaultTenantID string
+	store           inboundDeliveryStore
+	processor       InboundTurnProcessor
+	cfg             chatIngressConfig
+	wake            chan struct{}
+}
+
+func newChatIngressWithDefaults(
+	defaultTenantID string,
+	store inboundDeliveryStore,
+	processor InboundTurnProcessor,
 ) (*ChatIngress, error) {
-	if capacity <= 0 {
-		return nil, errors.New("chat ingress capacity must be positive")
-	}
-	if process == nil {
-		return nil, errors.New("chat ingress processor is required")
-	}
-	return &ChatIngress{
-		queue:       make(chan chat.InboundMessage, capacity),
-		slots:       make(chan struct{}, capacity),
-		process:     process,
-		workerCount: min(capacity, 16),
-		maxSeen:     max(capacity*16, 256),
-	}, nil
+	return newChatIngress(defaultTenantID, store, processor, defaultChatIngressConfig())
 }
 
 func newChatIngress(
-	capacity int,
-	process func(context.Context, chat.InboundMessage),
+	defaultTenantID string,
+	store inboundDeliveryStore,
+	processor InboundTurnProcessor,
+	cfg chatIngressConfig,
 ) (*ChatIngress, error) {
-	return NewChatIngress(capacity, process)
+	if strings.TrimSpace(defaultTenantID) == "" {
+		return nil, errors.New("chat ingress default tenant is required")
+	}
+	if store == nil {
+		return nil, errors.New("chat ingress store is required")
+	}
+	if processor == nil {
+		return nil, errors.New("chat ingress processor is required")
+	}
+	if cfg.LeaseDuration <= 0 || cfg.PollInterval <= 0 || cfg.BaseBackoff <= 0 || cfg.MaxBackoff <= 0 {
+		return nil, errors.New("chat ingress durations must be positive")
+	}
+	if cfg.MaxBackoff < cfg.BaseBackoff {
+		return nil, errors.New("chat ingress max backoff must not be shorter than base backoff")
+	}
+	if cfg.WorkerCount <= 0 {
+		return nil, errors.New("chat ingress worker count must be positive")
+	}
+	if cfg.Now == nil {
+		return nil, errors.New("chat ingress clock is required")
+	}
+	return &ChatIngress{
+		defaultTenantID: strings.TrimSpace(defaultTenantID),
+		store:           store,
+		processor:       processor,
+		cfg:             cfg,
+		wake:            make(chan struct{}, 1),
+	}, nil
 }
 
-func (i *ChatIngress) Enqueue(ctx context.Context, message chat.InboundMessage) error {
-	select {
-	case i.slots <- struct{}{}:
-	case <-ctx.Done():
-		return ctx.Err()
+func (i *ChatIngress) Accept(ctx context.Context, message chat.InboundMessage) error {
+	message, input, err := i.acceptInput(message)
+	if err != nil {
+		return err
 	}
-	select {
-	case i.queue <- message:
-		return nil
-	case <-ctx.Done():
-		<-i.slots
-		return ctx.Err()
+	input.Message = message
+	if _, _, err := i.store.Accept(ctx, input, i.now()); err != nil {
+		return fmt.Errorf("persist inbound chat message: %w", err)
 	}
+	i.notify()
+	return nil
 }
 
 func (i *ChatIngress) Run(ctx context.Context) {
-	seen := make(map[string]time.Time)
-	active := make(map[string]bool)
-	pending := make(map[string][]chat.InboundMessage)
-	jobs := make(chan chatIngressJob, cap(i.queue))
-	completed := make(chan string, i.workerCount)
+	recovery := time.NewTicker(i.cfg.PollInterval)
+	cleanup := time.NewTicker(chatIngressCleanupInterval)
+	defer recovery.Stop()
+	defer cleanup.Stop()
+
+	jobs := make(chan inboundDelivery)
+	completed := make(chan struct{}, i.cfg.WorkerCount)
 	var workers sync.WaitGroup
-	for range i.workerCount {
+	for range i.cfg.WorkerCount {
 		workers.Add(1)
 		go func() {
 			defer workers.Done()
@@ -84,113 +143,289 @@ func (i *ChatIngress) Run(ctx context.Context) {
 		workers.Wait()
 	}()
 
+	active := 0
+	i.recoverExpiredProcessing(ctx)
+	claimWork := true
 	for {
+		if claimWork && active < i.cfg.WorkerCount {
+			delivery, ok, err := i.claimDue(ctx)
+			if err != nil {
+				if ctx.Err() == nil {
+					slog.Error("claim inbound delivery failed", "error_category", "store")
+				}
+				claimWork = false
+			} else if ok {
+				select {
+				case jobs <- delivery:
+					active++
+					continue
+				case <-ctx.Done():
+					return
+				}
+			} else {
+				claimWork = false
+			}
+		}
+
 		select {
 		case <-ctx.Done():
 			return
-		case key := <-completed:
-			<-i.slots
-			queued := pending[key]
-			if len(queued) == 0 {
-				delete(active, key)
-				delete(pending, key)
-				continue
+		case <-i.wake:
+			claimWork = true
+		case <-recovery.C:
+			i.recoverExpiredProcessing(ctx)
+			claimWork = true
+		case <-cleanup.C:
+			if _, err := i.store.DeleteDeliveredBefore(
+				ctx, i.now().Add(-chatIngressRecordRetention), chatIngressBatchSize,
+			); err != nil && ctx.Err() == nil {
+				slog.Warn("clean delivered inbound records failed", "error_category", "store")
 			}
-			next := queued[0]
-			pending[key] = queued[1:]
-			if !sendChatIngressJob(ctx, jobs, chatIngressJob{key: key, message: next}) {
-				return
-			}
-		case message := <-i.queue:
-			if duplicateDelivery(seen, message, time.Now(), i.maxSeen) {
-				<-i.slots
-				continue
-			}
-			key := chatIngressRoute(message)
-			if active[key] {
-				pending[key] = append(pending[key], message)
-				continue
-			}
-			active[key] = true
-			if !sendChatIngressJob(ctx, jobs, chatIngressJob{key: key, message: message}) {
-				return
-			}
+		case <-completed:
+			active--
+			claimWork = true
 		}
-	}
-}
-
-type chatIngressJob struct {
-	key     string
-	message chat.InboundMessage
-}
-
-func sendChatIngressJob(ctx context.Context, jobs chan<- chatIngressJob, job chatIngressJob) bool {
-	select {
-	case jobs <- job:
-		return true
-	case <-ctx.Done():
-		return false
 	}
 }
 
 func (i *ChatIngress) runWorker(
 	ctx context.Context,
-	jobs <-chan chatIngressJob,
-	completed chan<- string,
+	jobs <-chan inboundDelivery,
+	completed chan<- struct{},
 ) {
-	for {
+	for delivery := range jobs {
+		switch delivery.Status {
+		case inboundDeliveryProcessing:
+			i.process(ctx, delivery)
+		case inboundDeliveryDelivering:
+			i.deliver(ctx, delivery)
+		}
 		select {
+		case completed <- struct{}{}:
 		case <-ctx.Done():
 			return
-		case job, ok := <-jobs:
-			if !ok {
-				return
-			}
-			i.process(ctx, job.message)
-			select {
-			case completed <- job.key:
-			case <-ctx.Done():
-				return
-			}
 		}
 	}
 }
 
-func chatIngressRoute(message chat.InboundMessage) string {
-	return message.TenantID + "\x00" + message.Channel + "\x00" + message.DestinationID()
+func (i *ChatIngress) process(ctx context.Context, delivery inboundDelivery) {
+	result, processErr, leaseErr := withInboundLease(
+		ctx, i, delivery, inboundDeliveryProcessing,
+		func(phaseCtx context.Context) (agent.TurnResult, error) {
+			return i.processor.ProcessTurn(phaseCtx, delivery.Message)
+		},
+	)
+	if leaseErr != nil {
+		if ctx.Err() == nil {
+			slog.Warn("inbound processing lease lost", "delivery_id", delivery.ID, "error_category", "store")
+		}
+		return
+	}
+	if processErr != nil {
+		slog.Error("process inbound turn failed", "delivery_id", delivery.ID, "error_category", "turn")
+		result = interruptedTurnResult()
+	}
+	if err := i.store.CompleteProcessing(ctx, delivery.ID, delivery.LeaseToken, result, i.now()); err != nil {
+		if ctx.Err() == nil {
+			slog.Error("persist inbound turn result failed", "delivery_id", delivery.ID, "error_category", "store")
+		}
+		return
+	}
+	i.notify()
 }
 
-func duplicateDelivery(
-	seen map[string]time.Time,
-	message chat.InboundMessage,
-	now time.Time,
-	maxSeen int,
-) bool {
+func (i *ChatIngress) deliver(ctx context.Context, delivery inboundDelivery) {
+	_, deliveryErr, leaseErr := withInboundLease(
+		ctx, i, delivery, inboundDeliveryDelivering,
+		func(phaseCtx context.Context) (struct{}, error) {
+			return struct{}{}, i.processor.DeliverTurn(phaseCtx, delivery.Message, delivery.Result)
+		},
+	)
+	if leaseErr != nil {
+		if ctx.Err() == nil {
+			slog.Warn("inbound delivery lease lost", "delivery_id", delivery.ID, "error_category", "store")
+		}
+		return
+	}
+	if deliveryErr != nil {
+		if ctx.Err() != nil {
+			return
+		}
+		nextAttempt := i.now().Add(i.backoff(delivery.DeliveryAttemptCount))
+		if err := i.store.ScheduleDeliveryRetry(
+			ctx, delivery.ID, delivery.LeaseToken, nextAttempt, i.now(),
+		); err != nil {
+			slog.Error("schedule inbound delivery retry failed", "delivery_id", delivery.ID, "error_category", "store")
+			return
+		}
+		slog.Warn("inbound turn delivery scheduled for retry",
+			"delivery_id", delivery.ID,
+			"attempt_count", delivery.DeliveryAttemptCount,
+			"error_category", "channel",
+		)
+		return
+	}
+	if err := i.store.MarkDelivered(ctx, delivery.ID, delivery.LeaseToken, i.now()); err != nil {
+		if ctx.Err() == nil {
+			slog.Error("acknowledge inbound turn delivery failed", "delivery_id", delivery.ID, "error_category", "store")
+		}
+	}
+}
+
+func withInboundLease[T any](
+	ctx context.Context,
+	ingress *ChatIngress,
+	delivery inboundDelivery,
+	status inboundDeliveryStatus,
+	work func(context.Context) (T, error),
+) (T, error, error) {
+	phaseCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	type outcome struct {
+		value T
+		err   error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		value, err := work(phaseCtx)
+		done <- outcome{value: value, err: err}
+	}()
+	ticker := time.NewTicker(ingress.cfg.LeaseDuration / 3)
+	defer ticker.Stop()
+	for {
+		select {
+		case result := <-done:
+			return result.value, result.err, nil
+		case <-ticker.C:
+			now := ingress.now()
+			if err := ingress.store.RenewLease(
+				ctx, delivery.ID, delivery.LeaseToken, status, now, now.Add(ingress.cfg.LeaseDuration),
+			); err != nil {
+				cancel()
+				result := <-done
+				return result.value, result.err, err
+			}
+		case <-ctx.Done():
+			cancel()
+			result := <-done
+			return result.value, result.err, ctx.Err()
+		}
+	}
+}
+
+func (i *ChatIngress) claimDue(ctx context.Context) (inboundDelivery, bool, error) {
+	now := i.now()
+	return i.store.ClaimDue(ctx, newInboundDeliveryToken(), now, now.Add(i.cfg.LeaseDuration))
+}
+
+func (i *ChatIngress) recoverExpiredProcessing(ctx context.Context) {
+	_, err := i.store.RecoverExpiredProcessing(
+		ctx,
+		agent.TurnResult{Text: chatIngressInterruptedResponse},
+		i.now(),
+		chatIngressBatchSize,
+	)
+	if err != nil {
+		if ctx.Err() == nil {
+			slog.Error("recover interrupted inbound processing failed", "error_category", "store")
+		}
+	}
+}
+
+func (i *ChatIngress) acceptInput(message chat.InboundMessage) (
+	chat.InboundMessage,
+	inboundDeliveryAcceptInput,
+	error,
+) {
+	message.Channel = strings.TrimSpace(message.Channel)
+	if message.Channel == "" {
+		return chat.InboundMessage{}, inboundDeliveryAcceptInput{}, errors.New("inbound chat channel is required")
+	}
+	message.TenantID = strings.TrimSpace(message.TenantID)
+	if message.TenantID == "" {
+		message.TenantID = i.defaultTenantID
+	}
+	message.DeliveryID = strings.TrimSpace(message.DeliveryID)
 	if message.DeliveryID == "" {
-		return false
-	}
-	key := message.TenantID + "\x00" + message.Channel + "\x00" + message.DeliveryID
-	if expiresAt, ok := seen[key]; ok && expiresAt.After(now) {
-		return true
-	}
-	if len(seen) >= maxSeen {
-		for delivery, expiresAt := range seen {
-			if !expiresAt.After(now) {
-				delete(seen, delivery)
-			}
-		}
-		if len(seen) >= maxSeen {
-			var oldestKey string
-			var oldestExpiry time.Time
-			for delivery, expiresAt := range seen {
-				if oldestKey == "" || expiresAt.Before(oldestExpiry) {
-					oldestKey = delivery
-					oldestExpiry = expiresAt
-				}
-			}
-			delete(seen, oldestKey)
+		switch message.Channel {
+		case "websocket", "embed":
+			message.DeliveryID = "generated:" + newInboundDeliveryToken()
+		default:
+			return chat.InboundMessage{}, inboundDeliveryAcceptInput{}, errors.New("inbound chat delivery ID is required")
 		}
 	}
-	seen[key] = now.Add(chatIngressDedupeTTL)
-	return false
+	learnerKey := inboundLearnerKey(message)
+	destination := strings.TrimSpace(message.DestinationID())
+	if learnerKey == "" || destination == "" {
+		return chat.InboundMessage{}, inboundDeliveryAcceptInput{}, errors.New("inbound chat learner and destination are required")
+	}
+	return message, inboundDeliveryAcceptInput{
+		TenantID: message.TenantID, Channel: message.Channel, DeliveryID: message.DeliveryID,
+		LearnerKey: learnerKey, DestinationKey: inboundCompositeKey(message.Channel, destination),
+	}, nil
+}
+
+func inboundLearnerKey(message chat.InboundMessage) string {
+	if internalID := strings.TrimSpace(message.InternalUserID); internalID != "" {
+		return inboundCompositeKey("internal", internalID)
+	}
+	channel := strings.TrimSpace(message.IdentityChannel)
+	if channel == "" {
+		channel = strings.TrimSpace(message.Channel)
+	}
+	externalID := strings.TrimSpace(message.ExternalID)
+	if externalID == "" {
+		externalID = strings.TrimSpace(message.UserID)
+	}
+	if channel == "" || externalID == "" {
+		return ""
+	}
+	return inboundCompositeKey("external", channel, externalID)
+}
+
+func inboundCompositeKey(parts ...string) string {
+	var key strings.Builder
+	for _, part := range parts {
+		key.WriteString(strconv.Itoa(len(part)))
+		key.WriteByte(':')
+		key.WriteString(part)
+	}
+	return key.String()
+}
+
+func interruptedTurnResult() agent.TurnResult {
+	return agent.TurnResult{Text: chatIngressInterruptedResponse}
+}
+
+func (i *ChatIngress) backoff(attempt int) time.Duration {
+	delay := i.cfg.BaseBackoff
+	for current := 1; current < attempt; current++ {
+		if delay >= i.cfg.MaxBackoff/2 {
+			return i.cfg.MaxBackoff
+		}
+		delay *= 2
+	}
+	if delay > i.cfg.MaxBackoff {
+		return i.cfg.MaxBackoff
+	}
+	return delay
+}
+
+func (i *ChatIngress) now() time.Time {
+	return i.cfg.Now().UTC()
+}
+
+func (i *ChatIngress) notify() {
+	select {
+	case i.wake <- struct{}{}:
+	default:
+	}
+}
+
+func newInboundDeliveryToken() string {
+	var raw [16]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		panic(fmt.Sprintf("generate inbound delivery token: %v", err))
+	}
+	return hex.EncodeToString(raw[:])
 }

--- a/internal/server/chat_ingress_delivery.go
+++ b/internal/server/chat_ingress_delivery.go
@@ -1,0 +1,182 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/p-n-ai/pai-bot/internal/agent"
+	"github.com/p-n-ai/pai-bot/internal/chat"
+	"github.com/p-n-ai/pai-bot/internal/focusedpage"
+)
+
+var (
+	ErrInboundDeliveryLeaseLost = errors.New("inbound delivery lease lost")
+	ErrInboundDeliveryConflict  = errors.New("inbound delivery identity conflict")
+)
+
+type inboundDeliveryStatus string
+
+const (
+	inboundDeliveryReceived        inboundDeliveryStatus = "received"
+	inboundDeliveryProcessing      inboundDeliveryStatus = "processing"
+	inboundDeliveryDeliveryPending inboundDeliveryStatus = "delivery_pending"
+	inboundDeliveryDelivering      inboundDeliveryStatus = "delivering"
+	inboundDeliveryDelivered       inboundDeliveryStatus = "delivered"
+)
+
+type inboundDelivery struct {
+	ID                     string
+	TenantID               string
+	Channel                string
+	DeliveryID             string
+	LearnerKey             string
+	DestinationKey         string
+	AcceptedSequence       int64
+	Message                chat.InboundMessage
+	Result                 agent.TurnResult
+	Status                 inboundDeliveryStatus
+	ProcessingAttemptCount int
+	DeliveryAttemptCount   int
+	NextAttemptAt          time.Time
+	LeaseToken             string
+	LeaseExpiresAt         *time.Time
+	DeliveredAt            *time.Time
+	CreatedAt              time.Time
+	UpdatedAt              time.Time
+}
+
+type inboundDeliveryAcceptInput struct {
+	TenantID       string
+	Channel        string
+	DeliveryID     string
+	LearnerKey     string
+	DestinationKey string
+	Message        chat.InboundMessage
+}
+
+type inboundDeliveryStore interface {
+	Accept(context.Context, inboundDeliveryAcceptInput, time.Time) (inboundDelivery, bool, error)
+	ClaimDue(context.Context, string, time.Time, time.Time) (inboundDelivery, bool, error)
+	RenewLease(context.Context, string, string, inboundDeliveryStatus, time.Time, time.Time) error
+	CompleteProcessing(context.Context, string, string, agent.TurnResult, time.Time) error
+	ScheduleDeliveryRetry(context.Context, string, string, time.Time, time.Time) error
+	MarkDelivered(context.Context, string, string, time.Time) error
+	RecoverExpiredProcessing(context.Context, agent.TurnResult, time.Time, int) (int64, error)
+	DeleteDeliveredBefore(context.Context, time.Time, int) (int64, error)
+}
+
+type inboundMessagePayload struct {
+	Version           int    `json:"version"`
+	Channel           string `json:"channel"`
+	UserID            string `json:"user_id"`
+	TenantID          string `json:"tenant_id"`
+	InternalUserID    string `json:"internal_user_id,omitempty"`
+	IdentityChannel   string `json:"identity_channel,omitempty"`
+	ExternalID        string `json:"external_id,omitempty"`
+	ThreadID          string `json:"thread_id,omitempty"`
+	MessageID         string `json:"message_id,omitempty"`
+	DeliveryID        string `json:"delivery_id"`
+	Text              string `json:"text,omitempty"`
+	Caption           string `json:"caption,omitempty"`
+	HasImage          bool   `json:"has_image,omitempty"`
+	ImageFileID       string `json:"image_file_id,omitempty"`
+	ImageDataURL      string `json:"image_data_url,omitempty"`
+	ReplyToText       string `json:"reply_to_text,omitempty"`
+	Username          string `json:"username,omitempty"`
+	FirstName         string `json:"first_name,omitempty"`
+	LastName          string `json:"last_name,omitempty"`
+	Language          string `json:"language,omitempty"`
+	CallbackQueryID   string `json:"callback_query_id,omitempty"`
+	CallbackMessageID int    `json:"callback_message_id,omitempty"`
+}
+
+type inboundTurnResultPayload struct {
+	Version     int                         `json:"version"`
+	Text        string                      `json:"text"`
+	FocusedPage *inboundFocusedPageArtifact `json:"focused_page,omitempty"`
+}
+
+type inboundFocusedPageArtifact struct {
+	PublicID  string    `json:"public_id"`
+	URL       string    `json:"url"`
+	ExpiresAt time.Time `json:"expires_at"`
+	TenantID  string    `json:"tenant_id"`
+	TurnID    string    `json:"turn_id"`
+}
+
+func newInboundMessagePayload(message chat.InboundMessage) inboundMessagePayload {
+	return inboundMessagePayload{
+		Version: 1, Channel: message.Channel, UserID: message.UserID, TenantID: message.TenantID,
+		InternalUserID: message.InternalUserID, IdentityChannel: message.IdentityChannel,
+		ExternalID: message.ExternalID, ThreadID: message.ThreadID, MessageID: message.MessageID,
+		DeliveryID: message.DeliveryID, Text: message.Text, Caption: message.Caption,
+		HasImage: message.HasImage, ImageFileID: message.ImageFileID, ImageDataURL: message.ImageDataURL,
+		ReplyToText: message.ReplyToText, Username: message.Username, FirstName: message.FirstName,
+		LastName: message.LastName, Language: message.Language, CallbackQueryID: message.CallbackQueryID,
+		CallbackMessageID: message.CallbackMessageID,
+	}
+}
+
+func (p inboundMessagePayload) message() (chat.InboundMessage, error) {
+	if p.Version != 1 {
+		return chat.InboundMessage{}, fmt.Errorf("unsupported inbound message payload version %d", p.Version)
+	}
+	return chat.InboundMessage{
+		Channel: p.Channel, UserID: p.UserID, TenantID: p.TenantID, InternalUserID: p.InternalUserID,
+		IdentityChannel: p.IdentityChannel, ExternalID: p.ExternalID, ThreadID: p.ThreadID,
+		MessageID: p.MessageID, DeliveryID: p.DeliveryID, Text: p.Text, Caption: p.Caption,
+		HasImage: p.HasImage, ImageFileID: p.ImageFileID, ImageDataURL: p.ImageDataURL,
+		ReplyToText: p.ReplyToText, Username: p.Username, FirstName: p.FirstName, LastName: p.LastName,
+		Language: p.Language, CallbackQueryID: p.CallbackQueryID, CallbackMessageID: p.CallbackMessageID,
+	}, nil
+}
+
+func newInboundTurnResultPayload(result agent.TurnResult) inboundTurnResultPayload {
+	payload := inboundTurnResultPayload{Version: 1, Text: result.Text}
+	if result.FocusedPage != nil {
+		payload.FocusedPage = &inboundFocusedPageArtifact{
+			PublicID: result.FocusedPage.PublicID, URL: result.FocusedPage.URL,
+			ExpiresAt: result.FocusedPage.ExpiresAt, TenantID: result.FocusedPage.TenantID,
+			TurnID: result.FocusedPage.TurnID,
+		}
+	}
+	return payload
+}
+
+func (p inboundTurnResultPayload) result() (agent.TurnResult, error) {
+	if p.Version != 1 {
+		return agent.TurnResult{}, fmt.Errorf("unsupported inbound turn result payload version %d", p.Version)
+	}
+	result := agent.TurnResult{Text: p.Text}
+	if p.FocusedPage != nil {
+		result.FocusedPage = &focusedpage.Artifact{
+			PublicID: p.FocusedPage.PublicID, URL: p.FocusedPage.URL,
+			ExpiresAt: p.FocusedPage.ExpiresAt, TenantID: p.FocusedPage.TenantID,
+			TurnID: p.FocusedPage.TurnID,
+		}
+	}
+	return result, nil
+}
+
+func validateInboundDeliveryAcceptInput(input inboundDeliveryAcceptInput) error {
+	for name, value := range map[string]string{
+		"tenant": input.TenantID, "channel": input.Channel, "delivery ID": input.DeliveryID,
+		"learner key": input.LearnerKey, "destination key": input.DestinationKey,
+	} {
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("inbound delivery %s is required", name)
+		}
+	}
+	if input.Message.TenantID != input.TenantID ||
+		input.Message.Channel != input.Channel ||
+		input.Message.DeliveryID != input.DeliveryID {
+		return errors.New("inbound delivery identity does not match its message")
+	}
+	return nil
+}

--- a/internal/server/chat_ingress_delivery_postgres.go
+++ b/internal/server/chat_ingress_delivery_postgres.go
@@ -1,0 +1,379 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/p-n-ai/pai-bot/internal/agent"
+)
+
+type postgresInboundDeliveryStore struct {
+	pool *pgxpool.Pool
+}
+
+func NewPostgresChatIngress(
+	defaultTenantID string,
+	pool *pgxpool.Pool,
+	processor InboundTurnProcessor,
+) (*ChatIngress, error) {
+	return newChatIngressWithDefaults(
+		defaultTenantID,
+		newPostgresInboundDeliveryStore(pool),
+		processor,
+	)
+}
+
+func newPostgresInboundDeliveryStore(pool *pgxpool.Pool) *postgresInboundDeliveryStore {
+	return &postgresInboundDeliveryStore{pool: pool}
+}
+
+func (s *postgresInboundDeliveryStore) Accept(
+	ctx context.Context,
+	input inboundDeliveryAcceptInput,
+	now time.Time,
+) (inboundDelivery, bool, error) {
+	if s.pool == nil {
+		return inboundDelivery{}, false, errors.New("inbound delivery pool is nil")
+	}
+	if err := validateInboundDeliveryAcceptInput(input); err != nil {
+		return inboundDelivery{}, false, err
+	}
+	payload, err := json.Marshal(newInboundMessagePayload(input.Message))
+	if err != nil {
+		return inboundDelivery{}, false, fmt.Errorf("encode inbound delivery: %w", err)
+	}
+	payloadHash := sha256.Sum256(payload)
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return inboundDelivery{}, false, fmt.Errorf("begin inbound delivery acceptance: %w", err)
+	}
+	defer func() { _ = tx.Rollback(context.Background()) }()
+
+	lockKeys := []string{
+		input.TenantID + ":learner:" + input.LearnerKey,
+		input.TenantID + ":destination:" + input.DestinationKey,
+	}
+	sort.Strings(lockKeys)
+	for _, lockKey := range lockKeys {
+		if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`, lockKey); err != nil {
+			return inboundDelivery{}, false, fmt.Errorf("lock inbound delivery ordering: %w", err)
+		}
+	}
+
+	delivery, err := scanInboundDelivery(tx.QueryRow(ctx, `
+		INSERT INTO chat_inbound_deliveries (
+			tenant_id, channel, delivery_id, learner_key, destination_key,
+			inbound_payload, inbound_payload_hash, next_attempt_at, created_at, updated_at
+		) VALUES ($1::uuid, $2, $3, $4, $5, $6::jsonb, $7, $8, $8, $8)
+		ON CONFLICT (tenant_id, channel, delivery_id) DO NOTHING
+		RETURNING `+inboundDeliveryColumns,
+		input.TenantID, input.Channel, input.DeliveryID, input.LearnerKey,
+		input.DestinationKey, payload, payloadHash[:], now))
+	inserted := true
+	if errors.Is(err, pgx.ErrNoRows) {
+		inserted = false
+		delivery, err = scanInboundDelivery(tx.QueryRow(ctx, `
+			SELECT `+inboundDeliveryColumns+`
+			FROM chat_inbound_deliveries
+			WHERE tenant_id = $1::uuid AND channel = $2 AND delivery_id = $3`,
+			input.TenantID, input.Channel, input.DeliveryID))
+	}
+	if err != nil {
+		return inboundDelivery{}, false, fmt.Errorf("accept inbound delivery: %w", err)
+	}
+	var storedHash []byte
+	if err := tx.QueryRow(ctx, `
+		SELECT inbound_payload_hash
+		FROM chat_inbound_deliveries
+		WHERE id = $1::uuid`, delivery.ID).Scan(&storedHash); err != nil {
+		return inboundDelivery{}, false, fmt.Errorf("read inbound delivery identity: %w", err)
+	}
+	if !bytes.Equal(storedHash, payloadHash[:]) {
+		return inboundDelivery{}, false, ErrInboundDeliveryConflict
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return inboundDelivery{}, false, fmt.Errorf("commit inbound delivery acceptance: %w", err)
+	}
+	return delivery, inserted, nil
+}
+
+func (s *postgresInboundDeliveryStore) ClaimDue(
+	ctx context.Context,
+	token string,
+	now time.Time,
+	leaseExpiresAt time.Time,
+) (inboundDelivery, bool, error) {
+	if s.pool == nil {
+		return inboundDelivery{}, false, errors.New("inbound delivery pool is nil")
+	}
+	if err := validateLeaseInput(token, now, leaseExpiresAt); err != nil {
+		return inboundDelivery{}, false, err
+	}
+	delivery, err := scanInboundDelivery(s.pool.QueryRow(ctx, `
+		WITH candidate AS (
+			SELECT delivery.id, delivery.status
+			FROM chat_inbound_deliveries AS delivery
+			WHERE (
+				(delivery.status = 'received' AND delivery.next_attempt_at <= $2
+				 AND NOT EXISTS (
+					SELECT 1 FROM chat_inbound_deliveries AS earlier
+					WHERE earlier.tenant_id = delivery.tenant_id
+					  AND earlier.learner_key = delivery.learner_key
+					  AND earlier.accepted_sequence < delivery.accepted_sequence
+					  AND earlier.status <> 'delivered'
+				 ))
+				OR (delivery.status = 'delivery_pending' AND delivery.next_attempt_at <= $2
+				 AND NOT EXISTS (
+					SELECT 1 FROM chat_inbound_deliveries AS earlier
+					WHERE earlier.tenant_id = delivery.tenant_id
+					  AND earlier.destination_key = delivery.destination_key
+					  AND earlier.accepted_sequence < delivery.accepted_sequence
+					  AND earlier.status <> 'delivered'
+				 ))
+				OR (delivery.status = 'delivering' AND delivery.lease_expires_at <= $2)
+			)
+			ORDER BY delivery.next_attempt_at, delivery.accepted_sequence
+			FOR UPDATE SKIP LOCKED
+			LIMIT 1
+		)
+		UPDATE chat_inbound_deliveries AS delivery
+		SET status = CASE candidate.status
+				WHEN 'received' THEN 'processing'
+				ELSE 'delivering'
+			END,
+			processing_attempt_count = delivery.processing_attempt_count
+				+ CASE WHEN candidate.status = 'received' THEN 1 ELSE 0 END,
+			delivery_attempt_count = delivery.delivery_attempt_count
+				+ CASE WHEN candidate.status <> 'received' THEN 1 ELSE 0 END,
+			lease_token = $1, lease_expires_at = $3, updated_at = $2
+		FROM candidate
+		WHERE delivery.id = candidate.id
+		RETURNING `+prefixedInboundDeliveryColumns("delivery"), token, now, leaseExpiresAt))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return inboundDelivery{}, false, nil
+	}
+	if err != nil {
+		return inboundDelivery{}, false, fmt.Errorf("claim due inbound delivery: %w", err)
+	}
+	return delivery, true, nil
+}
+
+func (s *postgresInboundDeliveryStore) RenewLease(
+	ctx context.Context,
+	id string,
+	token string,
+	status inboundDeliveryStatus,
+	now time.Time,
+	leaseExpiresAt time.Time,
+) error {
+	if s.pool == nil {
+		return errors.New("inbound delivery pool is nil")
+	}
+	if status != inboundDeliveryProcessing && status != inboundDeliveryDelivering {
+		return errors.New("inbound delivery renewal status must be leased")
+	}
+	if err := validateLeaseInput(token, now, leaseExpiresAt); err != nil {
+		return err
+	}
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE chat_inbound_deliveries
+		SET lease_expires_at = $5, updated_at = $4
+		WHERE id = $1::uuid AND lease_token = $2 AND status = $3
+		  AND lease_expires_at > $4`, id, token, status, now, leaseExpiresAt)
+	return fencedInboundDeliveryTransition("renew inbound delivery lease", tag, err)
+}
+
+func (s *postgresInboundDeliveryStore) CompleteProcessing(
+	ctx context.Context,
+	id string,
+	token string,
+	result agent.TurnResult,
+	now time.Time,
+) error {
+	payload, err := json.Marshal(newInboundTurnResultPayload(result))
+	if err != nil {
+		return fmt.Errorf("encode inbound turn result: %w", err)
+	}
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE chat_inbound_deliveries
+		SET status = 'delivery_pending', result_payload = $4::jsonb,
+		    next_attempt_at = $3, lease_token = NULL, lease_expires_at = NULL, updated_at = $3
+		WHERE id = $1::uuid AND lease_token = $2 AND status = 'processing'
+		  AND lease_expires_at > $3`, id, token, now, payload)
+	return fencedInboundDeliveryTransition("complete inbound delivery processing", tag, err)
+}
+
+func (s *postgresInboundDeliveryStore) ScheduleDeliveryRetry(
+	ctx context.Context,
+	id string,
+	token string,
+	nextAttempt time.Time,
+	now time.Time,
+) error {
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE chat_inbound_deliveries
+		SET status = 'delivery_pending', next_attempt_at = $4,
+		    lease_token = NULL, lease_expires_at = NULL, updated_at = $3
+		WHERE id = $1::uuid AND lease_token = $2 AND status = 'delivering'
+		  AND lease_expires_at > $3`, id, token, now, nextAttempt)
+	return fencedInboundDeliveryTransition("schedule inbound delivery retry", tag, err)
+}
+
+func (s *postgresInboundDeliveryStore) MarkDelivered(
+	ctx context.Context,
+	id string,
+	token string,
+	now time.Time,
+) error {
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE chat_inbound_deliveries
+		SET status = 'delivered', delivered_at = $3,
+		    lease_token = NULL, lease_expires_at = NULL, updated_at = $3
+		WHERE id = $1::uuid AND lease_token = $2 AND status = 'delivering'
+		  AND lease_expires_at > $3`, id, token, now)
+	return fencedInboundDeliveryTransition("mark inbound delivery delivered", tag, err)
+}
+
+func (s *postgresInboundDeliveryStore) RecoverExpiredProcessing(
+	ctx context.Context,
+	result agent.TurnResult,
+	now time.Time,
+	limit int,
+) (int64, error) {
+	if limit <= 0 {
+		return 0, errors.New("inbound delivery recovery limit must be positive")
+	}
+	payload, err := json.Marshal(newInboundTurnResultPayload(result))
+	if err != nil {
+		return 0, fmt.Errorf("encode recovered inbound result: %w", err)
+	}
+	tag, err := s.pool.Exec(ctx, `
+		WITH expired AS (
+			SELECT id FROM chat_inbound_deliveries
+			WHERE status = 'processing' AND lease_expires_at <= $1
+			ORDER BY accepted_sequence
+			FOR UPDATE SKIP LOCKED
+			LIMIT $3
+		)
+		UPDATE chat_inbound_deliveries AS delivery
+		SET status = 'delivery_pending', result_payload = $2::jsonb,
+		    next_attempt_at = $1, lease_token = NULL, lease_expires_at = NULL, updated_at = $1
+		FROM expired
+		WHERE delivery.id = expired.id`, now, payload, limit)
+	if err != nil {
+		return 0, fmt.Errorf("recover expired inbound processing: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
+func (s *postgresInboundDeliveryStore) DeleteDeliveredBefore(
+	ctx context.Context,
+	before time.Time,
+	limit int,
+) (int64, error) {
+	if limit <= 0 {
+		return 0, errors.New("inbound delivery cleanup limit must be positive")
+	}
+	tag, err := s.pool.Exec(ctx, `
+		WITH expired AS (
+			SELECT id FROM chat_inbound_deliveries
+			WHERE status = 'delivered' AND delivered_at <= $1
+			ORDER BY delivered_at, accepted_sequence
+			FOR UPDATE SKIP LOCKED
+			LIMIT $2
+		)
+		DELETE FROM chat_inbound_deliveries AS delivery
+		USING expired
+		WHERE delivery.id = expired.id`, before, limit)
+	if err != nil {
+		return 0, fmt.Errorf("delete delivered inbound records: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
+const inboundDeliveryColumns = `
+	id::text, tenant_id::text, channel, delivery_id, learner_key, destination_key,
+	accepted_sequence, inbound_payload, result_payload, status,
+	processing_attempt_count, delivery_attempt_count, next_attempt_at,
+	COALESCE(lease_token, ''), lease_expires_at, delivered_at, created_at, updated_at`
+
+func prefixedInboundDeliveryColumns(alias string) string {
+	return `
+	` + alias + `.id::text, ` + alias + `.tenant_id::text, ` + alias + `.channel,
+	` + alias + `.delivery_id, ` + alias + `.learner_key, ` + alias + `.destination_key,
+	` + alias + `.accepted_sequence, ` + alias + `.inbound_payload, ` + alias + `.result_payload,
+	` + alias + `.status, ` + alias + `.processing_attempt_count, ` + alias + `.delivery_attempt_count,
+	` + alias + `.next_attempt_at, COALESCE(` + alias + `.lease_token, ''),
+	` + alias + `.lease_expires_at, ` + alias + `.delivered_at, ` + alias + `.created_at, ` + alias + `.updated_at`
+}
+
+type inboundDeliveryRow interface {
+	Scan(...any) error
+}
+
+func scanInboundDelivery(row inboundDeliveryRow) (inboundDelivery, error) {
+	var delivery inboundDelivery
+	var inboundJSON, resultJSON []byte
+	err := row.Scan(
+		&delivery.ID, &delivery.TenantID, &delivery.Channel, &delivery.DeliveryID,
+		&delivery.LearnerKey, &delivery.DestinationKey, &delivery.AcceptedSequence,
+		&inboundJSON, &resultJSON, &delivery.Status, &delivery.ProcessingAttemptCount,
+		&delivery.DeliveryAttemptCount, &delivery.NextAttemptAt, &delivery.LeaseToken,
+		&delivery.LeaseExpiresAt, &delivery.DeliveredAt, &delivery.CreatedAt, &delivery.UpdatedAt,
+	)
+	if err != nil {
+		return inboundDelivery{}, err
+	}
+	var inboundPayload inboundMessagePayload
+	if err := json.Unmarshal(inboundJSON, &inboundPayload); err != nil {
+		return inboundDelivery{}, fmt.Errorf("decode inbound message payload: %w", err)
+	}
+	delivery.Message, err = inboundPayload.message()
+	if err != nil {
+		return inboundDelivery{}, err
+	}
+	if len(resultJSON) > 0 {
+		var resultPayload inboundTurnResultPayload
+		if err := json.Unmarshal(resultJSON, &resultPayload); err != nil {
+			return inboundDelivery{}, fmt.Errorf("decode inbound result payload: %w", err)
+		}
+		delivery.Result, err = resultPayload.result()
+		if err != nil {
+			return inboundDelivery{}, err
+		}
+	}
+	return delivery, nil
+}
+
+func validateLeaseInput(token string, now, leaseExpiresAt time.Time) error {
+	if token == "" {
+		return errors.New("inbound delivery lease token is required")
+	}
+	if !leaseExpiresAt.After(now) {
+		return errors.New("inbound delivery lease expiry must be after current time")
+	}
+	return nil
+}
+
+func fencedInboundDeliveryTransition(operation string, tag pgconn.CommandTag, err error) error {
+	if err != nil {
+		return fmt.Errorf("%s: %w", operation, err)
+	}
+	if tag.RowsAffected() != 1 {
+		return ErrInboundDeliveryLeaseLost
+	}
+	return nil
+}

--- a/internal/server/chat_ingress_delivery_postgres_integration_test.go
+++ b/internal/server/chat_ingress_delivery_postgres_integration_test.go
@@ -1,0 +1,249 @@
+//go:build integration
+
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+
+	"github.com/p-n-ai/pai-bot/internal/agent"
+	"github.com/p-n-ai/pai-bot/internal/chat"
+	"github.com/p-n-ai/pai-bot/internal/focusedpage"
+)
+
+func TestPostgresInboundDeliveryStorePersistsLifecycleAcrossRestart(t *testing.T) {
+	ctx := context.Background()
+	pool := startInboundDeliveryPostgres(t, ctx)
+	tenantID := seedInboundDeliveryTenant(t, ctx, pool, "inbound-lifecycle")
+	store := newPostgresInboundDeliveryStore(pool)
+	now := time.Date(2026, 8, 13, 8, 0, 0, 0, time.UTC)
+	input := postgresInboundDeliveryInput(tenantID, "delivery-1", "hello")
+
+	var insertedCount atomic.Int32
+	var workers sync.WaitGroup
+	for range 16 {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			_, inserted, err := store.Accept(ctx, input, now)
+			if err != nil {
+				t.Errorf("Accept() error = %v", err)
+				return
+			}
+			if inserted {
+				insertedCount.Add(1)
+			}
+		}()
+	}
+	workers.Wait()
+	if insertedCount.Load() != 1 {
+		t.Fatalf("inserted duplicates = %d, want one", insertedCount.Load())
+	}
+	changed := input
+	changed.Message.Text = "changed duplicate"
+	if _, _, err := store.Accept(ctx, changed, now); !errors.Is(err, ErrInboundDeliveryConflict) {
+		t.Fatalf("Accept(changed duplicate) error = %v, want conflict", err)
+	}
+
+	restarted := newPostgresInboundDeliveryStore(pool)
+	processing, ok, err := restarted.ClaimDue(ctx, "processor", now, now.Add(time.Minute))
+	if err != nil || !ok {
+		t.Fatalf("ClaimDue(processing) = %#v, %t, %v", processing, ok, err)
+	}
+	if processing.Status != inboundDeliveryProcessing || processing.Message != input.Message {
+		t.Fatalf("recovered processing payload = %#v, want %#v", processing, input.Message)
+	}
+	if err := restarted.RenewLease(
+		ctx, processing.ID, "stale", inboundDeliveryProcessing, now, now.Add(2*time.Minute),
+	); !errors.Is(err, ErrInboundDeliveryLeaseLost) {
+		t.Fatalf("RenewLease(stale) error = %v, want lease lost", err)
+	}
+	if err := restarted.RenewLease(
+		ctx, processing.ID, "processor", inboundDeliveryProcessing, now, now.Add(2*time.Minute),
+	); err != nil {
+		t.Fatalf("RenewLease(current) error = %v", err)
+	}
+
+	result := agent.TurnResult{
+		Text: "durable reply",
+		FocusedPage: &focusedpage.Artifact{
+			PublicID: "page-1", URL: "https://example.com/a/page-1",
+			ExpiresAt: now.Add(time.Hour), TenantID: tenantID, TurnID: "turn-1",
+		},
+	}
+	completeAt := now.Add(30 * time.Second)
+	if err := restarted.CompleteProcessing(ctx, processing.ID, "processor", result, completeAt); err != nil {
+		t.Fatalf("CompleteProcessing() error = %v", err)
+	}
+	delivering, ok, err := newPostgresInboundDeliveryStore(pool).ClaimDue(
+		ctx, "deliverer-1", completeAt, completeAt.Add(time.Minute),
+	)
+	if err != nil || !ok {
+		t.Fatalf("ClaimDue(delivery) = %#v, %t, %v", delivering, ok, err)
+	}
+	if delivering.Status != inboundDeliveryDelivering || delivering.Result.Text != result.Text ||
+		delivering.Result.FocusedPage == nil || *delivering.Result.FocusedPage != *result.FocusedPage {
+		t.Fatalf("durable result = %#v, want %#v", delivering.Result, result)
+	}
+
+	retryAt := completeAt.Add(2 * time.Minute)
+	if err := restarted.ScheduleDeliveryRetry(ctx, delivering.ID, "deliverer-1", retryAt, completeAt); err != nil {
+		t.Fatalf("ScheduleDeliveryRetry() error = %v", err)
+	}
+	if _, ok, err := restarted.ClaimDue(ctx, "early", retryAt.Add(-time.Second), retryAt.Add(time.Minute)); err != nil || ok {
+		t.Fatalf("ClaimDue(before retry) = %t, %v; want false, nil", ok, err)
+	}
+	retried, ok, err := restarted.ClaimDue(ctx, "deliverer-2", retryAt, retryAt.Add(time.Minute))
+	if err != nil || !ok || retried.Result.Text != result.Text || retried.ProcessingAttemptCount != 1 {
+		t.Fatalf("ClaimDue(retry) = %#v, %t, %v", retried, ok, err)
+	}
+	if err := restarted.MarkDelivered(ctx, retried.ID, "deliverer-2", retryAt); err != nil {
+		t.Fatalf("MarkDelivered() error = %v", err)
+	}
+	duplicate, inserted, err := restarted.Accept(ctx, input, retryAt.Add(time.Hour))
+	if err != nil || inserted || duplicate.Status != inboundDeliveryDelivered {
+		t.Fatalf("Accept(delivered duplicate) = %#v, %t, %v", duplicate, inserted, err)
+	}
+	deleted, err := restarted.DeleteDeliveredBefore(ctx, retryAt, 10)
+	if err != nil || deleted != 1 {
+		t.Fatalf("DeleteDeliveredBefore() = %d, %v; want one", deleted, err)
+	}
+}
+
+func TestPostgresInboundDeliveryStoreRecoversCrashWithoutReprocessing(t *testing.T) {
+	ctx := context.Background()
+	pool := startInboundDeliveryPostgres(t, ctx)
+	tenantID := seedInboundDeliveryTenant(t, ctx, pool, "inbound-recovery")
+	store := newPostgresInboundDeliveryStore(pool)
+	now := time.Date(2026, 8, 13, 9, 0, 0, 0, time.UTC)
+	firstInput := postgresInboundDeliveryInput(tenantID, "delivery-1", "first")
+	secondInput := postgresInboundDeliveryInput(tenantID, "delivery-2", "second")
+	secondInput.Message.ThreadID = "thread-2"
+	secondInput.DestinationKey = inboundCompositeKey("slack", "thread-2")
+	if _, _, err := store.Accept(ctx, firstInput, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.Accept(ctx, secondInput, now.Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	first, ok, err := store.ClaimDue(ctx, "crashed", now, now.Add(time.Minute))
+	if err != nil || !ok || first.DeliveryID != firstInput.DeliveryID {
+		t.Fatalf("ClaimDue(first) = %#v, %t, %v", first, ok, err)
+	}
+	if _, ok, err := store.ClaimDue(ctx, "blocked", now.Add(30*time.Second), now.Add(2*time.Minute)); err != nil || ok {
+		t.Fatalf("ClaimDue(blocked learner) = %t, %v; want false, nil", ok, err)
+	}
+	recoveryAt := now.Add(time.Minute)
+	recovered, err := newPostgresInboundDeliveryStore(pool).RecoverExpiredProcessing(
+		ctx, agent.TurnResult{Text: chatIngressInterruptedResponse}, recoveryAt, 10,
+	)
+	if err != nil || recovered != 1 {
+		t.Fatalf("RecoverExpiredProcessing() = %d, %v", recovered, err)
+	}
+	recovery, ok, err := store.ClaimDue(ctx, "recovery-delivery", recoveryAt, recoveryAt.Add(time.Minute))
+	if err != nil || !ok || recovery.DeliveryID != firstInput.DeliveryID ||
+		recovery.Status != inboundDeliveryDelivering || recovery.Result.Text != chatIngressInterruptedResponse {
+		t.Fatalf("ClaimDue(recovery result) = %#v, %t, %v", recovery, ok, err)
+	}
+	if err := store.MarkDelivered(ctx, recovery.ID, "recovery-delivery", recoveryAt); err != nil {
+		t.Fatal(err)
+	}
+	second, ok, err := store.ClaimDue(ctx, "second-processor", recoveryAt, recoveryAt.Add(time.Minute))
+	if err != nil || !ok || second.DeliveryID != secondInput.DeliveryID ||
+		second.Status != inboundDeliveryProcessing {
+		t.Fatalf("ClaimDue(second) = %#v, %t, %v", second, ok, err)
+	}
+}
+
+func postgresInboundDeliveryInput(tenantID, deliveryID, text string) inboundDeliveryAcceptInput {
+	message := chat.InboundMessage{
+		Channel: "slack", UserID: "learner-1", TenantID: tenantID,
+		InternalUserID: "internal-1", IdentityChannel: "slack", ExternalID: "learner-1",
+		ThreadID: "thread-1", MessageID: "message-" + deliveryID, DeliveryID: deliveryID,
+		Text: text, Caption: "caption", HasImage: true, ImageFileID: "image-1",
+		ImageDataURL: "data:image/png;base64,AA==", ReplyToText: "previous",
+		Username: "learner", FirstName: "First", LastName: "Last", Language: "en",
+		CallbackQueryID: "callback-1", CallbackMessageID: 42,
+	}
+	return inboundDeliveryAcceptInput{
+		TenantID: tenantID, Channel: message.Channel, DeliveryID: deliveryID,
+		LearnerKey:     inboundLearnerKey(message),
+		DestinationKey: inboundCompositeKey(message.Channel, message.DestinationID()),
+		Message:        message,
+	}
+}
+
+func startInboundDeliveryPostgres(t *testing.T, ctx context.Context) *pgxpool.Pool {
+	t.Helper()
+	container, err := tcpostgres.Run(ctx, "postgres:17-alpine",
+		tcpostgres.WithDatabase("pai"),
+		tcpostgres.WithUsername("pai"),
+		tcpostgres.WithPassword("pai"),
+		tcpostgres.BasicWaitStrategies(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = container.Terminate(context.Background()) })
+	connectionString, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool, err := pgxpool.New(ctx, connectionString)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	for _, name := range []string{
+		"20260318100000_initial.sql",
+		"20260813100000_chat_inbound_deliveries.sql",
+	} {
+		applyInboundDeliveryMigration(t, ctx, pool, filepath.Join("..", "..", "migrations", name))
+	}
+	return pool
+}
+
+func seedInboundDeliveryTenant(t *testing.T, ctx context.Context, pool *pgxpool.Pool, slug string) string {
+	t.Helper()
+	var tenantID string
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO tenants (name, slug) VALUES ($1, $1) RETURNING id::text`, slug).Scan(&tenantID); err != nil {
+		t.Fatal(err)
+	}
+	return tenantID
+}
+
+func applyInboundDeliveryMigration(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	path string,
+) {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(content)
+	up := strings.Index(text, "-- +goose Up")
+	down := strings.Index(text, "-- +goose Down")
+	if up < 0 || down < 0 || down <= up {
+		t.Fatalf("invalid Goose migration %s", path)
+	}
+	if _, err := pool.Exec(ctx, text[up+len("-- +goose Up"):down]); err != nil {
+		t.Fatalf("apply %s: %v", path, err)
+	}
+}

--- a/internal/server/chat_ingress_delivery_test.go
+++ b/internal/server/chat_ingress_delivery_test.go
@@ -1,0 +1,416 @@
+// Copyright 2026 the P&AI authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/p-n-ai/pai-bot/internal/agent"
+)
+
+type memoryInboundDeliveryStore struct {
+	mu           sync.Mutex
+	deliveries   map[string]inboundDelivery
+	byIdentity   map[string]string
+	nextSequence int64
+	failRenewal  bool
+	renewals     int
+}
+
+func newMemoryInboundDeliveryStore() *memoryInboundDeliveryStore {
+	return &memoryInboundDeliveryStore{
+		deliveries: make(map[string]inboundDelivery),
+		byIdentity: make(map[string]string),
+	}
+}
+
+func (s *memoryInboundDeliveryStore) Accept(
+	ctx context.Context,
+	input inboundDeliveryAcceptInput,
+	now time.Time,
+) (inboundDelivery, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return inboundDelivery{}, false, err
+	}
+	if err := validateInboundDeliveryAcceptInput(input); err != nil {
+		return inboundDelivery{}, false, err
+	}
+	identity := input.TenantID + "\x00" + input.Channel + "\x00" + input.DeliveryID
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if id := s.byIdentity[identity]; id != "" {
+		delivery := s.deliveries[id]
+		if delivery.LearnerKey != input.LearnerKey ||
+			delivery.DestinationKey != input.DestinationKey ||
+			!reflect.DeepEqual(delivery.Message, input.Message) {
+			return inboundDelivery{}, false, ErrInboundDeliveryConflict
+		}
+		return delivery, false, nil
+	}
+	s.nextSequence++
+	id := fmt.Sprintf("delivery-%d", s.nextSequence)
+	delivery := inboundDelivery{
+		ID: id, TenantID: input.TenantID, Channel: input.Channel, DeliveryID: input.DeliveryID,
+		LearnerKey: input.LearnerKey, DestinationKey: input.DestinationKey,
+		AcceptedSequence: s.nextSequence, Message: input.Message, Status: inboundDeliveryReceived,
+		NextAttemptAt: now, CreatedAt: now, UpdatedAt: now,
+	}
+	s.deliveries[id] = delivery
+	s.byIdentity[identity] = id
+	return delivery, true, nil
+}
+
+func (s *memoryInboundDeliveryStore) ClaimDue(
+	ctx context.Context,
+	token string,
+	now time.Time,
+	leaseExpiresAt time.Time,
+) (inboundDelivery, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return inboundDelivery{}, false, err
+	}
+	if err := validateLeaseInput(token, now, leaseExpiresAt); err != nil {
+		return inboundDelivery{}, false, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ordered := make([]inboundDelivery, 0, len(s.deliveries))
+	for _, delivery := range s.deliveries {
+		ordered = append(ordered, delivery)
+	}
+	sort.Slice(ordered, func(a, b int) bool {
+		if ordered[a].NextAttemptAt.Equal(ordered[b].NextAttemptAt) {
+			return ordered[a].AcceptedSequence < ordered[b].AcceptedSequence
+		}
+		return ordered[a].NextAttemptAt.Before(ordered[b].NextAttemptAt)
+	})
+	for _, candidate := range ordered {
+		if !s.claimableLocked(candidate, now) {
+			continue
+		}
+		if candidate.Status == inboundDeliveryReceived {
+			candidate.Status = inboundDeliveryProcessing
+			candidate.ProcessingAttemptCount++
+		} else {
+			candidate.Status = inboundDeliveryDelivering
+			candidate.DeliveryAttemptCount++
+		}
+		candidate.LeaseToken = token
+		candidate.LeaseExpiresAt = timePointer(leaseExpiresAt)
+		candidate.UpdatedAt = now
+		s.deliveries[candidate.ID] = candidate
+		return candidate, true, nil
+	}
+	return inboundDelivery{}, false, nil
+}
+
+func (s *memoryInboundDeliveryStore) claimableLocked(candidate inboundDelivery, now time.Time) bool {
+	switch candidate.Status {
+	case inboundDeliveryReceived:
+		if candidate.NextAttemptAt.After(now) {
+			return false
+		}
+		for _, earlier := range s.deliveries {
+			if earlier.TenantID == candidate.TenantID &&
+				earlier.LearnerKey == candidate.LearnerKey &&
+				earlier.AcceptedSequence < candidate.AcceptedSequence &&
+				earlier.Status != inboundDeliveryDelivered {
+				return false
+			}
+		}
+		return true
+	case inboundDeliveryDeliveryPending:
+		if candidate.NextAttemptAt.After(now) {
+			return false
+		}
+		for _, earlier := range s.deliveries {
+			if earlier.TenantID == candidate.TenantID &&
+				earlier.DestinationKey == candidate.DestinationKey &&
+				earlier.AcceptedSequence < candidate.AcceptedSequence &&
+				earlier.Status != inboundDeliveryDelivered {
+				return false
+			}
+		}
+		return true
+	case inboundDeliveryDelivering:
+		return candidate.LeaseExpiresAt != nil && !candidate.LeaseExpiresAt.After(now)
+	default:
+		return false
+	}
+}
+
+func (s *memoryInboundDeliveryStore) RenewLease(
+	ctx context.Context,
+	id string,
+	token string,
+	status inboundDeliveryStatus,
+	now time.Time,
+	leaseExpiresAt time.Time,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.failRenewal {
+		return ErrInboundDeliveryLeaseLost
+	}
+	delivery, ok := s.deliveries[id]
+	if !ok || delivery.Status != status || delivery.LeaseToken != token ||
+		delivery.LeaseExpiresAt == nil || !delivery.LeaseExpiresAt.After(now) {
+		return ErrInboundDeliveryLeaseLost
+	}
+	delivery.LeaseExpiresAt = timePointer(leaseExpiresAt)
+	delivery.UpdatedAt = now
+	s.deliveries[id] = delivery
+	s.renewals++
+	return nil
+}
+
+func (s *memoryInboundDeliveryStore) CompleteProcessing(
+	ctx context.Context,
+	id string,
+	token string,
+	result agent.TurnResult,
+	now time.Time,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delivery, ok := s.deliveries[id]
+	if !ok || delivery.Status != inboundDeliveryProcessing || delivery.LeaseToken != token ||
+		delivery.LeaseExpiresAt == nil || !delivery.LeaseExpiresAt.After(now) {
+		return ErrInboundDeliveryLeaseLost
+	}
+	delivery.Status = inboundDeliveryDeliveryPending
+	delivery.Result = result
+	delivery.NextAttemptAt = now
+	delivery.LeaseToken = ""
+	delivery.LeaseExpiresAt = nil
+	delivery.UpdatedAt = now
+	s.deliveries[id] = delivery
+	return nil
+}
+
+func (s *memoryInboundDeliveryStore) ScheduleDeliveryRetry(
+	ctx context.Context,
+	id string,
+	token string,
+	nextAttempt time.Time,
+	now time.Time,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delivery, ok := s.deliveries[id]
+	if !ok || delivery.Status != inboundDeliveryDelivering || delivery.LeaseToken != token ||
+		delivery.LeaseExpiresAt == nil || !delivery.LeaseExpiresAt.After(now) {
+		return ErrInboundDeliveryLeaseLost
+	}
+	delivery.Status = inboundDeliveryDeliveryPending
+	delivery.NextAttemptAt = nextAttempt
+	delivery.LeaseToken = ""
+	delivery.LeaseExpiresAt = nil
+	delivery.UpdatedAt = now
+	s.deliveries[id] = delivery
+	return nil
+}
+
+func (s *memoryInboundDeliveryStore) MarkDelivered(
+	ctx context.Context,
+	id string,
+	token string,
+	now time.Time,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delivery, ok := s.deliveries[id]
+	if !ok || delivery.Status != inboundDeliveryDelivering || delivery.LeaseToken != token ||
+		delivery.LeaseExpiresAt == nil || !delivery.LeaseExpiresAt.After(now) {
+		return ErrInboundDeliveryLeaseLost
+	}
+	delivery.Status = inboundDeliveryDelivered
+	delivery.LeaseToken = ""
+	delivery.LeaseExpiresAt = nil
+	delivery.DeliveredAt = timePointer(now)
+	delivery.UpdatedAt = now
+	s.deliveries[id] = delivery
+	return nil
+}
+
+func (s *memoryInboundDeliveryStore) RecoverExpiredProcessing(
+	ctx context.Context,
+	result agent.TurnResult,
+	now time.Time,
+	limit int,
+) (int64, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	if limit <= 0 {
+		return 0, errors.New("inbound delivery recovery limit must be positive")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var recovered int64
+	for id, delivery := range s.deliveries {
+		if recovered >= int64(limit) {
+			break
+		}
+		if delivery.Status != inboundDeliveryProcessing || delivery.LeaseExpiresAt == nil ||
+			delivery.LeaseExpiresAt.After(now) {
+			continue
+		}
+		delivery.Status = inboundDeliveryDeliveryPending
+		delivery.Result = result
+		delivery.NextAttemptAt = now
+		delivery.LeaseToken = ""
+		delivery.LeaseExpiresAt = nil
+		delivery.UpdatedAt = now
+		s.deliveries[id] = delivery
+		recovered++
+	}
+	return recovered, nil
+}
+
+func (s *memoryInboundDeliveryStore) DeleteDeliveredBefore(
+	ctx context.Context,
+	before time.Time,
+	limit int,
+) (int64, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	if limit <= 0 {
+		return 0, errors.New("inbound delivery cleanup limit must be positive")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var deleted int64
+	for id, delivery := range s.deliveries {
+		if deleted >= int64(limit) {
+			break
+		}
+		if delivery.Status != inboundDeliveryDelivered || delivery.DeliveredAt == nil ||
+			delivery.DeliveredAt.After(before) {
+			continue
+		}
+		delete(s.deliveries, id)
+		delete(s.byIdentity, delivery.TenantID+"\x00"+delivery.Channel+"\x00"+delivery.DeliveryID)
+		deleted++
+	}
+	return deleted, nil
+}
+
+func (s *memoryInboundDeliveryStore) snapshotByDeliveryID(deliveryID string) (inboundDelivery, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, delivery := range s.deliveries {
+		if delivery.DeliveryID == deliveryID {
+			return delivery, true
+		}
+	}
+	return inboundDelivery{}, false
+}
+
+func (s *memoryInboundDeliveryStore) renewalCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.renewals
+}
+
+func timePointer(value time.Time) *time.Time {
+	return &value
+}
+
+func TestMemoryInboundDeliveryStoreRejectsChangedDuplicatePayload(t *testing.T) {
+	store := newMemoryInboundDeliveryStore()
+	now := time.Date(2026, 8, 13, 8, 0, 0, 0, time.UTC)
+	input := testInboundDeliveryInput("delivery-1", "first")
+	first, inserted, err := store.Accept(t.Context(), input, now)
+	if err != nil || !inserted {
+		t.Fatalf("Accept(first) = %#v, %t, %v; want inserted", first, inserted, err)
+	}
+	duplicate, inserted, err := store.Accept(t.Context(), input, now.Add(time.Hour))
+	if err != nil || inserted || duplicate.ID != first.ID {
+		t.Fatalf("Accept(duplicate) = %#v, %t, %v; want original", duplicate, inserted, err)
+	}
+	changed := input
+	changed.Message.Text = "changed"
+	if _, _, err := store.Accept(t.Context(), changed, now); !errors.Is(err, ErrInboundDeliveryConflict) {
+		t.Fatalf("Accept(changed duplicate) error = %v, want conflict", err)
+	}
+}
+
+func TestMemoryInboundDeliveryStoreRenewsOnlyCurrentLease(t *testing.T) {
+	store := newMemoryInboundDeliveryStore()
+	now := time.Date(2026, 8, 13, 8, 0, 0, 0, time.UTC)
+	if _, _, err := store.Accept(t.Context(), testInboundDeliveryInput("delivery-1", "hello"), now); err != nil {
+		t.Fatal(err)
+	}
+	claimed, ok, err := store.ClaimDue(t.Context(), "current", now, now.Add(time.Minute))
+	if err != nil || !ok {
+		t.Fatalf("ClaimDue() = %#v, %t, %v", claimed, ok, err)
+	}
+	if err := store.RenewLease(
+		t.Context(), claimed.ID, "stale", inboundDeliveryProcessing, now, now.Add(2*time.Minute),
+	); !errors.Is(err, ErrInboundDeliveryLeaseLost) {
+		t.Fatalf("RenewLease(stale) error = %v, want lease lost", err)
+	}
+	if err := store.RenewLease(
+		t.Context(), claimed.ID, "current", inboundDeliveryProcessing, now, now.Add(2*time.Minute),
+	); err != nil {
+		t.Fatalf("RenewLease(current) error = %v", err)
+	}
+	if _, ok, err := store.ClaimDue(t.Context(), "reclaim", now.Add(time.Minute), now.Add(3*time.Minute)); err != nil || ok {
+		t.Fatalf("ClaimDue(before renewed expiry) = %t, %v; want false, nil", ok, err)
+	}
+}
+
+func TestMemoryInboundDeliveryStoreRecoversProcessingAsStoredResult(t *testing.T) {
+	store := newMemoryInboundDeliveryStore()
+	now := time.Date(2026, 8, 13, 8, 0, 0, 0, time.UTC)
+	if _, _, err := store.Accept(t.Context(), testInboundDeliveryInput("delivery-1", "hello"), now); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, err := store.ClaimDue(t.Context(), "worker", now, now.Add(time.Minute)); err != nil || !ok {
+		t.Fatalf("ClaimDue() = %t, %v", ok, err)
+	}
+	recovered, err := store.RecoverExpiredProcessing(
+		t.Context(), agent.TurnResult{Text: "safe result"}, now.Add(time.Minute), 10,
+	)
+	if err != nil || recovered != 1 {
+		t.Fatalf("RecoverExpiredProcessing() = %d, %v", recovered, err)
+	}
+	claimed, ok, err := store.ClaimDue(
+		t.Context(), "deliverer", now.Add(time.Minute), now.Add(2*time.Minute),
+	)
+	if err != nil || !ok || claimed.Status != inboundDeliveryDelivering || claimed.Result.Text != "safe result" {
+		t.Fatalf("recovered ClaimDue() = %#v, %t, %v", claimed, ok, err)
+	}
+}
+
+func testInboundDeliveryInput(deliveryID, text string) inboundDeliveryAcceptInput {
+	message := testInboundMessage(deliveryID, text)
+	message.TenantID = testChatIngressTenantID
+	return inboundDeliveryAcceptInput{
+		TenantID: testChatIngressTenantID, Channel: message.Channel,
+		DeliveryID: deliveryID, LearnerKey: inboundCompositeKey("external", "slack", "learner-1"),
+		DestinationKey: inboundCompositeKey("slack", "thread-1"), Message: message,
+	}
+}

--- a/internal/server/chat_ingress_test.go
+++ b/internal/server/chat_ingress_test.go
@@ -6,48 +6,96 @@ package server
 import (
 	"context"
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/p-n-ai/pai-bot/internal/agent"
 	"github.com/p-n-ai/pai-bot/internal/chat"
 )
 
-func TestChatIngressDeduplicatesDeliveriesPerChannel(t *testing.T) {
-	processed := make(chan chat.InboundMessage, 3)
-	ingress, err := newChatIngress(4, func(_ context.Context, message chat.InboundMessage) {
-		processed <- message
-	})
+const testChatIngressTenantID = "11111111-1111-1111-1111-111111111111"
+
+type chatIngressProcessorStub struct {
+	process func(context.Context, chat.InboundMessage) (agent.TurnResult, error)
+	deliver func(context.Context, chat.InboundMessage, agent.TurnResult) error
+}
+
+func (s chatIngressProcessorStub) ProcessTurn(
+	ctx context.Context,
+	message chat.InboundMessage,
+) (agent.TurnResult, error) {
+	return s.process(ctx, message)
+}
+
+func (s chatIngressProcessorStub) DeliverTurn(
+	ctx context.Context,
+	message chat.InboundMessage,
+	result agent.TurnResult,
+) error {
+	return s.deliver(ctx, message, result)
+}
+
+func newTestChatIngress(
+	t *testing.T,
+	workers int,
+	store inboundDeliveryStore,
+	processor InboundTurnProcessor,
+) *ChatIngress {
+	t.Helper()
+	ingress, err := newChatIngress(
+		testChatIngressTenantID,
+		store,
+		processor,
+		chatIngressConfig{
+			LeaseDuration: 90 * time.Millisecond,
+			PollInterval:  5 * time.Millisecond,
+			BaseBackoff:   100 * time.Millisecond,
+			MaxBackoff:    200 * time.Millisecond,
+			WorkerCount:   workers,
+			Now:           time.Now,
+		},
+	)
 	if err != nil {
 		t.Fatalf("newChatIngress() error = %v", err)
 	}
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		ingress.Run(ctx)
-	}()
+	return ingress
+}
 
-	slack := chat.InboundMessage{Channel: "slack", DeliveryID: "delivery-1", Text: "first"}
-	if err := ingress.Enqueue(ctx, slack); err != nil {
-		t.Fatalf("Enqueue(first Slack delivery) error = %v", err)
+func TestChatIngressDeduplicatesExplicitDeliveryPerChannel(t *testing.T) {
+	store := newMemoryInboundDeliveryStore()
+	processed := make(chan chat.InboundMessage, 3)
+	ingress := newTestChatIngress(t, 2, store, chatIngressProcessorStub{
+		process: func(_ context.Context, message chat.InboundMessage) (agent.TurnResult, error) {
+			processed <- message
+			return agent.TurnResult{Text: message.Text}, nil
+		},
+		deliver: func(context.Context, chat.InboundMessage, agent.TurnResult) error { return nil },
+	})
+	ctx, cancel, done := runChatIngress(t, ingress)
+	defer stopChatIngress(cancel, done)
+
+	slack := testInboundMessage("delivery-1", "first")
+	if err := ingress.Accept(ctx, slack); err != nil {
+		t.Fatalf("Accept(first Slack delivery) error = %v", err)
 	}
-	if err := ingress.Enqueue(ctx, slack); err != nil {
-		t.Fatalf("Enqueue(duplicate Slack delivery) error = %v", err)
+	if err := ingress.Accept(ctx, slack); err != nil {
+		t.Fatalf("Accept(duplicate Slack delivery) error = %v", err)
 	}
-	if err := ingress.Enqueue(ctx, chat.InboundMessage{
-		Channel: "discord", DeliveryID: "delivery-1", Text: "same ID, other channel",
-	}); err != nil {
-		t.Fatalf("Enqueue(Discord delivery) error = %v", err)
+	discord := slack
+	discord.Channel = "discord"
+	discord.ThreadID = "discord-thread"
+	discord.Text = "same ID, other channel"
+	if err := ingress.Accept(ctx, discord); err != nil {
+		t.Fatalf("Accept(Discord delivery) error = %v", err)
 	}
 
-	got := make([]chat.InboundMessage, 0, 2)
-	for len(got) < 2 {
+	for count := 0; count < 2; count++ {
 		select {
-		case message := <-processed:
-			got = append(got, message)
+		case <-processed:
 		case <-time.After(time.Second):
-			t.Fatalf("processed %d messages, want 2 unique channel deliveries", len(got))
+			t.Fatalf("processed %d messages, want two channel-scoped deliveries", count)
 		}
 	}
 	select {
@@ -55,189 +103,412 @@ func TestChatIngressDeduplicatesDeliveriesPerChannel(t *testing.T) {
 		t.Fatalf("duplicate delivery processed: %#v", extra)
 	case <-time.After(25 * time.Millisecond):
 	}
-
-	cancel()
-	<-done
 }
 
-func TestChatIngressProcessesMessagesWithoutDeliveryID(t *testing.T) {
+func TestChatIngressAssignsDistinctIDsToLegacyWebSocketMessages(t *testing.T) {
+	store := newMemoryInboundDeliveryStore()
 	processed := make(chan chat.InboundMessage, 2)
-	ingress, err := newChatIngress(2, func(_ context.Context, message chat.InboundMessage) {
-		processed <- message
+	ingress := newTestChatIngress(t, 2, store, chatIngressProcessorStub{
+		process: func(_ context.Context, message chat.InboundMessage) (agent.TurnResult, error) {
+			processed <- message
+			return agent.TurnResult{Text: "ok"}, nil
+		},
+		deliver: func(context.Context, chat.InboundMessage, agent.TurnResult) error { return nil },
 	})
-	if err != nil {
-		t.Fatalf("newChatIngress() error = %v", err)
-	}
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	go ingress.Run(ctx)
+	ctx, cancel, done := runChatIngress(t, ingress)
+	defer stopChatIngress(cancel, done)
 
-	message := chat.InboundMessage{Channel: "websocket", UserID: "learner-1", Text: "hello"}
-	if err := ingress.Enqueue(ctx, message); err != nil {
-		t.Fatalf("Enqueue(first message) error = %v", err)
+	message := chat.InboundMessage{
+		Channel: "websocket", UserID: "learner-1", ExternalID: "learner-1", Text: "same text",
 	}
-	if err := ingress.Enqueue(ctx, message); err != nil {
-		t.Fatalf("Enqueue(second message) error = %v", err)
+	if err := ingress.Accept(ctx, message); err != nil {
+		t.Fatal(err)
 	}
-
-	for i := 0; i < 2; i++ {
-		select {
-		case <-processed:
-		case <-time.After(time.Second):
-			t.Fatalf("processed %d messages without delivery IDs, want 2", i)
-		}
+	if err := ingress.Accept(ctx, message); err != nil {
+		t.Fatal(err)
+	}
+	first := waitForProcessedMessage(t, processed)
+	second := waitForProcessedMessage(t, processed)
+	if first.DeliveryID == "" || second.DeliveryID == "" || first.DeliveryID == second.DeliveryID {
+		t.Fatalf("generated delivery IDs = %q and %q, want distinct non-empty IDs", first.DeliveryID, second.DeliveryID)
 	}
 }
 
-func TestChatIngressDoesNotBlockIndependentThreads(t *testing.T) {
-	firstStarted := make(chan struct{})
-	releaseFirst := make(chan struct{})
-	secondProcessed := make(chan struct{})
-	ingress, err := newChatIngress(4, func(_ context.Context, message chat.InboundMessage) {
-		switch message.ThreadID {
-		case "slack:C1:T1":
-			close(firstStarted)
-			<-releaseFirst
-		case "slack:C2:T2":
-			close(secondProcessed)
-		}
+func TestChatIngressStoresFailureResultWithoutReprocessing(t *testing.T) {
+	store := newMemoryInboundDeliveryStore()
+	var processCalls atomic.Int32
+	delivered := make(chan agent.TurnResult, 1)
+	ingress := newTestChatIngress(t, 1, store, chatIngressProcessorStub{
+		process: func(context.Context, chat.InboundMessage) (agent.TurnResult, error) {
+			processCalls.Add(1)
+			return agent.TurnResult{Text: "unsafe partial reply"}, errors.New("model failed after an uncertain mutation")
+		},
+		deliver: func(_ context.Context, _ chat.InboundMessage, result agent.TurnResult) error {
+			delivered <- result
+			return nil
+		},
 	})
-	if err != nil {
-		t.Fatalf("newChatIngress() error = %v", err)
+	ctx, cancel, done := runChatIngress(t, ingress)
+	defer stopChatIngress(cancel, done)
+	message := testInboundMessage("delivery-failed-processing", "hello")
+	if err := ingress.Accept(ctx, message); err != nil {
+		t.Fatal(err)
 	}
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	go ingress.Run(ctx)
+	if err := ingress.Accept(ctx, message); err != nil {
+		t.Fatal(err)
+	}
 
-	if err := ingress.Enqueue(ctx, chat.InboundMessage{
-		Channel: "slack", ThreadID: "slack:C1:T1", DeliveryID: "D1",
-	}); err != nil {
-		t.Fatalf("Enqueue(first thread) error = %v", err)
+	select {
+	case result := <-delivered:
+		if result.Text != chatIngressInterruptedResponse {
+			t.Fatalf("delivered text = %q, want technical response", result.Text)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("stored failure response was not delivered")
+	}
+	if calls := processCalls.Load(); calls != 1 {
+		t.Fatalf("processing calls = %d, want one", calls)
+	}
+}
+
+func TestChatIngressRetriesStoredOutputWithoutReprocessing(t *testing.T) {
+	store := newMemoryInboundDeliveryStore()
+	var processCalls atomic.Int32
+	firstDelivery := make(chan struct{}, 1)
+	first := newTestChatIngress(t, 1, store, chatIngressProcessorStub{
+		process: func(context.Context, chat.InboundMessage) (agent.TurnResult, error) {
+			processCalls.Add(1)
+			return agent.TurnResult{Text: "durable reply"}, nil
+		},
+		deliver: func(context.Context, chat.InboundMessage, agent.TurnResult) error {
+			firstDelivery <- struct{}{}
+			return errors.New("temporary channel failure")
+		},
+	})
+	ctx, cancel, done := runChatIngress(t, first)
+	message := testInboundMessage("delivery-retry", "hello")
+	if err := first.Accept(ctx, message); err != nil {
+		t.Fatal(err)
 	}
 	select {
-	case <-firstStarted:
+	case <-firstDelivery:
 	case <-time.After(time.Second):
-		t.Fatal("first thread did not start")
+		t.Fatal("first delivery attempt did not run")
 	}
-	if err := ingress.Enqueue(ctx, chat.InboundMessage{
-		Channel: "slack", ThreadID: "slack:C2:T2", DeliveryID: "D2",
-	}); err != nil {
-		t.Fatalf("Enqueue(second thread) error = %v", err)
+	waitForInboundStatus(t, store, message.DeliveryID, inboundDeliveryDeliveryPending)
+	stopChatIngress(cancel, done)
+
+	retried := make(chan agent.TurnResult, 1)
+	restarted := newTestChatIngress(t, 1, store, chatIngressProcessorStub{
+		process: func(context.Context, chat.InboundMessage) (agent.TurnResult, error) {
+			processCalls.Add(1)
+			return agent.TurnResult{}, errors.New("must not reprocess stored output")
+		},
+		deliver: func(_ context.Context, _ chat.InboundMessage, result agent.TurnResult) error {
+			retried <- result
+			return nil
+		},
+	})
+	_, cancelRestarted, restartedDone := runChatIngress(t, restarted)
+	defer stopChatIngress(cancelRestarted, restartedDone)
+	select {
+	case result := <-retried:
+		if result.Text != "durable reply" {
+			t.Fatalf("retried result = %#v, want exact durable reply", result)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("fresh worker did not retry stored output")
+	}
+	if calls := processCalls.Load(); calls != 1 {
+		t.Fatalf("processing calls = %d, want one across restart", calls)
+	}
+}
+
+func TestChatIngressSerializesOneLearnerThroughDelivery(t *testing.T) {
+	store := newMemoryInboundDeliveryStore()
+	firstDeliveryStarted := make(chan struct{})
+	releaseFirstDelivery := make(chan struct{})
+	secondProcessed := make(chan struct{})
+	ingress := newTestChatIngress(t, 2, store, chatIngressProcessorStub{
+		process: func(_ context.Context, message chat.InboundMessage) (agent.TurnResult, error) {
+			if message.Text == "second" {
+				close(secondProcessed)
+			}
+			return agent.TurnResult{Text: message.Text}, nil
+		},
+		deliver: func(_ context.Context, message chat.InboundMessage, _ agent.TurnResult) error {
+			if message.Text == "first" {
+				close(firstDeliveryStarted)
+				<-releaseFirstDelivery
+			}
+			return nil
+		},
+	})
+	ctx, cancel, done := runChatIngress(t, ingress)
+	defer stopChatIngress(cancel, done)
+	first := testInboundMessage("delivery-1", "first")
+	first.ThreadID = "thread-1"
+	second := testInboundMessage("delivery-2", "second")
+	second.ThreadID = "thread-2"
+	if err := ingress.Accept(ctx, first); err != nil {
+		t.Fatal(err)
+	}
+	if err := ingress.Accept(ctx, second); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-firstDeliveryStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first delivery did not start")
 	}
 	select {
 	case <-secondProcessed:
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("independent thread was blocked by an in-flight turn")
+		t.Fatal("second thread processed before the learner's first delivery completed")
+	case <-time.After(40 * time.Millisecond):
 	}
-	close(releaseFirst)
+	close(releaseFirstDelivery)
+	select {
+	case <-secondProcessed:
+	case <-time.After(time.Second):
+		t.Fatal("second thread did not process after the first delivery completed")
+	}
 }
 
-func TestChatIngressSerializesOneThread(t *testing.T) {
+func TestChatIngressDoesNotBlockDifferentLearners(t *testing.T) {
+	store := newMemoryInboundDeliveryStore()
 	firstStarted := make(chan struct{})
 	releaseFirst := make(chan struct{})
-	order := make(chan string, 2)
-	ingress, err := newChatIngress(4, func(_ context.Context, message chat.InboundMessage) {
-		if message.Text == "first" {
-			close(firstStarted)
-			<-releaseFirst
-		}
-		order <- message.Text
+	secondProcessed := make(chan struct{})
+	ingress := newTestChatIngress(t, 2, store, chatIngressProcessorStub{
+		process: func(_ context.Context, message chat.InboundMessage) (agent.TurnResult, error) {
+			if message.UserID == "learner-1" {
+				close(firstStarted)
+				<-releaseFirst
+			} else {
+				close(secondProcessed)
+			}
+			return agent.TurnResult{Text: "ok"}, nil
+		},
+		deliver: func(context.Context, chat.InboundMessage, agent.TurnResult) error { return nil },
 	})
-	if err != nil {
-		t.Fatalf("newChatIngress() error = %v", err)
-	}
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	go ingress.Run(ctx)
-
-	for index, text := range []string{"first", "second"} {
-		if err := ingress.Enqueue(ctx, chat.InboundMessage{
-			Channel: "slack", ThreadID: "slack:C1:T1", DeliveryID: string(rune('1' + index)), Text: text,
-		}); err != nil {
-			t.Fatalf("Enqueue(%s) error = %v", text, err)
-		}
+	ctx, cancel, done := runChatIngress(t, ingress)
+	defer stopChatIngress(cancel, done)
+	first := testInboundMessage("delivery-1", "first")
+	second := testInboundMessage("delivery-2", "second")
+	second.UserID = "learner-2"
+	second.ExternalID = "learner-2"
+	second.ThreadID = "thread-2"
+	if err := ingress.Accept(ctx, first); err != nil {
+		t.Fatal(err)
 	}
 	select {
 	case <-firstStarted:
 	case <-time.After(time.Second):
-		t.Fatal("first turn did not start")
+		t.Fatal("first learner did not start")
+	}
+	if err := ingress.Accept(ctx, second); err != nil {
+		t.Fatal(err)
 	}
 	select {
-	case got := <-order:
-		t.Fatalf("same-thread turn completed before release: %q", got)
-	case <-time.After(25 * time.Millisecond):
+	case <-secondProcessed:
+	case <-time.After(time.Second):
+		t.Fatal("different learner was blocked")
 	}
 	close(releaseFirst)
-	for _, want := range []string{"first", "second"} {
-		select {
-		case got := <-order:
-			if got != want {
-				t.Fatalf("processed %q, want %q", got, want)
-			}
-		case <-time.After(time.Second):
-			t.Fatalf("timed out waiting for %q", want)
-		}
+}
+
+func TestChatIngressRenewsClaimWhileProcessing(t *testing.T) {
+	store := newMemoryInboundDeliveryStore()
+	release := make(chan struct{})
+	delivered := make(chan struct{})
+	ingress := newTestChatIngress(t, 1, store, chatIngressProcessorStub{
+		process: func(context.Context, chat.InboundMessage) (agent.TurnResult, error) {
+			<-release
+			return agent.TurnResult{Text: "ok"}, nil
+		},
+		deliver: func(context.Context, chat.InboundMessage, agent.TurnResult) error {
+			close(delivered)
+			return nil
+		},
+	})
+	ingress.cfg.LeaseDuration = 30 * time.Millisecond
+	ctx, cancel, done := runChatIngress(t, ingress)
+	defer stopChatIngress(cancel, done)
+	message := testInboundMessage("delivery-renew", "hello")
+	if err := ingress.Accept(ctx, message); err != nil {
+		t.Fatal(err)
+	}
+	waitForCondition(t, time.Second, func() bool { return store.renewalCount() >= 2 }, "lease renewal")
+	if _, ok, err := store.ClaimDue(
+		t.Context(), "competing-worker", time.Now(), time.Now().Add(time.Second),
+	); err != nil || ok {
+		t.Fatalf("competing ClaimDue() = %t, %v; want no claim while renewed", ok, err)
+	}
+	close(release)
+	select {
+	case <-delivered:
+	case <-time.After(time.Second):
+		t.Fatal("renewed turn did not finish")
+	}
+	if delivery, ok := store.snapshotByDeliveryID(message.DeliveryID); !ok || delivery.ProcessingAttemptCount != 1 {
+		t.Fatalf("processing state = %#v, want one attempt", delivery)
 	}
 }
 
-func TestChatIngressCapacityBoundsQueuedAndProcessingMessages(t *testing.T) {
-	started := make(chan struct{})
-	release := make(chan struct{})
-	ingress, err := newChatIngress(1, func(_ context.Context, _ chat.InboundMessage) {
-		close(started)
-		<-release
+func TestChatIngressCancelsAndDoesNotPersistAfterLeaseLoss(t *testing.T) {
+	store := newMemoryInboundDeliveryStore()
+	store.failRenewal = true
+	processingCanceled := make(chan struct{})
+	var deliveryCalls atomic.Int32
+	ingress := newTestChatIngress(t, 1, store, chatIngressProcessorStub{
+		process: func(ctx context.Context, _ chat.InboundMessage) (agent.TurnResult, error) {
+			<-ctx.Done()
+			close(processingCanceled)
+			return agent.TurnResult{Text: "unsafe late result"}, nil
+		},
+		deliver: func(context.Context, chat.InboundMessage, agent.TurnResult) error {
+			deliveryCalls.Add(1)
+			return nil
+		},
 	})
-	if err != nil {
-		t.Fatalf("newChatIngress() error = %v", err)
+	ingress.cfg.LeaseDuration = 60 * time.Millisecond
+	ctx, cancel, done := runChatIngress(t, ingress)
+	message := testInboundMessage("delivery-lost", "hello")
+	if err := ingress.Accept(ctx, message); err != nil {
+		t.Fatal(err)
 	}
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	go ingress.Run(ctx)
-
-	if err := ingress.Enqueue(ctx, chat.InboundMessage{Channel: "slack", ThreadID: "thread-1"}); err != nil {
-		t.Fatalf("Enqueue(first) error = %v", err)
+	select {
+	case <-processingCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("lease loss did not cancel processing")
 	}
-	<-started
-	enqueueCtx, cancelEnqueue := context.WithTimeout(ctx, 25*time.Millisecond)
-	defer cancelEnqueue()
-	if err := ingress.Enqueue(enqueueCtx, chat.InboundMessage{
-		Channel: "slack", ThreadID: "thread-2",
-	}); !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("Enqueue(over capacity) error = %v, want deadline exceeded", err)
+	stopChatIngress(cancel, done)
+	delivery, ok := store.snapshotByDeliveryID(message.DeliveryID)
+	if !ok || delivery.Status != inboundDeliveryProcessing || delivery.Result.Text != "" {
+		t.Fatalf("state after lease loss = %#v, want uncommitted processing claim", delivery)
 	}
-	close(release)
+	if calls := deliveryCalls.Load(); calls != 0 {
+		t.Fatalf("delivery calls after lease loss = %d, want zero", calls)
+	}
 }
 
 func TestChatIngressRunWaitsForCanceledWorker(t *testing.T) {
+	store := newMemoryInboundDeliveryStore()
 	started := make(chan struct{})
 	workerDone := make(chan struct{})
-	ingress, err := newChatIngress(1, func(ctx context.Context, _ chat.InboundMessage) {
-		close(started)
-		<-ctx.Done()
-		close(workerDone)
+	ingress := newTestChatIngress(t, 1, store, chatIngressProcessorStub{
+		process: func(ctx context.Context, _ chat.InboundMessage) (agent.TurnResult, error) {
+			close(started)
+			<-ctx.Done()
+			close(workerDone)
+			return agent.TurnResult{}, ctx.Err()
+		},
+		deliver: func(context.Context, chat.InboundMessage, agent.TurnResult) error { return nil },
 	})
-	if err != nil {
-		t.Fatalf("newChatIngress() error = %v", err)
+	ctx, cancel, done := runChatIngress(t, ingress)
+	if err := ingress.Accept(ctx, testInboundMessage("delivery-cancel", "hello")); err != nil {
+		t.Fatal(err)
 	}
-	ctx, cancel := context.WithCancel(t.Context())
-	runDone := make(chan struct{})
-	go func() {
-		ingress.Run(ctx)
-		close(runDone)
-	}()
-	if err := ingress.Enqueue(ctx, chat.InboundMessage{Channel: "slack", ThreadID: "thread-1"}); err != nil {
-		t.Fatalf("Enqueue() error = %v", err)
-	}
-	<-started
-	cancel()
 	select {
-	case <-runDone:
+	case <-started:
 	case <-time.After(time.Second):
-		t.Fatal("Run() did not stop after cancellation")
+		t.Fatal("worker did not start")
 	}
+	stopChatIngress(cancel, done)
 	select {
 	case <-workerDone:
 	default:
 		t.Fatal("Run() returned before its worker stopped")
+	}
+}
+
+func testInboundMessage(deliveryID, text string) chat.InboundMessage {
+	return chat.InboundMessage{
+		Channel: "slack", UserID: "learner-1", ExternalID: "learner-1",
+		ThreadID: "thread-1", DeliveryID: deliveryID, Text: text,
+	}
+}
+
+func runChatIngress(t *testing.T, ingress *ChatIngress) (context.Context, context.CancelFunc, <-chan struct{}) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ingress.Run(ctx)
+	}()
+	return ctx, cancel, done
+}
+
+func stopChatIngress(cancel context.CancelFunc, done <-chan struct{}) {
+	cancel()
+	<-done
+}
+
+func waitForProcessedMessage(t *testing.T, messages <-chan chat.InboundMessage) chat.InboundMessage {
+	t.Helper()
+	select {
+	case message := <-messages:
+		return message
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for processed message")
+		return chat.InboundMessage{}
+	}
+}
+
+func waitForInboundStatus(
+	t *testing.T,
+	store *memoryInboundDeliveryStore,
+	deliveryID string,
+	status inboundDeliveryStatus,
+) {
+	t.Helper()
+	waitForCondition(t, time.Second, func() bool {
+		delivery, ok := store.snapshotByDeliveryID(deliveryID)
+		return ok && delivery.Status == status
+	}, "inbound status "+string(status))
+}
+
+func waitForCondition(t *testing.T, timeout time.Duration, condition func() bool, description string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for !condition() {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s", description)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestChatIngressAcceptIsSafeUnderConcurrentDuplicateRequests(t *testing.T) {
+	store := newMemoryInboundDeliveryStore()
+	processor := chatIngressProcessorStub{
+		process: func(context.Context, chat.InboundMessage) (agent.TurnResult, error) {
+			return agent.TurnResult{Text: "ok"}, nil
+		},
+		deliver: func(context.Context, chat.InboundMessage, agent.TurnResult) error { return nil },
+	}
+	ingress := newTestChatIngress(t, 1, store, processor)
+	message := testInboundMessage("delivery-concurrent", "hello")
+	var workers sync.WaitGroup
+	var failures atomic.Int32
+	for range 16 {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			if err := ingress.Accept(t.Context(), message); err != nil {
+				failures.Add(1)
+			}
+		}()
+	}
+	workers.Wait()
+	if failures.Load() != 0 {
+		t.Fatalf("concurrent duplicate acceptance failures = %d", failures.Load())
+	}
+	store.mu.Lock()
+	count := len(store.deliveries)
+	store.mu.Unlock()
+	if count != 1 {
+		t.Fatalf("stored deliveries = %d, want one", count)
 	}
 }

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -85,8 +85,6 @@ type TopMuxOptions struct {
 	EmbedAuthenticator    EmbedPasswordAuthenticator
 	EmbedBaseURL          string
 	EmbedTokenTTL         time.Duration
-	WACloudChannel        *chat.WhatsAppChannel
-	InboundHandler        func(chat.InboundMessage)
 	AuthService           AuthService
 	JWTSecret             string
 	AccessTokenTTL        time.Duration
@@ -128,9 +126,6 @@ func NewTopMux(opts TopMuxOptions) http.Handler {
 			continue
 		}
 		topMux.Handle("/webhook/"+name, handler)
-	}
-	if opts.WACloudChannel != nil && opts.ChatWebhooks["whatsapp"] == nil {
-		topMux.Handle("/webhook/whatsapp", opts.WACloudChannel.WebhookHandler(opts.InboundHandler))
 	}
 	manager := auth.NewTokenManager(opts.JWTSecret, opts.AccessTokenTTL)
 	embedTokenTTL := opts.EmbedTokenTTL

--- a/internal/server/tenant_turn_router.go
+++ b/internal/server/tenant_turn_router.go
@@ -14,7 +14,8 @@ import (
 )
 
 type TurnProcessor interface {
-	ProcessAndDeliver(ctx context.Context, msg chat.InboundMessage) (agent.TurnResult, error)
+	ProcessTurn(ctx context.Context, msg chat.InboundMessage) (agent.TurnResult, error)
+	DeliverTurn(ctx context.Context, msg chat.InboundMessage, result agent.TurnResult) error
 }
 
 type TenantTurnRouter struct {
@@ -39,12 +40,20 @@ func NewTenantTurnRouter(defaultProcessor TurnProcessor, newForTenant func(strin
 	}, nil
 }
 
-func (r *TenantTurnRouter) ProcessAndDeliver(ctx context.Context, msg chat.InboundMessage) (agent.TurnResult, error) {
+func (r *TenantTurnRouter) ProcessTurn(ctx context.Context, msg chat.InboundMessage) (agent.TurnResult, error) {
 	processor, err := r.processorFor(msg)
 	if err != nil {
 		return agent.TurnResult{}, err
 	}
-	return processor.ProcessAndDeliver(ctx, msg)
+	return processor.ProcessTurn(ctx, msg)
+}
+
+func (r *TenantTurnRouter) DeliverTurn(ctx context.Context, msg chat.InboundMessage, result agent.TurnResult) error {
+	processor, err := r.processorFor(msg)
+	if err != nil {
+		return err
+	}
+	return processor.DeliverTurn(ctx, msg, result)
 }
 
 func (r *TenantTurnRouter) processorFor(msg chat.InboundMessage) (TurnProcessor, error) {

--- a/internal/server/tenant_turn_router_test.go
+++ b/internal/server/tenant_turn_router_test.go
@@ -12,12 +12,18 @@ import (
 )
 
 type turnProcessorStub struct {
-	messages []chat.InboundMessage
+	messages   []chat.InboundMessage
+	deliveries []chat.InboundMessage
 }
 
-func (s *turnProcessorStub) ProcessAndDeliver(_ context.Context, msg chat.InboundMessage) (agent.TurnResult, error) {
+func (s *turnProcessorStub) ProcessTurn(_ context.Context, msg chat.InboundMessage) (agent.TurnResult, error) {
 	s.messages = append(s.messages, msg)
 	return agent.TurnResult{}, nil
+}
+
+func (s *turnProcessorStub) DeliverTurn(_ context.Context, msg chat.InboundMessage, _ agent.TurnResult) error {
+	s.deliveries = append(s.deliveries, msg)
+	return nil
 }
 
 func TestTenantTurnRouterRoutesAuthenticatedEmbedByTenant(t *testing.T) {
@@ -41,7 +47,11 @@ func TestTenantTurnRouterRoutesAuthenticatedEmbedByTenant(t *testing.T) {
 		ExternalID:      "telegram-user-b",
 		Text:            "hello",
 	}
-	if _, err := router.ProcessAndDeliver(t.Context(), message); err != nil {
+	result, err := router.ProcessTurn(t.Context(), message)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := router.DeliverTurn(t.Context(), message, result); err != nil {
 		t.Fatal(err)
 	}
 	if len(defaultProcessor.messages) != 0 {
@@ -49,6 +59,9 @@ func TestTenantTurnRouterRoutesAuthenticatedEmbedByTenant(t *testing.T) {
 	}
 	if got := tenantProcessors["tenant-b"]; got == nil || len(got.messages) != 1 {
 		t.Fatalf("tenant-b processor messages = %#v", got)
+	}
+	if got := tenantProcessors["tenant-b"]; len(got.deliveries) != 1 {
+		t.Fatalf("tenant-b processor deliveries = %#v", got.deliveries)
 	}
 }
 
@@ -59,7 +72,7 @@ func TestTenantTurnRouterRejectsTenantWithoutInternalIdentity(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := router.ProcessAndDeliver(t.Context(), chat.InboundMessage{
+	if _, err := router.ProcessTurn(t.Context(), chat.InboundMessage{
 		Channel:  "embed",
 		TenantID: "tenant-b",
 		UserID:   "untrusted-external-id",

--- a/migrations/20260813100000_chat_inbound_deliveries.sql
+++ b/migrations/20260813100000_chat_inbound_deliveries.sql
@@ -1,0 +1,67 @@
+-- +goose Up
+CREATE TABLE chat_inbound_deliveries (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    channel TEXT NOT NULL CHECK (char_length(channel) > 0),
+    delivery_id TEXT NOT NULL CHECK (char_length(delivery_id) > 0),
+    learner_key TEXT NOT NULL CHECK (char_length(learner_key) > 0),
+    destination_key TEXT NOT NULL CHECK (char_length(destination_key) > 0),
+    accepted_sequence BIGSERIAL NOT NULL,
+    inbound_payload JSONB NOT NULL,
+    inbound_payload_hash BYTEA NOT NULL CHECK (octet_length(inbound_payload_hash) = 32),
+    result_payload JSONB,
+    status TEXT NOT NULL DEFAULT 'received'
+        CHECK (status IN ('received', 'processing', 'delivery_pending', 'delivering', 'delivered')),
+    processing_attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (processing_attempt_count >= 0),
+    delivery_attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (delivery_attempt_count >= 0),
+    next_attempt_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    lease_token TEXT,
+    lease_expires_at TIMESTAMPTZ,
+    delivered_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (tenant_id, channel, delivery_id),
+    CHECK (
+        (status = 'received' AND result_payload IS NULL
+            AND lease_token IS NULL AND lease_expires_at IS NULL AND delivered_at IS NULL)
+        OR (status = 'processing' AND result_payload IS NULL
+            AND lease_token IS NOT NULL AND lease_expires_at IS NOT NULL AND delivered_at IS NULL)
+        OR (status = 'delivery_pending' AND result_payload IS NOT NULL
+            AND lease_token IS NULL AND lease_expires_at IS NULL AND delivered_at IS NULL)
+        OR (status = 'delivering' AND result_payload IS NOT NULL
+            AND lease_token IS NOT NULL AND lease_expires_at IS NOT NULL AND delivered_at IS NULL)
+        OR (status = 'delivered' AND result_payload IS NOT NULL
+            AND lease_token IS NULL AND lease_expires_at IS NULL AND delivered_at IS NOT NULL)
+    )
+);
+
+CREATE INDEX chat_inbound_deliveries_received_idx
+    ON chat_inbound_deliveries (next_attempt_at, accepted_sequence)
+    WHERE status = 'received';
+
+CREATE INDEX chat_inbound_deliveries_processing_lease_idx
+    ON chat_inbound_deliveries (lease_expires_at, accepted_sequence)
+    WHERE status = 'processing';
+
+CREATE INDEX chat_inbound_deliveries_delivery_idx
+    ON chat_inbound_deliveries (next_attempt_at, accepted_sequence)
+    WHERE status = 'delivery_pending';
+
+CREATE INDEX chat_inbound_deliveries_delivery_lease_idx
+    ON chat_inbound_deliveries (lease_expires_at, accepted_sequence)
+    WHERE status = 'delivering';
+
+CREATE INDEX chat_inbound_deliveries_learner_order_idx
+    ON chat_inbound_deliveries (tenant_id, learner_key, accepted_sequence)
+    WHERE status <> 'delivered';
+
+CREATE INDEX chat_inbound_deliveries_destination_order_idx
+    ON chat_inbound_deliveries (tenant_id, destination_key, accepted_sequence)
+    WHERE status <> 'delivered';
+
+CREATE INDEX chat_inbound_deliveries_delivered_idx
+    ON chat_inbound_deliveries (delivered_at, accepted_sequence)
+    WHERE status = 'delivered';
+
+-- +goose Down
+DROP TABLE IF EXISTS chat_inbound_deliveries;


### PR DESCRIPTION
## Summary

Persist inbound chat deliveries in Postgres before processing tutor turns, providing durable acceptance, duplicate protection, and retry-safe webhook handling across chat channels. Webhooks now acknowledge messages only after persistence succeeds, while the release workflow stores nightly candidates without publishing GitHub prereleases.

## Risk

- API contract: additive; webhook adapters return `503 Service Unavailable` when durable acceptance fails so providers can retry.
- Database migrations: backward-compatible; adds the chat inbound deliveries table. Rollback requires stopping ingress and reverting the application before removing the migration’s schema.
- Release and deployment: nightly only; merges to `main` now create candidate artifacts without publishing nightly GitHub prereleases. Stable promotion remains manual.
- Rollback: deploy the previous application version after pausing or draining inbound processing; retain the new delivery table until all queued deliveries are handled.

## Verification

- Added unit and integration coverage for delivery persistence, duplicate handling, retry behavior, and tenant isolation.
- Added webhook tests confirming acknowledgment occurs only after inbound acceptance succeeds.
- Added failure-path tests confirming persistence errors return a retryable status without exposing internal errors.
- Updated channel, WebSocket, gateway, ingress, and release workflow tests for the new contracts.
- Verification results: not provided in the change request.