### PR TITLE
feat(admin): adopt Pandai design and manage catalog AI providers

### DIFF
--- a/admin-spa/src/components/settings/ai-settings-panel.test.tsx
+++ b/admin-spa/src/components/settings/ai-settings-panel.test.tsx
@@ -102,6 +102,9 @@ describe('AISettingsPanel', () => {
     expect(
       within(providerSection('Ollama provider')).queryByLabelText(/URL/i),
     ).not.toBeInTheDocument()
+    expect(
+      within(providerSection('Cerebras provider')).getByText('Default'),
+    ).toBeInTheDocument()
   })
 
   it('switches the default with a closed provider selector', async () => {
@@ -165,7 +168,7 @@ describe('AISettingsPanel', () => {
 
     fireEvent.click(
       within(section).getByRole('button', {
-        name: 'Use environment model',
+        name: 'Reset model to baseline',
       }),
     )
     await waitFor(() => {
@@ -307,7 +310,7 @@ describe('AISettingsPanel', () => {
     })
     fireEvent.click(
       within(section).getByRole('button', {
-        name: 'Use environment model',
+        name: 'Reset model to baseline',
       }),
     )
     await waitFor(() => {
@@ -351,7 +354,7 @@ describe('AISettingsPanel', () => {
     })
     fireEvent.click(
       within(section).getByRole('button', {
-        name: 'Use environment model',
+        name: 'Reset model to baseline',
       }),
     )
     await waitFor(() => {

--- a/admin-spa/src/components/settings/ai-settings-panel.tsx
+++ b/admin-spa/src/components/settings/ai-settings-panel.tsx
@@ -9,7 +9,6 @@ import type {
 
 import type {
   AISettings,
-  APIKeyProviderName,
   ProviderProjection,
   ProviderSelector,
   UpdateAISettingsInput,
@@ -51,18 +50,6 @@ type CodexState =
   | { status: 'unavailable' }
   | { status: 'error'; message: string }
   | { status: 'ready'; auth: CodexAuthStatus }
-
-const providerLabels: Record<APIKeyProviderName, string> = {
-  openai: 'OpenAI',
-  anthropic: 'Anthropic',
-  deepseek: 'DeepSeek',
-  groq: 'Groq',
-  xai: 'xAI',
-  mistral: 'Mistral',
-  cerebras: 'Cerebras',
-  google: 'Google',
-  openrouter: 'OpenRouter',
-}
 
 /** Supplies the admin boundary operations required by the AI settings panel. */
 export type AISettingsPanelAPI = {
@@ -295,7 +282,7 @@ export function AISettingsPanel({
           },
         },
         keySubmit,
-        `Unable to save the ${providerLabels[provider.name]} API key. Check the key and try again.`,
+        `${provider.displayName} API key could not be saved.`,
         () => {
           setKeyInputs((current) => ({ ...current, [provider.name]: '' }))
           setReplacingKeys((current) => ({
@@ -319,7 +306,7 @@ export function AISettingsPanel({
           },
         },
         keySubmit,
-        `Unable to reset the ${providerLabels[provider.name]} API key. Try again.`,
+        `${provider.displayName} API key could not be reset.`,
       )
     },
     [keySubmit, submitSettings],
@@ -656,8 +643,8 @@ function APIKeyProviderEditor({
   return (
     <SettingsSection
       description='Choose the model and save a new API key.'
-      label={`${providerLabels[provider.name]} provider`}
-      title={providerLabels[provider.name]}
+      label={`${provider.displayName} provider`}
+      title={provider.displayName}
     >
       <ModelEditor
         isPending={isModelPending}
@@ -684,7 +671,7 @@ function APIKeyProviderEditor({
         <KeyEntryForm
           isPending={isKeyPending}
           isReplacing={keyReplacing}
-          label={`${providerLabels[provider.name]} API key`}
+          label={`${provider.displayName} API key`}
           onCancel={onCancelKey}
           onChange={onKeyChange}
           onSave={onSaveKey}
@@ -841,7 +828,7 @@ function ModelEditor({
             type='button'
             variant='outline'
           >
-            Use environment model
+            Reset model to baseline
           </Button>
         ) : null}
       </form>
@@ -1149,6 +1136,7 @@ function SettingsSection({
 function SourceBadge({ source }: { source: string }) {
   if (source === 'db') return <Badge variant='secondary'>Override</Badge>
   if (source === 'env') return <Badge variant='outline'>Environment</Badge>
+  if (source === 'default') return <Badge variant='outline'>Default</Badge>
   return null
 }
 
@@ -1177,7 +1165,7 @@ function providerID(provider: ProviderProjection): string {
 function providerTitle(provider: ProviderProjection): string {
   switch (provider.type) {
     case 'api_key':
-      return providerLabels[provider.name]
+      return provider.displayName
     case 'ollama':
       return 'Ollama'
     case 'managed_codex':
@@ -1217,25 +1205,12 @@ function selectorValue(selector: ProviderSelector): string {
 }
 
 function decodeSelectorValue(value: string): ProviderSelector {
+  const apiKeyPrefix = 'api_key:'
+  if (value.startsWith(apiKeyPrefix)) {
+    const name = value.slice(apiKeyPrefix.length)
+    if (name) return { type: 'api_key', name }
+  }
   switch (value) {
-    case 'api_key:openai':
-      return { type: 'api_key', name: 'openai' }
-    case 'api_key:anthropic':
-      return { type: 'api_key', name: 'anthropic' }
-    case 'api_key:deepseek':
-      return { type: 'api_key', name: 'deepseek' }
-    case 'api_key:groq':
-      return { type: 'api_key', name: 'groq' }
-    case 'api_key:xai':
-      return { type: 'api_key', name: 'xai' }
-    case 'api_key:mistral':
-      return { type: 'api_key', name: 'mistral' }
-    case 'api_key:cerebras':
-      return { type: 'api_key', name: 'cerebras' }
-    case 'api_key:google':
-      return { type: 'api_key', name: 'google' }
-    case 'api_key:openrouter':
-      return { type: 'api_key', name: 'openrouter' }
     case 'ollama':
       return { type: 'ollama' }
     case 'managed_codex':

--- a/admin-spa/src/lib/ai-settings-types.test.ts
+++ b/admin-spa/src/lib/ai-settings-types.test.ts
@@ -43,6 +43,7 @@ export const aiSettingsFixture = {
     {
       type: 'api_key',
       name: 'openai',
+      displayName: 'OpenAI',
       model,
       credential,
       readiness,
@@ -50,6 +51,7 @@ export const aiSettingsFixture = {
     {
       type: 'api_key',
       name: 'anthropic',
+      displayName: 'Anthropic',
       model,
       credential,
       readiness,
@@ -57,6 +59,7 @@ export const aiSettingsFixture = {
     {
       type: 'api_key',
       name: 'deepseek',
+      displayName: 'DeepSeek',
       model,
       credential,
       readiness,
@@ -64,6 +67,7 @@ export const aiSettingsFixture = {
     {
       type: 'api_key',
       name: 'groq',
+      displayName: 'Groq',
       model,
       credential,
       readiness,
@@ -71,6 +75,7 @@ export const aiSettingsFixture = {
     {
       type: 'api_key',
       name: 'xai',
+      displayName: 'xAI',
       model,
       credential,
       readiness,
@@ -78,6 +83,7 @@ export const aiSettingsFixture = {
     {
       type: 'api_key',
       name: 'mistral',
+      displayName: 'Mistral',
       model,
       credential,
       readiness,
@@ -85,13 +91,20 @@ export const aiSettingsFixture = {
     {
       type: 'api_key',
       name: 'cerebras',
-      model,
+      displayName: 'Cerebras',
+      model: {
+        ...model,
+        baseline: 'gpt-oss-120b',
+        effective: 'gpt-oss-120b',
+        source: 'default',
+      },
       credential,
       readiness,
     },
     {
       type: 'api_key',
       name: 'google',
+      displayName: 'Google',
       model,
       credential,
       readiness,
@@ -99,6 +112,7 @@ export const aiSettingsFixture = {
     {
       type: 'api_key',
       name: 'openrouter',
+      displayName: 'OpenRouter',
       model: { ...model, override: 'runtime-model', source: 'db' },
       credential,
       readiness: { ...readiness, effective: true },
@@ -169,7 +183,7 @@ describe('AI settings response guard', () => {
     ).not.toBeNull()
   })
 
-  it('rejects unknown, partial, and cross-provider variants', () => {
+  it('accepts server-declared API providers and rejects invalid variants', () => {
     const replaceProvider = (provider: unknown) => ({
       ...aiSettingsFixture,
       providers: [provider, ...aiSettingsFixture.providers.slice(1)],
@@ -182,7 +196,7 @@ describe('AI settings response guard', () => {
       readAISettings(
         replaceProvider({
           ...aiSettingsFixture.providers[0],
-          type: 'bedrock',
+          displayName: '',
         }),
       ),
     ).toBeNull()
@@ -190,9 +204,40 @@ describe('AI settings response guard', () => {
       readAISettings(
         replaceProvider({
           ...aiSettingsFixture.providers[0],
-          name: 'azure',
+          type: 'bedrock',
         }),
       ),
+    ).toBeNull()
+    expect(
+      readAISettings({
+        ...aiSettingsFixture,
+        providers: [
+          ...aiSettingsFixture.providers,
+          {
+            ...aiSettingsFixture.providers[0],
+            name: 'azure',
+            displayName: 'Azure AI',
+          },
+        ],
+      }),
+    ).not.toBeNull()
+    expect(
+      readAISettings({
+        ...aiSettingsFixture,
+        defaultProvider: {
+          ...aiSettingsFixture.defaultProvider,
+          effective: { type: 'api_key', name: 'undeclared' },
+        },
+      }),
+    ).toBeNull()
+    expect(
+      readAISettings({
+        ...aiSettingsFixture,
+        providers: [
+          ...aiSettingsFixture.providers,
+          aiSettingsFixture.providers[0],
+        ],
+      }),
     ).toBeNull()
     expect(
       readAISettings(

--- a/admin-spa/src/lib/ai-settings-types.ts
+++ b/admin-spa/src/lib/ai-settings-types.ts
@@ -1,23 +1,13 @@
 import { Option, Schema } from 'effect'
 import type { Schema as EffectSchema } from 'effect/Schema'
 
-export const APIKeyProviderNameSchema = Schema.Literals([
-  'openai',
-  'anthropic',
-  'deepseek',
-  'groq',
-  'xai',
-  'mistral',
-  'cerebras',
-  'google',
-  'openrouter',
-])
+export const APIKeyProviderNameSchema = Schema.String
 
 export type APIKeyProviderName = EffectSchema.Type<
   typeof APIKeyProviderNameSchema
 >
 
-const SettingsSourceSchema = Schema.Literals(['db', 'env', 'none'])
+const SettingsSourceSchema = Schema.Literals(['db', 'env', 'default', 'none'])
 
 export const APIKeyProviderSelectorSchema = Schema.Struct({
   type: Schema.Literal('api_key'),
@@ -91,6 +81,7 @@ const CredentialProjectionSchema = Schema.Struct({
 export const APIKeyProviderProjectionSchema = Schema.Struct({
   type: Schema.Literal('api_key'),
   name: APIKeyProviderNameSchema,
+  displayName: Schema.String,
   model: StringProjectionSchema,
   credential: CredentialProjectionSchema,
   readiness: ProviderReadinessSchema,
@@ -182,5 +173,29 @@ const decodeAISettings = Schema.decodeUnknownOption(AISettingsSchema, {
 
 /** Decodes an unknown response into the exact redacted AI settings contract. */
 export function readAISettings(value: unknown): AISettings | null {
-  return Option.getOrNull(decodeAISettings(value))
+  const settings = Option.getOrNull(decodeAISettings(value))
+  if (!settings) return null
+  const apiKeyNames = new Set<string>()
+  for (const provider of settings.providers) {
+    if (provider.type === 'api_key') {
+      if (
+        !provider.name.trim() ||
+        !provider.displayName.trim() ||
+        apiKeyNames.has(provider.name)
+      ) {
+        return null
+      }
+      apiKeyNames.add(provider.name)
+    }
+  }
+  for (const selector of [
+    settings.defaultProvider.baseline,
+    settings.defaultProvider.override,
+    settings.defaultProvider.effective,
+  ]) {
+    if (selector?.type === 'api_key' && !apiKeyNames.has(selector.name)) {
+      return null
+    }
+  }
+  return settings
 }

--- a/docs/ai/providers/cerebras.md
+++ b/docs/ai/providers/cerebras.md
@@ -6,8 +6,8 @@
 - **Authentication:** `LEARN_AI_CEREBRAS_API_KEY` (Bearer token); optional `LEARN_AI_CEREBRAS_MODEL`.
 - **Base URL:** `https://api.cerebras.ai/v1`.
 - **Model scope:** Default `gpt-oss-120b`; curated catalog: `gemma-4-31b`, `gpt-oss-120b`, `zai-glm-4.7`. `LEARN_AI_CEREBRAS_MODEL` overrides the default; there is no runtime discovery.
-- **Capabilities:** Catalog advertises chat, streaming, tools, structured output; vision is false.
+- **Capabilities:** Every curated model supports chat, JSON-schema output, and `max_completion_tokens`. Only `gemma-4-31b` advertises vision; the default `gpt-oss-120b` is text-only.
 - **pai-bot seam:** `internal/ai/provider_catalog.go`; environment/runtime settings in `internal/platform/config` and `internal/platform/settings`; registration in `internal/platform/airouter/setup.go`; admin contract/UI in `internal/apidocs`, `internal/server`, and `admin-spa/src/components/settings/ai-settings-panel.tsx`.
 - **Pi mapping and provenance:** Pi reference: `packages/ai/src/providers/cerebras.ts`, `cerebras.models.ts`, generated `data/cerebras.json`, shared OpenAI Completions transport, and `env-api-keys.ts` in `/tmp/pi-provider-review`. This is design provenance only; pai-bot does not import Pi.
-- **Compatibility gaps:** Catalog capability flags describe intended protocol compatibility; the shared `Complete` stream remains a final buffered chunk.
+- **Compatibility gaps:** Catalog providers do not implement pai-bot's native tool-continuation contract. The shared `Complete` stream remains a final buffered chunk.
 - **Acceptance tests:** Accepted when backend catalog/config/router/settings and admin SPA settings tests pass; environment or encrypted runtime credentials register the named provider; a blank model selects the catalog default; and OpenAPI/UI selectors expose the provider without returning secret material.

--- a/docs/ai/providers/deepseek.md
+++ b/docs/ai/providers/deepseek.md
@@ -7,7 +7,7 @@
 - **Base URL:** `https://api.deepseek.com`.
 - **Model scope:** Default `deepseek-v4-flash`; curated catalog: `deepseek-v4-flash`, `deepseek-v4-pro`. There is no runtime discovery.
 - **Capabilities:** Text chat and usage; JSON-object structured-output fallback.
-- **pai-bot seam:** `NewDeepSeekProvider` in `internal/ai/provider_openai.go`; config/server registration.
+- **pai-bot seam:** Catalog definition and shared compatible adapter in `internal/ai/provider_catalog.go` and `internal/ai/provider_openai.go`; config/server registration.
 - **Pi mapping and provenance:** Pi reference: `packages/ai/src/providers/deepseek.ts`, `deepseek.models.ts` (when present), shared API transports, and `env-api-keys.ts` in `/tmp/pi-provider-review`. This is design provenance only; pai-bot does not import Pi.
 - **Compatibility gaps:** No vision claim; schema strictness is not transmitted, and stream is not incremental.
-- **Acceptance tests:** Accepted when the documented command succeeds: `go test ./internal/ai -run DeepSeek`.
+- **Acceptance tests:** Accepted when the documented command succeeds: `go test ./internal/ai -run 'DeepSeek|Catalog'`.

--- a/docs/ai/providers/groq.md
+++ b/docs/ai/providers/groq.md
@@ -6,8 +6,8 @@
 - **Authentication:** `LEARN_AI_GROQ_API_KEY` (Bearer token); optional `LEARN_AI_GROQ_MODEL`.
 - **Base URL:** `https://api.groq.com/openai/v1`.
 - **Model scope:** Default `llama-3.3-70b-versatile`; curated catalog: `llama-3.1-8b-instant`, `llama-3.3-70b-versatile`, `openai/gpt-oss-120b`, `openai/gpt-oss-20b`, `openai/gpt-oss-safeguard-20b`, `qwen/qwen3.6-27b`. `LEARN_AI_GROQ_MODEL` overrides the default; there is no runtime discovery.
-- **Capabilities:** Catalog advertises chat, streaming, tools, structured output, and vision.
+- **Capabilities:** Every curated model supports text chat. Llama models use JSON-object mode; GPT-OSS models use JSON-schema mode. No curated model advertises vision.
 - **pai-bot seam:** `internal/ai/provider_catalog.go`; environment/runtime settings in `internal/platform/config` and `internal/platform/settings`; registration in `internal/platform/airouter/setup.go`; admin contract/UI in `internal/apidocs`, `internal/server`, and `admin-spa/src/components/settings/ai-settings-panel.tsx`.
 - **Pi mapping and provenance:** Pi reference: `packages/ai/src/providers/groq.ts`, `groq.models.ts`, generated `data/groq.json`, shared OpenAI Completions transport, and `env-api-keys.ts` in `/tmp/pi-provider-review`. This is design provenance only; pai-bot does not import Pi.
-- **Compatibility gaps:** Catalog capability flags describe intended protocol compatibility; the shared `Complete` stream remains a final buffered chunk.
+- **Compatibility gaps:** Catalog providers do not implement pai-bot's native tool-continuation contract. The shared `Complete` stream remains a final buffered chunk.
 - **Acceptance tests:** Accepted when backend catalog/config/router/settings and admin SPA settings tests pass; environment or encrypted runtime credentials register the named provider; a blank model selects the catalog default; and OpenAPI/UI selectors expose the provider without returning secret material.

--- a/docs/ai/providers/mistral.md
+++ b/docs/ai/providers/mistral.md
@@ -6,8 +6,8 @@
 - **Authentication:** `LEARN_AI_MISTRAL_API_KEY` (Bearer token); optional `LEARN_AI_MISTRAL_MODEL`.
 - **Base URL:** `https://api.mistral.ai/v1`.
 - **Model scope:** Default `mistral-large-latest`; curated catalog: `codestral-latest`, `devstral-latest`, `magistral-medium-latest`, `magistral-small`, `mistral-large-latest`, `mistral-medium-latest`, `mistral-small-latest`, `pixtral-large-latest`. `LEARN_AI_MISTRAL_MODEL` overrides the default; there is no runtime discovery.
-- **Capabilities:** Catalog advertises chat, streaming, tools, structured output, and vision.
+- **Capabilities:** Every curated model supports chat and JSON-schema output. Only `pixtral-large-latest` advertises vision.
 - **pai-bot seam:** `internal/ai/provider_catalog.go`; environment/runtime settings in `internal/platform/config` and `internal/platform/settings`; registration in `internal/platform/airouter/setup.go`; admin contract/UI in `internal/apidocs`, `internal/server`, and `admin-spa/src/components/settings/ai-settings-panel.tsx`.
 - **Pi mapping and provenance:** Pi reference: `packages/ai/src/providers/mistral.ts`, `mistral.models.ts`, generated `data/mistral.json`, the native Mistral Conversations transport, and `env-api-keys.ts` in `/tmp/pi-provider-review`. pai-bot instead uses Mistral’s OpenAI-compatible endpoint. This is design provenance, not a dependency.
-- **Compatibility gaps:** Catalog capability flags describe intended protocol compatibility; the shared `Complete` stream remains a final buffered chunk.
+- **Compatibility gaps:** Catalog providers do not implement pai-bot's native tool-continuation contract. The shared `Complete` stream remains a final buffered chunk.
 - **Acceptance tests:** Accepted when backend catalog/config/router/settings and admin SPA settings tests pass; environment or encrypted runtime credentials register the named provider; a blank model selects the catalog default; and OpenAPI/UI selectors expose the provider without returning secret material.

--- a/docs/ai/providers/xai.md
+++ b/docs/ai/providers/xai.md
@@ -6,8 +6,8 @@
 - **Authentication:** `LEARN_AI_XAI_API_KEY` (Bearer token); optional `LEARN_AI_XAI_MODEL`.
 - **Base URL:** `https://api.x.ai/v1`.
 - **Model scope:** Default `grok-4.3`; curated catalog: `grok-4.3`, `grok-build-0.1`, `grok-4.5`. `LEARN_AI_XAI_MODEL` overrides the default; there is no runtime discovery.
-- **Capabilities:** Catalog advertises chat, streaming, tools, structured output, and vision.
+- **Capabilities:** Every curated model supports chat, JSON-schema output, and vision.
 - **pai-bot seam:** `internal/ai/provider_catalog.go`; environment/runtime settings in `internal/platform/config` and `internal/platform/settings`; registration in `internal/platform/airouter/setup.go`; admin contract/UI in `internal/apidocs`, `internal/server`, and `admin-spa/src/components/settings/ai-settings-panel.tsx`.
 - **Pi mapping and provenance:** Pi reference: `packages/ai/src/providers/xai.ts`, `xai.models.ts`, generated `data/xai.json`, shared OpenAI transports, and `env-api-keys.ts` in `/tmp/pi-provider-review`. Pi supports both Completions and Responses plus OAuth; pai-bot uses API-key Completions only. This is design provenance, not a dependency.
-- **Compatibility gaps:** Catalog capability flags describe intended protocol compatibility; the shared `Complete` stream remains a final buffered chunk.
+- **Compatibility gaps:** Catalog providers do not implement pai-bot's native tool-continuation contract. The shared `Complete` stream remains a final buffered chunk.
 - **Acceptance tests:** Accepted when backend catalog/config/router/settings and admin SPA settings tests pass; environment or encrypted runtime credentials register the named provider; a blank model selects the catalog default; and OpenAPI/UI selectors expose the provider without returning secret material.

--- a/internal/ai/complete_json_test.go
+++ b/internal/ai/complete_json_test.go
@@ -70,6 +70,48 @@ func TestRouter_CompleteJSON_UsesCatalogProviderCapabilitiesAndDefaultModel(t *t
 	}
 }
 
+func TestRouter_CompleteJSON_UsesCatalogCapabilitiesForSelectedModel(t *testing.T) {
+	router := newTestRouter()
+	cerebras := ai.NewMockProvider(`{"final_answer":"cerebras"}`)
+	fallback := ai.NewMockProvider(`{"final_answer":"fallback"}`)
+	router.ReplaceProviders([]ai.ProviderRegistration{
+		{Name: "cerebras", Provider: cerebras, DefaultModel: "gpt-oss-120b"},
+		{Name: "openai", Provider: fallback, DefaultModel: "gpt-5.4-mini"},
+	})
+
+	request := ai.CompletionRequest{
+		Messages: []ai.Message{{
+			Role:      "user",
+			Content:   "grade this image",
+			ImageURLs: []string{"data:image/png;base64,AAEC"},
+		}},
+		StructuredOutput: &ai.StructuredOutputSpec{
+			Name:       "grading_result",
+			JSONSchema: json.RawMessage(`{"type":"object","properties":{"final_answer":{"type":"string"}},"required":["final_answer"]}`),
+		},
+	}
+	var out structuredReply
+	_, err := router.CompleteJSON(context.Background(), request, &out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cerebras.LastRequest != nil || fallback.LastRequest == nil || out.FinalAnswer != "fallback" {
+		t.Fatalf("default Cerebras routing: cerebras=%#v fallback=%#v out=%#v", cerebras.LastRequest, fallback.LastRequest, out)
+	}
+
+	cerebras.LastRequest = nil
+	fallback.LastRequest = nil
+	request.Model = "gemma-4-31b"
+	out = structuredReply{}
+	_, err = router.CompleteJSON(context.Background(), request, &out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cerebras.LastRequest == nil || fallback.LastRequest != nil || out.FinalAnswer != "cerebras" {
+		t.Fatalf("Gemma routing: cerebras=%#v fallback=%#v out=%#v", cerebras.LastRequest, fallback.LastRequest, out)
+	}
+}
+
 func TestRouter_CompleteJSON_RequiresStructuredOutputSpec(t *testing.T) {
 	router := newTestRouter()
 	router.Register("openai", ai.NewMockProvider(`{"final_answer":"12"}`))

--- a/internal/ai/native_provider_contract_test.go
+++ b/internal/ai/native_provider_contract_test.go
@@ -194,6 +194,13 @@ func TestDeepSeekProviderDoesNotImplementNativeContract(t *testing.T) {
 	if _, ok := NewOpenAIProvider("test-key", WithProviderName("compatible")).(NativeProvider); ok {
 		t.Fatal("arbitrary OpenAI-compatible providers must remain outside the direct OpenAI native contract")
 	}
+	provider, err := NewCatalogProvider("deepseek", "test-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := provider.(NativeProvider); ok {
+		t.Fatal("catalog OpenAI-compatible providers must remain outside the direct OpenAI native contract")
+	}
 }
 
 func requireContractToolCall(t *testing.T, message llm.AssistantMessage) llm.ToolCall {

--- a/internal/ai/provider_catalog.go
+++ b/internal/ai/provider_catalog.go
@@ -4,10 +4,8 @@
 package ai
 
 import (
-	"context"
 	"fmt"
-
-	"github.com/p-n-ai/pai-bot/internal/llm"
+	"strings"
 )
 
 // ProviderProtocol identifies the wire protocol used by a provider.
@@ -15,13 +13,34 @@ type ProviderProtocol string
 
 const ProtocolOpenAICompatible ProviderProtocol = "openai-compatible"
 
-// ProviderCapabilities describes optional protocol features advertised by a provider.
+// StructuredOutputMode identifies the response-format contract supported by a model.
+type StructuredOutputMode string
+
+const (
+	StructuredOutputNone       StructuredOutputMode = ""
+	StructuredOutputJSONObject StructuredOutputMode = "json_object"
+	StructuredOutputJSONSchema StructuredOutputMode = "json_schema"
+)
+
+// ProviderCapabilities describes optional protocol features advertised by one model.
 type ProviderCapabilities struct {
 	Chat             bool
 	Streaming        bool
 	Tools            bool
-	StructuredOutput bool
+	StructuredOutput StructuredOutputMode
 	Vision           bool
+}
+
+// SupportsStructuredOutput reports whether the model has a usable structured-output mode.
+func (c ProviderCapabilities) SupportsStructuredOutput() bool {
+	return c.StructuredOutput != StructuredOutputNone
+}
+
+// ProviderModelDefinition describes one curated model and its request capabilities.
+type ProviderModelDefinition struct {
+	ID           string
+	Name         string
+	Capabilities ProviderCapabilities
 }
 
 // ProviderDefinition is the static, non-secret description of a provider.
@@ -31,33 +50,80 @@ type ProviderDefinition struct {
 	Protocol     ProviderProtocol
 	BaseURL      string
 	DefaultModel string
-	Capabilities ProviderCapabilities
-	Models       []ModelInfo
+	Models       []ProviderModelDefinition
 }
 
 var builtInProviderDefinitions = []ProviderDefinition{
-	openAICompatibleDefinition("deepseek", "DeepSeek", "https://api.deepseek.com", "deepseek-v4-flash", false,
-		"deepseek-v4-flash", "deepseek-v4-pro"),
-	openAICompatibleDefinition("groq", "Groq", "https://api.groq.com/openai/v1", "llama-3.3-70b-versatile", true,
-		"llama-3.1-8b-instant", "llama-3.3-70b-versatile", "openai/gpt-oss-120b", "openai/gpt-oss-20b", "openai/gpt-oss-safeguard-20b", "qwen/qwen3.6-27b"),
-	openAICompatibleDefinition("xai", "xAI", "https://api.x.ai/v1", "grok-4.3", true,
-		"grok-4.3", "grok-build-0.1", "grok-4.5"),
-	openAICompatibleDefinition("mistral", "Mistral", "https://api.mistral.ai/v1", "mistral-large-latest", true,
-		"codestral-latest", "devstral-latest", "magistral-medium-latest", "magistral-small", "mistral-large-latest", "mistral-medium-latest", "mistral-small-latest", "pixtral-large-latest"),
-	openAICompatibleDefinition("cerebras", "Cerebras", "https://api.cerebras.ai/v1", "gpt-oss-120b", true,
-		"gemma-4-31b", "gpt-oss-120b", "zai-glm-4.7"),
+	openAICompatibleDefinition("deepseek", "DeepSeek", "https://api.deepseek.com", "deepseek-v4-flash",
+		catalogModel("deepseek-v4-flash", StructuredOutputJSONObject, false),
+		catalogModel("deepseek-v4-pro", StructuredOutputJSONObject, false)),
+	openAICompatibleDefinition("groq", "Groq", "https://api.groq.com/openai/v1", "llama-3.3-70b-versatile",
+		catalogModel("llama-3.1-8b-instant", StructuredOutputJSONObject, false),
+		catalogModel("llama-3.3-70b-versatile", StructuredOutputJSONObject, false),
+		catalogModel("openai/gpt-oss-120b", StructuredOutputJSONSchema, false),
+		catalogModel("openai/gpt-oss-20b", StructuredOutputJSONSchema, false),
+		catalogModel("openai/gpt-oss-safeguard-20b", StructuredOutputJSONObject, false),
+		catalogModel("qwen/qwen3.6-27b", StructuredOutputJSONObject, false)),
+	openAICompatibleDefinition("xai", "xAI", "https://api.x.ai/v1", "grok-4.3",
+		catalogModel("grok-4.3", StructuredOutputJSONSchema, true),
+		catalogModel("grok-build-0.1", StructuredOutputJSONSchema, true),
+		catalogModel("grok-4.5", StructuredOutputJSONSchema, true)),
+	openAICompatibleDefinition("mistral", "Mistral", "https://api.mistral.ai/v1", "mistral-large-latest",
+		catalogModel("codestral-latest", StructuredOutputJSONSchema, false),
+		catalogModel("devstral-latest", StructuredOutputJSONSchema, false),
+		catalogModel("magistral-medium-latest", StructuredOutputJSONSchema, false),
+		catalogModel("magistral-small", StructuredOutputJSONSchema, false),
+		catalogModel("mistral-large-latest", StructuredOutputJSONSchema, false),
+		catalogModel("mistral-medium-latest", StructuredOutputJSONSchema, false),
+		catalogModel("mistral-small-latest", StructuredOutputJSONSchema, false),
+		catalogModel("pixtral-large-latest", StructuredOutputJSONSchema, true)),
+	openAICompatibleDefinition("cerebras", "Cerebras", "https://api.cerebras.ai/v1", "gpt-oss-120b",
+		catalogModel("gemma-4-31b", StructuredOutputJSONSchema, true),
+		catalogModel("gpt-oss-120b", StructuredOutputJSONSchema, false),
+		catalogModel("zai-glm-4.7", StructuredOutputJSONSchema, false)),
 }
 
-func openAICompatibleDefinition(id, name, baseURL, defaultModel string, vision bool, models ...string) ProviderDefinition {
-	definition := ProviderDefinition{
-		ID: id, Name: name, Protocol: ProtocolOpenAICompatible, BaseURL: baseURL, DefaultModel: defaultModel,
-		Capabilities: ProviderCapabilities{Chat: true, Streaming: true, Tools: true, StructuredOutput: true, Vision: vision},
-		Models:       make([]ModelInfo, len(models)),
+func openAICompatibleDefinition(id, name, baseURL, defaultModel string, models ...ProviderModelDefinition) ProviderDefinition {
+	return ProviderDefinition{
+		ID:           id,
+		Name:         name,
+		Protocol:     ProtocolOpenAICompatible,
+		BaseURL:      baseURL,
+		DefaultModel: defaultModel,
+		Models:       append([]ProviderModelDefinition(nil), models...),
 	}
-	for i, model := range models {
-		definition.Models[i] = ModelInfo{ID: model, Name: model}
+}
+
+func catalogModel(id string, structuredOutput StructuredOutputMode, vision bool) ProviderModelDefinition {
+	return ProviderModelDefinition{
+		ID:   id,
+		Name: id,
+		Capabilities: ProviderCapabilities{
+			Chat:             true,
+			StructuredOutput: structuredOutput,
+			Vision:           vision,
+		},
 	}
-	return definition
+}
+
+// CapabilitiesForModel returns the exact curated capabilities for model.
+func (d ProviderDefinition) CapabilitiesForModel(model string) (ProviderCapabilities, bool) {
+	model = strings.TrimSpace(model)
+	for _, candidate := range d.Models {
+		if candidate.ID == model {
+			return candidate.Capabilities, true
+		}
+	}
+	return ProviderCapabilities{}, false
+}
+
+// ModelInfos projects the curated models into the provider-neutral model contract.
+func (d ProviderDefinition) ModelInfos() []ModelInfo {
+	models := make([]ModelInfo, len(d.Models))
+	for i, model := range d.Models {
+		models[i] = ModelInfo{ID: model.ID, Name: model.Name}
+	}
+	return models
 }
 
 // ProviderCatalog returns a defensive copy of the built-in provider catalog.
@@ -80,30 +146,21 @@ func LookupProviderDefinition(id string) (ProviderDefinition, bool) {
 }
 
 func cloneProviderDefinition(definition ProviderDefinition) ProviderDefinition {
-	definition.Models = append([]ModelInfo(nil), definition.Models...)
+	definition.Models = append([]ProviderModelDefinition(nil), definition.Models...)
 	return definition
-}
-
-type catalogOpenAIProvider struct {
-	*OpenAIProvider
-}
-
-var _ NativeProvider = (*catalogOpenAIProvider)(nil)
-
-func (p *catalogOpenAIProvider) CompleteNative(ctx context.Context, model string, c llm.Context, opts *llm.StreamOptions) (llm.AssistantMessage, error) {
-	return (&directOpenAIProvider{OpenAIProvider: p.OpenAIProvider}).CompleteNative(ctx, model, c, opts)
 }
 
 // NewProviderFromDefinition constructs a provider using the definition's wire protocol.
 func NewProviderFromDefinition(definition ProviderDefinition, apiKey string, opts ...OpenAIOption) (Provider, error) {
 	switch definition.Protocol {
 	case ProtocolOpenAICompatible:
-		defaults := []OpenAIOption{WithBaseURL(definition.BaseURL), WithProviderName(definition.ID), WithDefaultModel(definition.DefaultModel), WithModels(append([]ModelInfo(nil), definition.Models...))}
-		provider := newOpenAIProvider(apiKey, append(defaults, opts...)...)
-		if definition.Capabilities.Tools {
-			return &catalogOpenAIProvider{OpenAIProvider: provider}, nil
+		defaults := []OpenAIOption{
+			WithBaseURL(definition.BaseURL),
+			WithProviderName(definition.ID),
+			WithDefaultModel(definition.DefaultModel),
+			WithModels(definition.ModelInfos()),
 		}
-		return provider, nil
+		return newOpenAIProvider(apiKey, append(defaults, opts...)...), nil
 	default:
 		return nil, fmt.Errorf("ai: unsupported provider protocol %q", definition.Protocol)
 	}

--- a/internal/ai/provider_catalog_test.go
+++ b/internal/ai/provider_catalog_test.go
@@ -9,8 +9,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-
-	"github.com/p-n-ai/pai-bot/internal/llm"
 )
 
 func TestProviderCatalogDefinitions(t *testing.T) {
@@ -29,9 +27,42 @@ func TestProviderCatalogDefinitions(t *testing.T) {
 		if len(definition.Models) == 0 {
 			t.Errorf("%s has no models", definition.ID)
 		}
-		if !definition.Capabilities.Chat || !definition.Capabilities.Streaming {
-			t.Errorf("%s lacks base capabilities", definition.ID)
+		for _, model := range definition.Models {
+			if !model.Capabilities.Chat {
+				t.Errorf("%s/%s lacks chat support", definition.ID, model.ID)
+			}
+			if model.Capabilities.Streaming {
+				t.Errorf("%s/%s advertises incremental streaming through the buffered adapter", definition.ID, model.ID)
+			}
+			if model.Capabilities.Tools {
+				t.Errorf("%s/%s advertises tools without a native continuation adapter", definition.ID, model.ID)
+			}
 		}
+	}
+}
+
+func TestProviderCatalogCapabilitiesAreModelScoped(t *testing.T) {
+	groq, _ := LookupProviderDefinition("groq")
+	llama, ok := groq.CapabilitiesForModel("llama-3.3-70b-versatile")
+	if !ok || llama.StructuredOutput != StructuredOutputJSONObject || llama.Vision {
+		t.Fatalf("Groq Llama capabilities = %#v, want text-only JSON object mode", llama)
+	}
+	gptOSS, ok := groq.CapabilitiesForModel("openai/gpt-oss-120b")
+	if !ok || gptOSS.StructuredOutput != StructuredOutputJSONSchema || gptOSS.Vision {
+		t.Fatalf("Groq GPT-OSS capabilities = %#v, want text-only JSON schema mode", gptOSS)
+	}
+
+	cerebras, _ := LookupProviderDefinition("cerebras")
+	defaultModel, ok := cerebras.CapabilitiesForModel(cerebras.DefaultModel)
+	if !ok || defaultModel.Vision {
+		t.Fatalf("Cerebras default capabilities = %#v, want no vision", defaultModel)
+	}
+	gemma, ok := cerebras.CapabilitiesForModel("gemma-4-31b")
+	if !ok || !gemma.Vision {
+		t.Fatalf("Cerebras Gemma capabilities = %#v, want vision", gemma)
+	}
+	if _, ok := cerebras.CapabilitiesForModel("unknown-model"); ok {
+		t.Fatal("unknown catalog model unexpectedly has capabilities")
 	}
 }
 
@@ -75,8 +106,8 @@ func TestNewCatalogProviderRoutesThroughDefinitionEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, ok := provider.(NativeProvider); !ok {
-		t.Fatal("catalog tool-capable provider does not implement NativeProvider")
+	if _, ok := provider.(NativeProvider); ok {
+		t.Fatal("catalog provider must stay outside the native continuation contract")
 	}
 	response, err := provider.Complete(context.Background(), CompletionRequest{Messages: []Message{{Role: "user", Content: "hi"}}})
 	if err != nil {
@@ -84,21 +115,5 @@ func TestNewCatalogProviderRoutesThroughDefinitionEndpoint(t *testing.T) {
 	}
 	if path != "/chat/completions" || request.Model != "deepseek-v4-flash" || response.Content != "ok" {
 		t.Fatalf("path=%q request=%+v response=%+v", path, request, response)
-	}
-	native, ok := provider.(NativeProvider)
-	if !ok {
-		t.Fatal("catalog tool-capable provider does not implement NativeProvider")
-	}
-	message, err := native.CompleteNative(
-		context.Background(),
-		"deepseek-v4-flash",
-		llm.Context{Messages: []llm.Message{llm.UserText("hi")}},
-		nil,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if message.Provider != "deepseek" {
-		t.Fatalf("native provider = %q, want deepseek", message.Provider)
 	}
 }

--- a/internal/ai/provider_openai.go
+++ b/internal/ai/provider_openai.go
@@ -104,6 +104,7 @@ func NewDeepSeekProvider(apiKey string, opts ...OpenAIOption) *OpenAIProvider {
 	opts = append([]OpenAIOption{
 		WithBaseURL(defaultDeepSeekBaseURL),
 		WithProviderName("deepseek"),
+		WithDefaultModel("deepseek-chat"),
 	}, opts...)
 	return newOpenAIProvider(apiKey, opts...)
 }
@@ -216,7 +217,7 @@ func (p *OpenAIProvider) Complete(ctx context.Context, req CompletionRequest) (C
 	if req.MaxTokens > 0 {
 		// Newer OpenAI models (o1+, gpt-5+) reject max_tokens and require
 		// max_completion_tokens instead.
-		if needsMaxCompletionTokens(model) {
+		if usesMaxCompletionTokens(p.name, model) {
 			oaiReq.MaxCompletionTokens = req.MaxTokens
 		} else {
 			oaiReq.MaxTokens = req.MaxTokens
@@ -226,7 +227,7 @@ func (p *OpenAIProvider) Complete(ctx context.Context, req CompletionRequest) (C
 		temp := req.Temperature
 		oaiReq.Temperature = &temp
 	}
-	if err := applyOpenAIStructuredOutput(p.name, &oaiReq, req.StructuredOutput); err != nil {
+	if err := applyOpenAIStructuredOutput(p.name, model, &oaiReq, req.StructuredOutput); err != nil {
 		return CompletionResponse{}, err
 	}
 
@@ -293,7 +294,7 @@ func (p *directOpenAIProvider) CompleteNative(ctx context.Context, model string,
 	}
 	if opts != nil {
 		if opts.MaxTokens > 0 {
-			if needsMaxCompletionTokens(model) {
+			if usesMaxCompletionTokens(p.name, model) {
 				request.MaxCompletionTokens = opts.MaxTokens
 			} else {
 				request.MaxTokens = opts.MaxTokens
@@ -306,7 +307,7 @@ func (p *directOpenAIProvider) CompleteNative(ctx context.Context, model string,
 				JSONSchema: append(json.RawMessage(nil), opts.StructuredOutput.JSONSchema...),
 				Strict:     opts.StructuredOutput.Strict,
 			}
-			if err := applyOpenAIStructuredOutput(p.name, &request, spec); err != nil {
+			if err := applyOpenAIStructuredOutput(p.name, model, &request, spec); err != nil {
 				return llm.AssistantMessage{}, err
 			}
 		}
@@ -532,7 +533,7 @@ func nativeOpenAIStopReason(reason string) (llm.StopReason, error) {
 	}
 }
 
-func applyOpenAIStructuredOutput(providerName string, oaiReq *openaiRequest, spec *StructuredOutputSpec) error {
+func applyOpenAIStructuredOutput(providerName, model string, oaiReq *openaiRequest, spec *StructuredOutputSpec) error {
 	if spec == nil {
 		return nil
 	}
@@ -543,24 +544,45 @@ func applyOpenAIStructuredOutput(providerName string, oaiReq *openaiRequest, spe
 		return fmt.Errorf("structured output JSON schema is required")
 	}
 
-	if providerName == "deepseek" {
+	switch structuredOutputMode(providerName, model) {
+	case StructuredOutputJSONObject:
 		oaiReq.ResponseFormat = &openaiResponseFormat{Type: "json_object"}
 		oaiReq.Messages = append([]openaiMessage{{
 			Role:    "system",
 			Content: fmt.Sprintf("Return a JSON object only that matches this schema: %s", string(spec.JSONSchema)),
 		}}, oaiReq.Messages...)
 		return nil
+	case StructuredOutputJSONSchema:
+		oaiReq.ResponseFormat = &openaiResponseFormat{
+			Type: "json_schema",
+			JSONSchema: &openaiResponseFormatSchema{
+				Name:   spec.Name,
+				Schema: spec.JSONSchema,
+				Strict: spec.Strict,
+			},
+		}
+		return nil
+	default:
+		return fmt.Errorf("provider %q model %q does not support structured output", providerName, model)
 	}
+}
 
-	oaiReq.ResponseFormat = &openaiResponseFormat{
-		Type: "json_schema",
-		JSONSchema: &openaiResponseFormatSchema{
-			Name:   spec.Name,
-			Schema: spec.JSONSchema,
-			Strict: spec.Strict,
-		},
+func structuredOutputMode(providerName, model string) StructuredOutputMode {
+	if providerName == "deepseek" {
+		return StructuredOutputJSONObject
 	}
-	return nil
+	if definition, ok := LookupProviderDefinition(providerName); ok {
+		capabilities, found := definition.CapabilitiesForModel(model)
+		if !found {
+			return StructuredOutputNone
+		}
+		return capabilities.StructuredOutput
+	}
+	return StructuredOutputJSONSchema
+}
+
+func usesMaxCompletionTokens(providerName, model string) bool {
+	return providerName == "cerebras" || needsMaxCompletionTokens(model)
 }
 
 // needsMaxCompletionTokens returns true for model families that reject the

--- a/internal/ai/provider_openai_test.go
+++ b/internal/ai/provider_openai_test.go
@@ -181,6 +181,79 @@ func TestDeepSeekProvider_Complete_StructuredOutput_UsesJSONObjectMode(t *testin
 	}
 }
 
+func TestCatalogProvider_Complete_UsesModelStructuredOutputMode(t *testing.T) {
+	tests := []struct {
+		name       string
+		model      string
+		wantFormat string
+	}{
+		{name: "default Llama JSON object", model: "llama-3.3-70b-versatile", wantFormat: "json_object"},
+		{name: "GPT-OSS JSON schema", model: "openai/gpt-oss-120b", wantFormat: "json_schema"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var captured map[string]any
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+					t.Fatal(err)
+				}
+				writeOpenAITextResponse(t, w, `{"final_answer":"ok"}`, test.model, 10, 5)
+			}))
+			defer server.Close()
+
+			provider, err := NewCatalogProvider("groq", "test-key", WithBaseURL(server.URL))
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = provider.Complete(context.Background(), CompletionRequest{
+				Messages: []Message{{Role: "user", Content: "grade this"}},
+				Model:    test.model,
+				StructuredOutput: &StructuredOutputSpec{
+					Name:       "grading_result",
+					JSONSchema: testStructuredSchema,
+					Strict:     true,
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			format, ok := captured["response_format"].(map[string]any)
+			if !ok || format["type"] != test.wantFormat {
+				t.Fatalf("response_format = %#v, want %q", captured["response_format"], test.wantFormat)
+			}
+		})
+	}
+}
+
+func TestCerebrasProvider_Complete_UsesMaxCompletionTokens(t *testing.T) {
+	var captured map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatal(err)
+		}
+		writeOpenAITextResponse(t, w, "ok", "gpt-oss-120b", 10, 5)
+	}))
+	defer server.Close()
+
+	provider, err := NewCatalogProvider("cerebras", "test-key", WithBaseURL(server.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = provider.Complete(context.Background(), CompletionRequest{
+		Messages:  []Message{{Role: "user", Content: "hello"}},
+		MaxTokens: 256,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if captured["max_completion_tokens"] != float64(256) {
+		t.Fatalf("max_completion_tokens = %#v, want 256", captured["max_completion_tokens"])
+	}
+	if _, present := captured["max_tokens"]; present {
+		t.Fatalf("Cerebras request contains legacy max_tokens: %#v", captured["max_tokens"])
+	}
+}
+
 func TestOpenAIProvider_HealthCheck(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/ai/router.go
+++ b/internal/ai/router.go
@@ -518,7 +518,11 @@ func validateCompleteJSONRequest(req CompletionRequest, out any) error {
 }
 
 func (r *Router) structuredProviderRequest(providerName string, req CompletionRequest) (CompletionRequest, bool) {
-	capabilities, ok := structuredProviderCapabilities(providerName)
+	model := strings.TrimSpace(req.Model)
+	if model == "" {
+		model = r.structuredDefaultModelForProvider(providerName)
+	}
+	capabilities, ok := structuredProviderCapabilities(providerName, model)
 	if !ok || !capabilities.StructuredOutput {
 		return CompletionRequest{}, false
 	}
@@ -528,11 +532,7 @@ func (r *Router) structuredProviderRequest(providerName string, req CompletionRe
 	if requestNeedsImageInputs(req) && !capabilities.ImageInputs {
 		return CompletionRequest{}, false
 	}
-	if req.Model != "" {
-		return req, true
-	}
-
-	req.Model = r.structuredDefaultModelForProvider(providerName)
+	req.Model = model
 	return req, true
 }
 
@@ -542,12 +542,16 @@ type providerStructuredCapabilities struct {
 	ImageInputs      bool
 }
 
-func structuredProviderCapabilities(providerName string) (providerStructuredCapabilities, bool) {
+func structuredProviderCapabilities(providerName, model string) (providerStructuredCapabilities, bool) {
 	if definition, ok := LookupProviderDefinition(providerName); ok {
+		capabilities, found := definition.CapabilitiesForModel(model)
+		if !found {
+			return providerStructuredCapabilities{}, false
+		}
 		return providerStructuredCapabilities{
-			StructuredOutput: definition.Capabilities.StructuredOutput,
+			StructuredOutput: capabilities.SupportsStructuredOutput(),
 			SystemMessages:   true,
-			ImageInputs:      definition.Capabilities.Vision,
+			ImageInputs:      capabilities.Vision,
 		}, true
 	}
 	switch providerName {

--- a/internal/apidocs/routes.go
+++ b/internal/apidocs/routes.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/p-n-ai/pai-bot/internal/adminapi"
 	"github.com/p-n-ai/pai-bot/internal/auth"
+	"github.com/p-n-ai/pai-bot/internal/platform/settings"
 )
 
 type refreshTokenRequest struct {
@@ -91,11 +92,12 @@ type aiCredentialProjectionDoc struct {
 }
 
 type aiAPIKeyProviderProjectionDoc struct {
-	Type       string                    `json:"type"`
-	Name       string                    `json:"name"`
-	Model      aiStringProjectionDoc     `json:"model"`
-	Credential aiCredentialProjectionDoc `json:"credential"`
-	Readiness  aiProviderReadinessDoc    `json:"readiness"`
+	Type        string                    `json:"type"`
+	Name        string                    `json:"name"`
+	DisplayName string                    `json:"displayName"`
+	Model       aiStringProjectionDoc     `json:"model"`
+	Credential  aiCredentialProjectionDoc `json:"credential"`
+	Readiness   aiProviderReadinessDoc    `json:"readiness"`
 }
 
 type aiOllamaProviderProjectionDoc struct {
@@ -175,12 +177,13 @@ func aiSettingsSchemas(registry *schemaRegistry) (request, response *Schema) {
 }
 
 func aiProviderSelectorSchema() *Schema {
+	providerNames := apiKeyProviderNames()
 	return &Schema{
 		OneOf: []*Schema{
 			closedObjectSchema(
 				map[string]*Schema{
 					"type": {Type: "string", Enum: []any{"api_key"}},
-					"name": {Type: "string", Enum: []any{"openai", "anthropic", "deepseek", "google", "openrouter", "groq", "xai", "mistral", "cerebras"}},
+					"name": {Type: "string", Enum: providerNames},
 				},
 				"type", "name",
 			),
@@ -198,10 +201,11 @@ func aiProviderSelectorSchema() *Schema {
 }
 
 func aiProviderPatchSchema() *Schema {
+	providerNames := apiKeyProviderNames()
 	apiKey := closedObjectSchema(
 		map[string]*Schema{
 			"type":   {Type: "string", Enum: []any{"api_key"}},
-			"name":   {Type: "string", Enum: []any{"openai", "anthropic", "deepseek", "google", "openrouter", "groq", "xai", "mistral", "cerebras"}},
+			"name":   {Type: "string", Enum: providerNames},
 			"model":  nullableStringSchema(),
 			"apiKey": nullableStringSchema(),
 		},
@@ -229,6 +233,15 @@ func aiProviderPatchSchema() *Schema {
 		OneOf:         []*Schema{apiKey, ollama, managedCodex},
 		Discriminator: &Discriminator{PropertyName: "type"},
 	}
+}
+
+func apiKeyProviderNames() []any {
+	definitions := settings.APIKeyProviderDefinitions()
+	names := make([]any, len(definitions))
+	for i, definition := range definitions {
+		names[i] = string(definition.ID)
+	}
+	return names
 }
 
 func closedObjectSchema(properties map[string]*Schema, required ...string) *Schema {

--- a/internal/platform/settings/settings.go
+++ b/internal/platform/settings/settings.go
@@ -6,7 +6,9 @@ package settings
 
 import (
 	"maps"
+	"strings"
 
+	"github.com/p-n-ai/pai-bot/internal/ai"
 	"github.com/p-n-ai/pai-bot/internal/platform/config"
 	"github.com/p-n-ai/pai-bot/internal/platform/featureflags"
 )
@@ -26,25 +28,48 @@ type APIKeyProvider string
 const (
 	APIKeyProviderOpenAI     APIKeyProvider = "openai"
 	APIKeyProviderAnthropic  APIKeyProvider = "anthropic"
-	APIKeyProviderDeepSeek   APIKeyProvider = "deepseek"
 	APIKeyProviderGoogle     APIKeyProvider = "google"
 	APIKeyProviderOpenRouter APIKeyProvider = "openrouter"
-	APIKeyProviderGroq       APIKeyProvider = "groq"
-	APIKeyProviderXAI        APIKeyProvider = "xai"
-	APIKeyProviderMistral    APIKeyProvider = "mistral"
-	APIKeyProviderCerebras   APIKeyProvider = "cerebras"
 )
 
-var apiKeyProviders = []APIKeyProvider{
-	APIKeyProviderOpenAI,
-	APIKeyProviderAnthropic,
-	APIKeyProviderDeepSeek,
-	APIKeyProviderGoogle,
-	APIKeyProviderOpenRouter,
-	APIKeyProviderGroq,
-	APIKeyProviderXAI,
-	APIKeyProviderMistral,
-	APIKeyProviderCerebras,
+// APIKeyProviderDefinition describes one provider exposed by runtime settings.
+type APIKeyProviderDefinition struct {
+	ID          APIKeyProvider
+	DisplayName string
+}
+
+var apiKeyProviderDefinitions = buildAPIKeyProviderDefinitions()
+var apiKeyProviders = apiKeyProviderIDs(apiKeyProviderDefinitions)
+
+func buildAPIKeyProviderDefinitions() []APIKeyProviderDefinition {
+	definitions := []APIKeyProviderDefinition{
+		{ID: APIKeyProviderOpenAI, DisplayName: "OpenAI"},
+		{ID: APIKeyProviderAnthropic, DisplayName: "Anthropic"},
+	}
+	for _, provider := range ai.ProviderCatalog() {
+		definitions = append(definitions, APIKeyProviderDefinition{
+			ID:          APIKeyProvider(provider.ID),
+			DisplayName: provider.Name,
+		})
+	}
+	definitions = append(definitions,
+		APIKeyProviderDefinition{ID: APIKeyProviderGoogle, DisplayName: "Google"},
+		APIKeyProviderDefinition{ID: APIKeyProviderOpenRouter, DisplayName: "OpenRouter"},
+	)
+	return definitions
+}
+
+// APIKeyProviderDefinitions returns the settings provider metadata.
+func APIKeyProviderDefinitions() []APIKeyProviderDefinition {
+	return append([]APIKeyProviderDefinition(nil), apiKeyProviderDefinitions...)
+}
+
+func apiKeyProviderIDs(definitions []APIKeyProviderDefinition) []APIKeyProvider {
+	providers := make([]APIKeyProvider, len(definitions))
+	for i, definition := range definitions {
+		providers[i] = definition.ID
+	}
+	return providers
 }
 
 // APIKeyProviders returns the closed API-key provider set.
@@ -55,8 +80,8 @@ func APIKeyProviders() []APIKeyProvider {
 // ParseAPIKeyProvider refines a persisted or HTTP provider name.
 func ParseAPIKeyProvider(name string) (APIKeyProvider, bool) {
 	provider := APIKeyProvider(name)
-	for _, candidate := range apiKeyProviders {
-		if provider == candidate {
+	for _, candidate := range apiKeyProviderDefinitions {
+		if provider == candidate.ID {
 			return provider, true
 		}
 	}
@@ -142,9 +167,10 @@ type PrepareApply func(Settings) (PreparedApply, error)
 
 // Source tags where an effective settings value came from.
 const (
-	SourceDB   = "db"
-	SourceEnv  = "env"
-	SourceNone = "none"
+	SourceDB      = "db"
+	SourceEnv     = "env"
+	SourceDefault = "default"
+	SourceNone    = "none"
 )
 
 // SecretView is the only projection of a provider credential allowed outside
@@ -232,7 +258,7 @@ func ReconcileAI(env config.AIConfig, st AISettings) AIReconciliation {
 		DefaultProviderSource: sourceForString(env.DefaultProvider),
 		Baseline: AISettingsView{
 			DefaultProvider: env.DefaultProvider,
-			Providers:       make(map[string]ProviderSettingsView, len(apiKeyProviders)+2),
+			Providers:       make(map[string]ProviderSettingsView, len(apiKeyProviderDefinitions)+2),
 		},
 		Override: AISettingsOverrideView{
 			DefaultProvider: cloneStringPointer(st.DefaultProvider),
@@ -240,9 +266,9 @@ func ReconcileAI(env config.AIConfig, st AISettings) AIReconciliation {
 		},
 		Effective: AISettingsView{
 			DefaultProvider: env.DefaultProvider,
-			Providers:       make(map[string]ProviderSettingsView, len(apiKeyProviders)+2),
+			Providers:       make(map[string]ProviderSettingsView, len(apiKeyProviderDefinitions)+2),
 		},
-		ProviderSources:     make(map[string]ProviderSources, len(apiKeyProviders)+2),
+		ProviderSources:     make(map[string]ProviderSources, len(apiKeyProviderDefinitions)+2),
 		CredentialEnvelopes: make(map[string]CredentialEnvelopeStatus),
 	}
 	if st.DefaultProvider != nil {
@@ -252,11 +278,16 @@ func ReconcileAI(env config.AIConfig, st AISettings) AIReconciliation {
 		result.DefaultProviderSource = SourceDB
 	}
 
-	for _, provider := range apiKeyProviders {
+	for _, definition := range apiKeyProviderDefinitions {
+		provider := definition.ID
 		name := string(provider)
 		envModel, envKey := apiKeyConfig(env, provider)
-		model, key := envModel, envKey
-		modelSource, keySource := sourceForString(envModel), sourceForString(envKey)
+		baselineModel := configuredOrCatalogDefault(provider, envModel)
+		model, key := baselineModel, envKey
+		modelSource, keySource := sourceForString(strings.TrimSpace(envModel)), sourceForString(envKey)
+		if modelSource == SourceNone && baselineModel != "" {
+			modelSource = SourceDefault
+		}
 		override := ProviderOverrideView{Kind: ProviderKindAPIKey, Name: name}
 		if providerOverride, ok := st.Providers.APIKey[provider]; ok && providerOverride.Model != nil {
 			model = *providerOverride.Model
@@ -279,7 +310,7 @@ func ReconcileAI(env config.AIConfig, st AISettings) AIReconciliation {
 		setAPIKeyConfig(&result.Config, provider, model, key)
 		baseline := ProviderSettingsView{
 			Kind: ProviderKindAPIKey, Name: name, Enabled: envKey != "",
-			Model: envModel, Credential: SecretView{Set: envKey != ""},
+			Model: baselineModel, Credential: SecretView{Set: envKey != ""},
 		}
 		effective := ProviderSettingsView{
 			Kind: ProviderKindAPIKey, Name: name, Enabled: key != "",
@@ -428,11 +459,13 @@ func apiKeyConfig(cfg config.AIConfig, provider APIKeyProvider) (model, key stri
 		return cfg.Google.Model, cfg.Google.APIKey
 	case APIKeyProviderOpenRouter:
 		return cfg.OpenRouter.Model, cfg.OpenRouter.APIKey
-	case APIKeyProviderDeepSeek, APIKeyProviderGroq, APIKeyProviderXAI, APIKeyProviderMistral, APIKeyProviderCerebras:
+	default:
+		if _, ok := ai.LookupProviderDefinition(string(provider)); !ok {
+			panic("unreachable API-key provider")
+		}
 		providerConfig := cfg.CatalogProviders[string(provider)]
 		return providerConfig.Model, providerConfig.APIKey
 	}
-	panic("unreachable API-key provider")
 }
 
 func setAPIKeyConfig(cfg *config.AIConfig, provider APIKeyProvider, model, key string) {
@@ -445,14 +478,26 @@ func setAPIKeyConfig(cfg *config.AIConfig, provider APIKeyProvider, model, key s
 		cfg.Google.Model, cfg.Google.APIKey = model, key
 	case APIKeyProviderOpenRouter:
 		cfg.OpenRouter.Model, cfg.OpenRouter.APIKey = model, key
-	case APIKeyProviderDeepSeek, APIKeyProviderGroq, APIKeyProviderXAI, APIKeyProviderMistral, APIKeyProviderCerebras:
+	default:
+		if _, ok := ai.LookupProviderDefinition(string(provider)); !ok {
+			panic("unreachable API-key provider")
+		}
 		if cfg.CatalogProviders == nil {
 			cfg.CatalogProviders = make(map[string]config.CatalogProviderConfig)
 		}
 		cfg.CatalogProviders[string(provider)] = config.CatalogProviderConfig{Model: model, APIKey: key}
-	default:
-		panic("unreachable API-key provider")
 	}
+}
+
+func configuredOrCatalogDefault(provider APIKeyProvider, configured string) string {
+	if strings.TrimSpace(configured) != "" {
+		return configured
+	}
+	definition, ok := ai.LookupProviderDefinition(string(provider))
+	if !ok {
+		return configured
+	}
+	return definition.DefaultModel
 }
 
 func sourceForString(value string) string {

--- a/internal/platform/settings/settings_test.go
+++ b/internal/platform/settings/settings_test.go
@@ -75,13 +75,13 @@ func TestReconcileAICatalogProviderOverrides(t *testing.T) {
 	}
 	st := AISettings{
 		Providers: ProviderOverrides{APIKey: map[APIKeyProvider]APIKeyProviderOverride{
-			APIKeyProviderDeepSeek: {Model: stringPointer("db-deepseek-model")},
-			APIKeyProviderGroq:     {Model: stringPointer("db-groq-model")},
+			APIKeyProvider("deepseek"): {Model: stringPointer("db-deepseek-model")},
+			APIKeyProvider("groq"):     {Model: stringPointer("db-groq-model")},
 		}},
 		Credentials: map[APIKeyProvider]CredentialOverride{
-			APIKeyProviderDeepSeek: {Value: "db-deepseek-secret-9012"},
-			APIKeyProviderGroq:     {Value: "db-groq-secret-1234"},
-			APIKeyProviderMistral:  {Value: "db-mistral-secret-5678"},
+			APIKeyProvider("deepseek"): {Value: "db-deepseek-secret-9012"},
+			APIKeyProvider("groq"):     {Value: "db-groq-secret-1234"},
+			APIKeyProvider("mistral"):  {Value: "db-mistral-secret-5678"},
 		},
 	}
 
@@ -108,16 +108,36 @@ func TestReconcileAICatalogProviderOverrides(t *testing.T) {
 	}
 }
 
+func TestReconcileAICatalogDefaultIsEffectiveSettingsState(t *testing.T) {
+	env := config.AIConfig{CatalogProviders: map[string]config.CatalogProviderConfig{
+		"cerebras": {APIKey: "env-cerebras-key"},
+	}}
+
+	got := ReconcileAI(env, AISettings{})
+	if model := got.Config.CatalogProviders["cerebras"].Model; model != "gpt-oss-120b" {
+		t.Fatalf("runtime Cerebras model = %q, want catalog default", model)
+	}
+	if model := got.Baseline.Providers["cerebras"].Model; model != "gpt-oss-120b" {
+		t.Fatalf("baseline Cerebras model = %q, want catalog default", model)
+	}
+	if model := got.Effective.Providers["cerebras"].Model; model != "gpt-oss-120b" {
+		t.Fatalf("effective Cerebras model = %q, want catalog default", model)
+	}
+	if source := got.ProviderSources["cerebras"].Model; source != SourceDefault {
+		t.Fatalf("Cerebras model source = %q, want default ownership", source)
+	}
+}
+
 func TestReconcileAIDoesNotMutateCatalogEnvironmentBaseline(t *testing.T) {
 	env := config.AIConfig{CatalogProviders: map[string]config.CatalogProviderConfig{
 		"groq": {APIKey: "env-groq-key", Model: "env-groq-model"},
 	}}
 	override := AISettings{
 		Providers: ProviderOverrides{APIKey: map[APIKeyProvider]APIKeyProviderOverride{
-			APIKeyProviderGroq: {Model: stringPointer("db-groq-model")},
+			APIKeyProvider("groq"): {Model: stringPointer("db-groq-model")},
 		}},
 		Credentials: map[APIKeyProvider]CredentialOverride{
-			APIKeyProviderGroq: {Value: "db-groq-secret-1234"},
+			APIKeyProvider("groq"): {Value: "db-groq-secret-1234"},
 		},
 	}
 

--- a/internal/server/admin_ai_settings.go
+++ b/internal/server/admin_ai_settings.go
@@ -110,11 +110,12 @@ type aiCredentialProjection struct {
 }
 
 type aiAPIKeyProviderProjection struct {
-	Type       settings.ProviderKind  `json:"type"`
-	Name       string                 `json:"name"`
-	Model      aiStringProjection     `json:"model"`
-	Credential aiCredentialProjection `json:"credential"`
-	Readiness  aiProviderReadiness    `json:"readiness"`
+	Type        settings.ProviderKind  `json:"type"`
+	Name        string                 `json:"name"`
+	DisplayName string                 `json:"displayName"`
+	Model       aiStringProjection     `json:"model"`
+	Credential  aiCredentialProjection `json:"credential"`
+	Readiness   aiProviderReadiness    `json:"readiness"`
 }
 
 type aiOllamaProviderProjection struct {
@@ -680,16 +681,17 @@ func buildAISettingsResponse(
 	managedCodexAvailable bool,
 ) aiSettingsResponse {
 	providers := make([]any, 0, len(settings.APIKeyProviders())+2)
-	for _, provider := range settings.APIKeyProviders() {
-		name := string(provider)
+	for _, definition := range settings.APIKeyProviderDefinitions() {
+		name := string(definition.ID)
 		baseline := eff.Baseline.Providers[name]
 		override := eff.Override.Providers[name]
 		effective := eff.Effective.Providers[name]
 		sources := eff.ProviderSources[name]
 		providers = append(providers, aiAPIKeyProviderProjection{
-			Type:  settings.ProviderKindAPIKey,
-			Name:  name,
-			Model: stringProjection(baseline.Model, override.Model, effective.Model, sources.Model),
+			Type:        settings.ProviderKindAPIKey,
+			Name:        name,
+			DisplayName: definition.DisplayName,
+			Model:       stringProjection(baseline.Model, override.Model, effective.Model, sources.Model),
 			Credential: aiCredentialProjection{
 				Baseline:  keyStatus(baseline.Credential),
 				Override:  keyStatus(override.Credential),

--- a/internal/server/admin_ai_settings_test.go
+++ b/internal/server/admin_ai_settings_test.go
@@ -218,6 +218,9 @@ func TestAdminAISettingsGetReturnsClosedRedactedProviderProjections(t *testing.T
 		},
 		Ollama: config.OllamaConfig{URL: "http://127.0.0.1:11434"},
 		Codex:  config.CodexConfig{Enabled: true, Model: "codex-env"},
+		CatalogProviders: map[string]config.CatalogProviderConfig{
+			"cerebras": {APIKey: "cerebras-env-key"},
+		},
 	}
 	store := &memorySettingsStore{envAI: env}
 	handler := newAISettingsHandler(store, nil)
@@ -243,6 +246,12 @@ func TestAdminAISettingsGetReturnsClosedRedactedProviderProjections(t *testing.T
 	effective := credential["effective"].(map[string]any)
 	if effective["set"] != true || effective["last4"] != "9876" || credential["source"] != settings.SourceEnv {
 		t.Fatalf("credential projection = %#v, want redacted env key", credential)
+	}
+	cerebras := decodeProviderProjection(t, payload, settings.ProviderKindAPIKey, "cerebras")
+	model := cerebras["model"].(map[string]any)
+	if cerebras["displayName"] != "Cerebras" || model["baseline"] != "gpt-oss-120b" ||
+		model["effective"] != "gpt-oss-120b" || model["source"] != settings.SourceDefault {
+		t.Fatalf("Cerebras projection = %#v, want catalog default metadata", cerebras)
 	}
 	decodeProviderProjection(t, payload, settings.ProviderKindOllama, "")
 	decodeProviderProjection(t, payload, settings.ProviderKindManagedCodex, "")


### PR DESCRIPTION
## Summary

Adopt the Pandai design system across the admin SPA and public site, including shared typography, colors, icons, layouts, and refreshed workspace flows.

Add a declarative AI provider catalog with model-scoped capabilities, provider settings reconciliation, admin management screens, and supporting provider documentation.

Publish SHA-addressed nightly GitHub prereleases from completed candidate metadata while keeping stable promotion manual.

## Risk

- API contract: additive and compatibility-preserving; AI provider catalog settings and model capabilities are expanded while existing provider behavior remains supported.
- Database migrations: none; rollback requires no database changes.
- Release and deployment: nightly only; the workflow now requires GitHub contents write permission and can create prerelease tags and releases from candidate metadata. Stable production promotion remains manual.
- Rollback: revert the change commits and stop nightly promotion; existing runtime settings and previously published releases remain available.

## Verification

- Updated AI provider catalog, routing, settings, and admin API tests.
- Updated admin SPA component, route, settings, authentication, onboarding, and shared UI tests.
- Added release workflow coverage for candidate metadata and nightly release behavior.
- Updated dependency lockfiles and provider documentation.
- Confirm the full repository and admin SPA checks pass before merge and verify the nightly workflow publishes the expected SHA-addressed prerelease.