### PR TITLE
feat(site): show Pandai logo in docs header

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -13,6 +13,10 @@ export default defineConfig({
       title: "P&AI Bot",
       description: "Open-source AI learning agent that teaches students through chat.",
       favicon: "/favicon.svg",
+      logo: {
+        src: "../docs/assets/pandai-logo.png",
+        alt: "Pandai",
+      },
       social: [
         { icon: "github", label: "GitHub", href: "https://github.com/p-n-ai/pai-bot" },
       ],

--- a/site/src/styles/starlight.css
+++ b/site/src/styles/starlight.css
@@ -69,18 +69,9 @@ header.header {
   letter-spacing: -0.02em;
 }
 
-.site-title::before {
-  display: inline-grid;
+.site-title img {
   width: 2.25rem;
   height: 2.25rem;
-  margin-inline-end: 0.65rem;
-  place-items: center;
-  border-radius: 10px;
-  color: white;
-  background: var(--pandai-navigation);
-  content: "P";
-  font-size: 0.875rem;
-  font-weight: 600;
 }
 
 .sidebar-pane {


### PR DESCRIPTION
## Summary
- use the canonical Pandai logo in the documentation header
- replace the generated letter badge with fixed logo sizing

## Testing
- `cd site && pnpm build`
- `git diff --check`